### PR TITLE
Add support for namespaces

### DIFF
--- a/tests/models/elements/test_complex_type.py
+++ b/tests/models/elements/test_complex_type.py
@@ -19,6 +19,7 @@ from xsdata.models.elements import (
     SimpleContent,
     SimpleType,
 )
+from xsdata.models.enums import Form
 from xsdata.parser import SchemaParser
 
 
@@ -74,9 +75,14 @@ class ComplexTypeDeserializeTests(ModelTestCase):
                 elements=[
                     Element.build(
                         name="PointOfSale",
+                        form=Form.UNQUALIFIED,
                         complex_type=ComplexType.build(
                             attributes=[
-                                Attribute.build(name="id", type="xs:string")
+                                Attribute.build(
+                                    name="id",
+                                    type="xs:string",
+                                    form=Form.UNQUALIFIED,
+                                )
                             ]
                         ),
                     )
@@ -98,6 +104,7 @@ class ComplexTypeDeserializeTests(ModelTestCase):
                         Attribute.build(
                             name="currency",
                             use="required",
+                            form=Form.UNQUALIFIED,
                             simple_type=SimpleType.build(
                                 restriction=Restriction.build(
                                     base="xs:string",
@@ -125,6 +132,7 @@ class ComplexTypeDeserializeTests(ModelTestCase):
                         Attribute.build(
                             name="id",
                             use="required",
+                            form=Form.UNQUALIFIED,
                             simple_type=SimpleType.build(
                                 restriction=Restriction.build(
                                     base="xs:string",

--- a/tests/target/air_v48_0/air.py
+++ b/tests/target/air_v48_0/air.py
@@ -109,6 +109,7 @@ class Adjustment:
         metadata=dict(
             name="Amount",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             required=True
         )
     )
@@ -545,6 +546,7 @@ class AirRefundInfo:
         metadata=dict(
             name="RefundRemark",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -780,6 +782,7 @@ class AlternateLocationDistance:
         metadata=dict(
             name="Distance",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             required=True
         )
     )
@@ -1025,6 +1028,7 @@ class AvailableDiscount:
         metadata=dict(
             name="LoyaltyProgram",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -1073,6 +1077,7 @@ class AvailableSsr:
         metadata=dict(
             name="SSR",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -1082,6 +1087,7 @@ class AvailableSsr:
         metadata=dict(
             name="SSRRules",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -1091,6 +1097,7 @@ class AvailableSsr:
         metadata=dict(
             name="IndustryStandardSSR",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -2366,6 +2373,7 @@ class ExcludeTicketing:
         metadata=dict(
             name="BookingTravelerRef",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -2406,6 +2414,7 @@ class ExemptTaxes:
         metadata=dict(
             name="CountryCode",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999,
             length=2
@@ -3063,14 +3072,16 @@ class FareRuleLookup:
         default=None,
         metadata=dict(
             name="AccountCode",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
     point_of_sale: PointOfSale = field(
         default=None,
         metadata=dict(
             name="PointOfSale",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
     origin: str = field(
@@ -3358,6 +3369,7 @@ class FlexExploreModifiers:
         metadata=dict(
             name="Destination",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=59,
             length=3,
@@ -3674,6 +3686,7 @@ class HostTokenList:
         metadata=dict(
             name="HostToken",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=1,
             max_occurs=999
         )
@@ -4122,6 +4135,7 @@ class MerchandisingPricingModifiers:
         metadata=dict(
             name="AccountCode",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=10
         )
@@ -4259,6 +4273,7 @@ class OfferAvailabilityModifiers:
         metadata=dict(
             name="ServiceType",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999,
             min_length=1.0,
@@ -4270,6 +4285,7 @@ class OfferAvailabilityModifiers:
         metadata=dict(
             name="Carrier",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999,
             length=2
@@ -5097,6 +5113,7 @@ class PermittedCabins:
         metadata=dict(
             name="CabinClass",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=1,
             max_occurs=5
         )
@@ -5113,6 +5130,7 @@ class PermittedCarriers:
         metadata=dict(
             name="Carrier",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=1,
             max_occurs=999
         )
@@ -5191,6 +5209,7 @@ class PolicyCodesList:
         metadata=dict(
             name="PolicyCode",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=1,
             max_occurs=10,
             min_inclusive=1.0,
@@ -5209,6 +5228,7 @@ class PreferredCabins:
         metadata=dict(
             name="CabinClass",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             required=True
         )
     )
@@ -5224,6 +5244,7 @@ class PreferredCarriers:
         metadata=dict(
             name="Carrier",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=1,
             max_occurs=999
         )
@@ -5485,6 +5506,7 @@ class ProhibitedCabins:
         metadata=dict(
             name="CabinClass",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=1,
             max_occurs=3
         )
@@ -5501,6 +5523,7 @@ class ProhibitedCarriers:
         metadata=dict(
             name="Carrier",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=1,
             max_occurs=999
         )
@@ -5614,6 +5637,7 @@ class RefundFailureInfo:
         metadata=dict(
             name="BookingTravelerRef",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=1,
             max_occurs=999
         )
@@ -5631,6 +5655,7 @@ class RefundFailureInfo:
         metadata=dict(
             name="TicketNumber",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             required=True
         )
     )
@@ -5939,6 +5964,7 @@ class SearchTraveler(TypePassengerType):
         metadata=dict(
             name="AirSeatAssignment",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -6148,6 +6174,7 @@ class SolutionGroup:
             metadata=dict(
                 name="AccountCode",
                 type="Element",
+                namespace="http://www.travelport.com/schema/common_v48_0",
                 min_occurs=1,
                 max_occurs=999
             )
@@ -6163,6 +6190,7 @@ class SolutionGroup:
             metadata=dict(
                 name="AccountCode",
                 type="Element",
+                namespace="http://www.travelport.com/schema/common_v48_0",
                 min_occurs=1,
                 max_occurs=999
             )
@@ -6178,6 +6206,7 @@ class SolutionGroup:
             metadata=dict(
                 name="AccountCode",
                 type="Element",
+                namespace="http://www.travelport.com/schema/common_v48_0",
                 min_occurs=1,
                 max_occurs=999
             )
@@ -6193,6 +6222,7 @@ class SolutionGroup:
             metadata=dict(
                 name="PointOfSale",
                 type="Element",
+                namespace="http://www.travelport.com/schema/common_v48_0",
                 min_occurs=1,
                 max_occurs=999
             )
@@ -6208,6 +6238,7 @@ class SolutionGroup:
             metadata=dict(
                 name="PointOfSale",
                 type="Element",
+                namespace="http://www.travelport.com/schema/common_v48_0",
                 min_occurs=1,
                 max_occurs=999
             )
@@ -6325,6 +6356,7 @@ class SpecificTimeTable:
             metadata=dict(
                 name="Airport",
                 type="Element",
+                namespace="http://www.travelport.com/schema/common_v48_0",
                 required=True
             )
         )
@@ -6339,6 +6371,7 @@ class SpecificTimeTable:
             metadata=dict(
                 name="Airport",
                 type="Element",
+                namespace="http://www.travelport.com/schema/common_v48_0",
                 required=True
             )
         )
@@ -6608,6 +6641,7 @@ class TextInfo:
         metadata=dict(
             name="Text",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999,
             max_length=250.0
@@ -6888,7 +6922,8 @@ class TypeFarePenalty:
         default=None,
         metadata=dict(
             name="Amount",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
     percentage: str = field(
@@ -6896,6 +6931,7 @@ class TypeFarePenalty:
         metadata=dict(
             name="Percentage",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             pattern="([0-9]{1,2}|100)\.[0-9]{1,2}"
         )
     )
@@ -7042,6 +7078,7 @@ class TypeTicketFailureInfo:
         metadata=dict(
             name="BookingTravelerRef",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=1,
             max_occurs=999
         )
@@ -7059,6 +7096,7 @@ class TypeTicketFailureInfo:
         metadata=dict(
             name="TicketNumber",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             required=True
         )
     )
@@ -7255,6 +7293,7 @@ class Urlinfo:
         metadata=dict(
             name="Text",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999,
             max_length=250.0
@@ -7549,6 +7588,7 @@ class AirExchangeBundle:
         metadata=dict(
             name="AirExchangeInfo",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             required=True
         )
     )
@@ -7575,6 +7615,7 @@ class AirExchangeBundle:
         metadata=dict(
             name="Penalty",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -7593,6 +7634,7 @@ class AirExchangeBundleTotal:
         metadata=dict(
             name="AirExchangeInfo",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             required=True
         )
     )
@@ -7601,6 +7643,7 @@ class AirExchangeBundleTotal:
         metadata=dict(
             name="Penalty",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -7728,6 +7771,7 @@ class AirExchangeTicketBundle:
         metadata=dict(
             name="TicketNumber",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             required=True
         )
     )
@@ -7736,6 +7780,7 @@ class AirExchangeTicketBundle:
         metadata=dict(
             name="FormOfPayment",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=2
         )
@@ -7744,7 +7789,8 @@ class AirExchangeTicketBundle:
         default=None,
         metadata=dict(
             name="FormOfPaymentRef",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
     waiver_code: WaiverCode = field(
@@ -8202,7 +8248,8 @@ class AirTicketingModifiers:
         default=None,
         metadata=dict(
             name="Commission",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
     form_of_payment: List[FormOfPayment] = field(
@@ -8210,6 +8257,7 @@ class AirTicketingModifiers:
         metadata=dict(
             name="FormOfPayment",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -8219,6 +8267,7 @@ class AirTicketingModifiers:
         metadata=dict(
             name="CreditCardAuth",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -8228,6 +8277,7 @@ class AirTicketingModifiers:
         metadata=dict(
             name="Payment",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -8940,7 +8990,8 @@ class DetailedBillingInformation:
         default=None,
         metadata=dict(
             name="FormOfPaymentRef",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
     air_pricing_info_ref: List[AirPricingInfoRef] = field(
@@ -9296,6 +9347,7 @@ class Facility:
         metadata=dict(
             name="Remark",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -9330,6 +9382,7 @@ class Facility:
         metadata=dict(
             name="ServiceData",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -9906,14 +9959,16 @@ class IssuanceModifiers:
         default=None,
         metadata=dict(
             name="FormOfPaymentRef",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
     form_of_payment: FormOfPayment = field(
         default=None,
         metadata=dict(
             name="FormOfPayment",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
     plating_carrier: str = field(
@@ -10199,7 +10254,8 @@ class Pcc:
         default=None,
         metadata=dict(
             name="OverridePCC",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
     point_of_sale: List[PointOfSale] = field(
@@ -10207,6 +10263,7 @@ class Pcc:
         metadata=dict(
             name="PointOfSale",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=5
         )
@@ -10350,6 +10407,7 @@ class RelatedTraveler:
         metadata=dict(
             name="LoyaltyCard",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -10540,6 +10598,7 @@ class SelectionModifiers:
         metadata=dict(
             name="SvcSegmentRef",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -10605,6 +10664,7 @@ class TcrexchangeBundle:
         metadata=dict(
             name="AirExchangeInfo",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             required=True
         )
     )
@@ -10640,6 +10700,7 @@ class TcrexchangeBundle:
         metadata=dict(
             name="Penalty",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -10962,7 +11023,8 @@ class AirFareDisplayModifiers:
         default=None,
         metadata=dict(
             name="CabinClass",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
     penalty_fare_information: PenaltyFareInformation = field(
@@ -11391,6 +11453,7 @@ class AirLegModifiers:
             metadata=dict(
                 name="ConnectionPoint",
                 type="Element",
+                namespace="http://www.travelport.com/schema/common_v48_0",
                 min_occurs=1,
                 max_occurs=999
             )
@@ -11406,6 +11469,7 @@ class AirLegModifiers:
             metadata=dict(
                 name="ConnectionPoint",
                 type="Element",
+                namespace="http://www.travelport.com/schema/common_v48_0",
                 min_occurs=1,
                 max_occurs=999
             )
@@ -11421,6 +11485,7 @@ class AirLegModifiers:
             metadata=dict(
                 name="ConnectionPoint",
                 type="Element",
+                namespace="http://www.travelport.com/schema/common_v48_0",
                 min_occurs=1,
                 max_occurs=99
             )
@@ -11576,6 +11641,7 @@ class AirPricingModifiers:
         metadata=dict(
             name="DiscountCard",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=9
         )
@@ -11600,7 +11666,8 @@ class AirPricingModifiers:
         default=None,
         metadata=dict(
             name="PointOfSale",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
     brand_modifiers: BrandModifiers = field(
@@ -11821,6 +11888,7 @@ class AirPricingModifiers:
             metadata=dict(
                 name="AccountCode",
                 type="Element",
+                namespace="http://www.travelport.com/schema/common_v48_0",
                 min_occurs=1,
                 max_occurs=999
             )
@@ -12124,6 +12192,7 @@ class AirSearchModifiers:
             metadata=dict(
                 name="Provider",
                 type="Element",
+                namespace="http://www.travelport.com/schema/common_v48_0",
                 min_occurs=1,
                 max_occurs=999
             )
@@ -12139,6 +12208,7 @@ class AirSearchModifiers:
             metadata=dict(
                 name="Provider",
                 type="Element",
+                namespace="http://www.travelport.com/schema/common_v48_0",
                 min_occurs=1,
                 max_occurs=999
             )
@@ -12154,6 +12224,7 @@ class AirSearchModifiers:
             metadata=dict(
                 name="Carrier",
                 type="Element",
+                namespace="http://www.travelport.com/schema/common_v48_0",
                 min_occurs=1,
                 max_occurs=999
             )
@@ -12434,6 +12505,7 @@ class BrandingInfo:
         metadata=dict(
             name="AirSegmentRef",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=1,
             max_occurs=99
         )
@@ -12505,6 +12577,7 @@ class DocumentInfo:
         metadata=dict(
             name="MCOInfo",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -12556,6 +12629,7 @@ class Emdinfo(ProviderReservation, AttrElementKeyResults):
         metadata=dict(
             name="SupplierLocator",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -12573,14 +12647,16 @@ class Emdinfo(ProviderReservation, AttrElementKeyResults):
         default=None,
         metadata=dict(
             name="Payment",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
     form_of_payment: FormOfPayment = field(
         default=None,
         metadata=dict(
             name="FormOfPayment",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
     emdpricing_info: EmdpricingInfo = field(
@@ -12653,7 +12729,8 @@ class EmdsummaryInfo(AttrElementKeyResults):
         default=None,
         metadata=dict(
             name="Payment",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
     provider_reservation_info_ref: str = field(
@@ -12967,6 +13044,7 @@ class FaxDetails:
         metadata=dict(
             name="PhoneNumber",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             required=True
         )
     )
@@ -12982,6 +13060,7 @@ class FaxDetails:
         metadata=dict(
             name="Remark",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -13143,6 +13222,7 @@ class FlightInfo:
         metadata=dict(
             name="FlightInfoErrorMessage",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -13456,6 +13536,7 @@ class GeneralTimeTable:
         metadata=dict(
             name="FlightOrigin",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             required=True
         )
     )
@@ -13464,6 +13545,7 @@ class GeneralTimeTable:
         metadata=dict(
             name="FlightDestination",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             required=True
         )
     )
@@ -13641,6 +13723,7 @@ class PrePayCustomer:
         metadata=dict(
             name="Email",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -13650,6 +13733,7 @@ class PrePayCustomer:
         metadata=dict(
             name="Address",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -13668,6 +13752,7 @@ class PrePayCustomer:
         metadata=dict(
             name="LoyaltyCard",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -14042,7 +14127,8 @@ class ServiceAssociations:
             default=None,
             metadata=dict(
                 name="ResponseMessage",
-                type="Element"
+                type="Element",
+                namespace="http://www.travelport.com/schema/common_v48_0"
             )
         )
         optional_service_ref: OptionalServiceRef = field(
@@ -14291,6 +14377,7 @@ class AutoPricingInfo(AttrElementKeyResults):
         metadata=dict(
             name="BookingTravelerRef",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=100
         )
@@ -14612,6 +14699,7 @@ class FareDisplay:
         metadata=dict(
             name="AccountCode",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -14920,7 +15008,8 @@ class MerchandisingAvailabilityDetails:
         default=None,
         metadata=dict(
             name="AccountCode",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
 
@@ -14946,6 +15035,7 @@ class MerchandisingDetails:
         metadata=dict(
             name="AccountCode",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=10
         )
@@ -15020,6 +15110,7 @@ class OptionalService(AttrProviderSupplier, AttrPrices, AttrElementKeyResults):
         metadata=dict(
             name="ServiceData",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -15028,7 +15119,8 @@ class OptionalService(AttrProviderSupplier, AttrPrices, AttrElementKeyResults):
         default=None,
         metadata=dict(
             name="ServiceInfo",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
     remark: List[Remark] = field(
@@ -15036,6 +15128,7 @@ class OptionalService(AttrProviderSupplier, AttrPrices, AttrElementKeyResults):
         metadata=dict(
             name="Remark",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -15522,6 +15615,7 @@ class SearchAirLeg:
         metadata=dict(
             name="SearchOrigin",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=1,
             max_occurs=999
         )
@@ -15531,6 +15625,7 @@ class SearchAirLeg:
         metadata=dict(
             name="SearchDestination",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -15547,6 +15642,7 @@ class SearchAirLeg:
         metadata=dict(
             name="SearchDepTime",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=1,
             max_occurs=999
         )
@@ -15556,6 +15652,7 @@ class SearchAirLeg:
         metadata=dict(
             name="SearchArvTime",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=1,
             max_occurs=999
         )
@@ -15625,6 +15722,7 @@ class TicketingModifiers(AttrElementKeyResults):
         metadata=dict(
             name="BookingTravelerRef",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -15689,7 +15787,8 @@ class TicketingModifiers(AttrElementKeyResults):
         default=None,
         metadata=dict(
             name="Commission",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
     tour_code: TourCode = field(
@@ -15749,7 +15848,8 @@ class TicketingModifiers(AttrElementKeyResults):
         default=None,
         metadata=dict(
             name="SupplierLocator",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
     destination_purpose_code: DestinationPurposeCode = field(
@@ -16010,6 +16110,7 @@ class TypeBaseAirSegment(Segment):
         metadata=dict(
             name="SellMessage",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -16351,6 +16452,7 @@ class FareRule(AttrProviderSupplier):
         metadata=dict(
             name="FareRuleResultMessage",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -16448,6 +16550,7 @@ class OptionalServices:
         metadata=dict(
             name="OptionalServiceRules",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -16567,6 +16670,7 @@ class AirItinerary:
         metadata=dict(
             name="HostToken",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -16657,6 +16761,7 @@ class AirSolution:
         metadata=dict(
             name="HostToken",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=16
         )
@@ -16919,6 +17024,7 @@ class ExchangeAirSegment:
         metadata=dict(
             name="CabinClass",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             required=True
         )
     )
@@ -17010,6 +17116,7 @@ class TcrrefundBundle:
         metadata=dict(
             name="HostToken",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -17195,6 +17302,7 @@ class FareInfo(AttrElementKeyResults):
         metadata=dict(
             name="AccountCode",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -17213,6 +17321,7 @@ class FareInfo(AttrElementKeyResults):
         metadata=dict(
             name="Endorsement",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -17258,7 +17367,8 @@ class FareInfo(AttrElementKeyResults):
         default=None,
         metadata=dict(
             name="Commission",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
     fare_attributes: str = field(
@@ -17641,6 +17751,7 @@ class AirPricingInfo(AttrPrices, AttrProviderSupplier, AttrElementKeyResults, At
         metadata=dict(
             name="BookingTravelerRef",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -17789,6 +17900,7 @@ class AirPricingInfo(AttrPrices, AttrProviderSupplier, AttrElementKeyResults, At
         metadata=dict(
             name="Commission",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -18028,6 +18140,7 @@ class AirPricePoint(AttrPrices):
         metadata=dict(
             name="AirPricingResultMessage",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -18196,6 +18309,7 @@ class AirPricingSolution(AttrPrices):
         metadata=dict(
             name="MetaData",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -18205,6 +18319,7 @@ class AirPricingSolution(AttrPrices):
         metadata=dict(
             name="AirPricingResultMessage",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -18241,6 +18356,7 @@ class AirPricingSolution(AttrPrices):
         metadata=dict(
             name="HostToken",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -18340,7 +18456,8 @@ class Etr(AttrPrices, AttrElementKeyResults):
         default=None,
         metadata=dict(
             name="AgencyInfo",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
     booking_traveler: BookingTraveler = field(
@@ -18348,6 +18465,7 @@ class Etr(AttrPrices, AttrElementKeyResults):
         metadata=dict(
             name="BookingTraveler",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             required=True
         )
     )
@@ -18356,6 +18474,7 @@ class Etr(AttrPrices, AttrElementKeyResults):
         metadata=dict(
             name="FormOfPayment",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -18365,6 +18484,7 @@ class Etr(AttrPrices, AttrElementKeyResults):
         metadata=dict(
             name="Payment",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -18374,6 +18494,7 @@ class Etr(AttrPrices, AttrElementKeyResults):
         metadata=dict(
             name="CreditCardAuth",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -18383,6 +18504,7 @@ class Etr(AttrPrices, AttrElementKeyResults):
         metadata=dict(
             name="SupplierLocator",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -18409,6 +18531,7 @@ class Etr(AttrPrices, AttrElementKeyResults):
         metadata=dict(
             name="Commission",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -18432,6 +18555,7 @@ class Etr(AttrPrices, AttrElementKeyResults):
         metadata=dict(
             name="Restriction",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -18580,6 +18704,7 @@ class Tcr(ProviderReservation):
         metadata=dict(
             name="FormOfPayment",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -18589,6 +18714,7 @@ class Tcr(ProviderReservation):
         metadata=dict(
             name="Payment",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -18598,6 +18724,7 @@ class Tcr(ProviderReservation):
         metadata=dict(
             name="BookingTraveler",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=1,
             max_occurs=999
         )
@@ -18624,7 +18751,8 @@ class Tcr(ProviderReservation):
         default=None,
         metadata=dict(
             name="AgencyInfo",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
     air_reservation_locator_code: AirReservationLocatorCode = field(
@@ -18639,6 +18767,7 @@ class Tcr(ProviderReservation):
         metadata=dict(
             name="SupplierLocator",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -18648,6 +18777,7 @@ class Tcr(ProviderReservation):
         metadata=dict(
             name="RefundRemark",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -18805,6 +18935,7 @@ class TypeBaseAirReservation(BaseReservation):
         metadata=dict(
             name="SupplierLocator",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -18814,6 +18945,7 @@ class TypeBaseAirReservation(BaseReservation):
         metadata=dict(
             name="ThirdPartyInformation",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -18830,6 +18962,7 @@ class TypeBaseAirReservation(BaseReservation):
         metadata=dict(
             name="BookingTravelerRef",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -18839,6 +18972,7 @@ class TypeBaseAirReservation(BaseReservation):
         metadata=dict(
             name="ProviderReservationInfoRef",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -18875,6 +19009,7 @@ class TypeBaseAirReservation(BaseReservation):
         metadata=dict(
             name="Payment",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -18884,6 +19019,7 @@ class TypeBaseAirReservation(BaseReservation):
         metadata=dict(
             name="CreditCardAuth",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -19009,7 +19145,8 @@ class AirPriceResult:
         default=None,
         metadata=dict(
             name="AirPriceError",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
     command_key: str = field(
@@ -19095,6 +19232,7 @@ class OptionalServicesInfo:
         metadata=dict(
             name="FormOfPayment",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -19104,6 +19242,7 @@ class OptionalServicesInfo:
         metadata=dict(
             name="FormOfPaymentRef",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -19121,6 +19260,7 @@ class TypeAirReservationWithFop(TypeBaseAirReservation):
         metadata=dict(
             name="FormOfPayment",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )

--- a/tests/target/air_v48_0/air_req_rsp.py
+++ b/tests/target/air_v48_0/air_req_rsp.py
@@ -72,6 +72,7 @@ class AirExchangeQuoteRsp(BaseRsp):
         metadata=dict(
             name="TicketNumber",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -106,6 +107,7 @@ class AirExchangeQuoteRsp(BaseRsp):
         metadata=dict(
             name="HostToken",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -160,6 +162,7 @@ class AirExchangeReq(BaseReq):
         metadata=dict(
             name="TicketNumber",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -210,6 +213,7 @@ class AirExchangeReq(BaseReq):
         metadata=dict(
             name="HostToken",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -225,14 +229,16 @@ class AirExchangeReq(BaseReq):
         default=None,
         metadata=dict(
             name="FormOfPayment",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
     form_of_payment_ref: FormOfPaymentRef = field(
         default=None,
         metadata=dict(
             name="FormOfPaymentRef",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
     ssrinfo: List[Ssrinfo] = field(
@@ -240,6 +246,7 @@ class AirExchangeReq(BaseReq):
         metadata=dict(
             name="SSRInfo",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -248,7 +255,8 @@ class AirExchangeReq(BaseReq):
         default=None,
         metadata=dict(
             name="AddSvc",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
     return_reservation: bool = field(
@@ -273,6 +281,7 @@ class AirExchangeRsp(BaseRsp):
         metadata=dict(
             name="TicketNumber",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -282,6 +291,7 @@ class AirExchangeRsp(BaseRsp):
         metadata=dict(
             name="BookingTraveler",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -330,6 +340,7 @@ class AirExchangeTicketingReq(BaseReq):
         metadata=dict(
             name="TicketNumber",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             required=True
         )
     )
@@ -461,6 +472,7 @@ class AirFareDisplayReq(BaseReq):
         metadata=dict(
             name="PassengerType",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -493,6 +505,7 @@ class AirFareDisplayReq(BaseReq):
         metadata=dict(
             name="Carrier",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=10
         )
@@ -502,6 +515,7 @@ class AirFareDisplayReq(BaseReq):
         metadata=dict(
             name="AccountCode",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=5
         )
@@ -525,6 +539,7 @@ class AirFareDisplayReq(BaseReq):
         metadata=dict(
             name="PointOfSale",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=5
         )
@@ -857,7 +872,8 @@ class AirMerchandisingOfferAvailabilityReq(BaseReq):
         default=None,
         metadata=dict(
             name="AgencySellInfo",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
     air_solution: AirSolution = field(
@@ -915,7 +931,8 @@ class AirMerchandisingOfferAvailabilityRsp(BaseRsp):
         default=None,
         metadata=dict(
             name="Remark",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
     optional_services: OptionalServices = field(
@@ -979,6 +996,7 @@ class AirPrePayReq(BaseReq):
             metadata=dict(
                 name="LoyaltyCard",
                 type="Element",
+                namespace="http://www.travelport.com/schema/common_v48_0",
                 min_occurs=1,
                 max_occurs=999
             )
@@ -1087,6 +1105,7 @@ class AirRefundQuoteReq(BaseReq):
         metadata=dict(
             name="TicketNumber",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -1112,6 +1131,7 @@ class AirRefundQuoteReq(BaseReq):
         metadata=dict(
             name="HostToken",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -1205,6 +1225,7 @@ class AirRefundReq(BaseReq):
         metadata=dict(
             name="Commission",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=9
         )
@@ -1213,7 +1234,8 @@ class AirRefundReq(BaseReq):
         default=None,
         metadata=dict(
             name="FormOfPayment",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
 
@@ -1304,6 +1326,7 @@ class AirRetrieveDocumentReq(BaseReq):
         metadata=dict(
             name="TicketNumber",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -1364,6 +1387,7 @@ class AirRetrieveDocumentRsp(BaseRsp):
         metadata=dict(
             name="MCO",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -1391,6 +1415,7 @@ class AirRetrieveDocumentRsp(BaseRsp):
         metadata=dict(
             name="ServiceFeeInfo",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=99
         )
@@ -1553,6 +1578,7 @@ class BaseAirExchangeMultiQuoteReq(BaseCoreReq):
         metadata=dict(
             name="TicketNumber",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -1591,7 +1617,8 @@ class BaseAirExchangeMultiQuoteReq(BaseCoreReq):
         default=None,
         metadata=dict(
             name="OverridePCC",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
 
@@ -1621,6 +1648,7 @@ class BaseAirExchangeQuoteReq(BaseCoreReq):
         metadata=dict(
             name="TicketNumber",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -1653,6 +1681,7 @@ class BaseAirExchangeQuoteReq(BaseCoreReq):
         metadata=dict(
             name="HostToken",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -1669,6 +1698,7 @@ class BaseAirExchangeQuoteReq(BaseCoreReq):
         metadata=dict(
             name="FormOfPayment",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -1750,6 +1780,7 @@ class BaseAirPriceReq(BaseCoreReq):
         metadata=dict(
             name="SearchPassenger",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=1,
             max_occurs=18
         )
@@ -1782,6 +1813,7 @@ class BaseAirPriceReq(BaseCoreReq):
         metadata=dict(
             name="FormOfPayment",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -1798,6 +1830,7 @@ class BaseAirPriceReq(BaseCoreReq):
         metadata=dict(
             name="SSR",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=99
         )
@@ -2004,6 +2037,7 @@ class EmdissuanceReq(BaseReq):
         metadata=dict(
             name="ProviderReservationDetail",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             required=True
         )
     )
@@ -2011,7 +2045,8 @@ class EmdissuanceReq(BaseReq):
         default=None,
         metadata=dict(
             name="TicketNumber",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
     issuance_modifiers: IssuanceModifiers = field(
@@ -2117,6 +2152,7 @@ class EmdretrieveReq(BaseReq):
             metadata=dict(
                 name="ProviderReservationDetail",
                 type="Element",
+                namespace="http://www.travelport.com/schema/common_v48_0",
                 required=True
             )
         )
@@ -2131,7 +2167,8 @@ class EmdretrieveReq(BaseReq):
             default=None,
             metadata=dict(
                 name="ProviderReservationDetail",
-                type="Element"
+                type="Element",
+                namespace="http://www.travelport.com/schema/common_v48_0"
             )
         )
         emdnumber: str = field(
@@ -2404,7 +2441,8 @@ class SeatMapReq(BaseReq):
         default=None,
         metadata=dict(
             name="AgencySellInfo",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
     air_segment: List[AirSegment] = field(
@@ -2421,6 +2459,7 @@ class SeatMapReq(BaseReq):
         metadata=dict(
             name="HostToken",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=99
         )
@@ -2485,6 +2524,7 @@ class SeatMapRsp(BaseRsp):
         metadata=dict(
             name="HostToken",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=99
         )
@@ -2493,7 +2533,8 @@ class SeatMapRsp(BaseRsp):
         default=None,
         metadata=dict(
             name="CabinClass",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
     air_segment: List[AirSegment] = field(
@@ -2525,7 +2566,8 @@ class SeatMapRsp(BaseRsp):
         default=None,
         metadata=dict(
             name="Remark",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
     rows: List[Rows] = field(
@@ -2542,6 +2584,7 @@ class SeatMapRsp(BaseRsp):
         metadata=dict(
             name="PaymentRestriction",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -2698,7 +2741,8 @@ class AirSearchReq(BaseSearchReq):
         default=None,
         metadata=dict(
             name="PointOfCommencement",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
     air_search_modifiers: AirSearchModifiers = field(
@@ -2802,35 +2846,40 @@ class AirSearchRsp(BaseAvailabilitySearchRsp):
         default=None,
         metadata=dict(
             name="RailSegmentList",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/rail_v48_0"
         )
     )
     rail_journey_list: RailJourneyList = field(
         default=None,
         metadata=dict(
             name="RailJourneyList",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/rail_v48_0"
         )
     )
     rail_fare_note_list: RailFareNoteList = field(
         default=None,
         metadata=dict(
             name="RailFareNoteList",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/rail_v48_0"
         )
     )
     rail_fare_idlist: RailFareIdlist = field(
         default=None,
         metadata=dict(
             name="RailFareIDList",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/rail_v48_0"
         )
     )
     rail_fare_list: RailFareList = field(
         default=None,
         metadata=dict(
             name="RailFareList",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/rail_v48_0"
         )
     )
     rail_pricing_solution: List[RailPricingSolution] = field(
@@ -2838,6 +2887,7 @@ class AirSearchRsp(BaseAvailabilitySearchRsp):
         metadata=dict(
             name="RailPricingSolution",
             type="Element",
+            namespace="http://www.travelport.com/schema/rail_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -2915,6 +2965,7 @@ class AirTicketingReq(AirBaseReq):
         metadata=dict(
             name="Commission",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=18
         )
@@ -2986,6 +3037,7 @@ class AirTicketingReq(AirBaseReq):
             metadata=dict(
                 name="BookingTravelerRef",
                 type="Element",
+                namespace="http://www.travelport.com/schema/common_v48_0",
                 min_occurs=0,
                 max_occurs=9
             )
@@ -3104,6 +3156,7 @@ class AvailabilitySearchReq(AirSearchReq):
         metadata=dict(
             name="SearchPassenger",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=18
         )
@@ -3113,6 +3166,7 @@ class AvailabilitySearchReq(AirSearchReq):
         metadata=dict(
             name="PointOfSale",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=5
         )
@@ -3176,6 +3230,7 @@ class BaseLowFareSearchReq(BaseAirSearchReq):
         metadata=dict(
             name="SearchPassenger",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=1,
             max_occurs=18
         )
@@ -3227,6 +3282,7 @@ class BaseLowFareSearchReq(BaseAirSearchReq):
         metadata=dict(
             name="FormOfPayment",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=99
         )

--- a/tests/target/rail_v48_0/rail.py
+++ b/tests/target/rail_v48_0/rail.py
@@ -542,6 +542,7 @@ class RailFareComponent:
             metadata=dict(
                 name="DiscountCard",
                 type="Element",
+                namespace="http://www.travelport.com/schema/common_v48_0",
                 min_occurs=1,
                 max_occurs=9
             )
@@ -706,6 +707,7 @@ class RailLegModifiers:
             metadata=dict(
                 name="ConnectionPoint",
                 type="Element",
+                namespace="http://www.travelport.com/schema/common_v48_0",
                 min_occurs=1,
                 max_occurs=999
             )
@@ -721,6 +723,7 @@ class RailLegModifiers:
             metadata=dict(
                 name="ConnectionPoint",
                 type="Element",
+                namespace="http://www.travelport.com/schema/common_v48_0",
                 min_occurs=1,
                 max_occurs=999
             )
@@ -742,6 +745,7 @@ class RailPricingModifiers:
         metadata=dict(
             name="DiscountCard",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=9
         )
@@ -996,6 +1000,7 @@ class Coach:
         metadata=dict(
             name="Remark",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -1061,7 +1066,8 @@ class RailFare(AttrElementKeyResults):
         default=None,
         metadata=dict(
             name="HostToken",
-            type="Element"
+            type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0"
         )
     )
     ful_fillment_type: List[FulFillmentType] = field(
@@ -1680,6 +1686,7 @@ class RailJourney(AttrRailSegmentOrigDestInfo, AttrPrices, AttrProviderSupplier,
         metadata=dict(
             name="HostToken",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -1805,6 +1812,7 @@ class RailPricingInfo(AttrPrices, AttrElementKeyResults):
         metadata=dict(
             name="PassengerType",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -1814,6 +1822,7 @@ class RailPricingInfo(AttrPrices, AttrElementKeyResults):
         metadata=dict(
             name="BookingTravelerRef",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -1912,6 +1921,7 @@ class RailReservation(BaseReservation):
         metadata=dict(
             name="BookingTravelerRef",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=1,
             max_occurs=9
         )
@@ -1939,6 +1949,7 @@ class RailReservation(BaseReservation):
         metadata=dict(
             name="Payment",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -1964,6 +1975,7 @@ class RailReservation(BaseReservation):
         metadata=dict(
             name="SupplierLocator",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=0,
             max_occurs=999
         )
@@ -1994,6 +2006,7 @@ class SearchRailLeg:
         metadata=dict(
             name="SearchOrigin",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=1,
             max_occurs=999
         )
@@ -2003,6 +2016,7 @@ class SearchRailLeg:
         metadata=dict(
             name="SearchDestination",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=1,
             max_occurs=999
         )
@@ -2026,6 +2040,7 @@ class SearchRailLeg:
         metadata=dict(
             name="SearchDepTime",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=1,
             max_occurs=999
         )
@@ -2035,6 +2050,7 @@ class SearchRailLeg:
         metadata=dict(
             name="SearchArvTime",
             type="Element",
+            namespace="http://www.travelport.com/schema/common_v48_0",
             min_occurs=1,
             max_occurs=999
         )

--- a/xsdata/builder.py
+++ b/xsdata/builder.py
@@ -125,6 +125,7 @@ class ClassBuilder:
                 local_type=type(obj).__name__,
                 help=obj.display_help,
                 forward_ref=inner_type,
+                namespace=obj.namespace,
                 restrictions=obj.get_restrictions(),
             )
         )

--- a/xsdata/models/elements.py
+++ b/xsdata/models/elements.py
@@ -11,7 +11,7 @@ from typing import Optional
 
 from lxml import etree
 
-from xsdata.models.enums import XMLSchema, XSDType
+from xsdata.models.enums import Form, XMLSchema, XSDType
 from xsdata.models.mixins import (
     ExtendsMixin,
     NamedField,
@@ -85,9 +85,9 @@ class BaseModel:
             if clazz == float:
                 return float(value)
         except ValueError:
-            pass
+            return str(value)
 
-        return str(value)
+        return clazz(value)
 
     @classmethod
     def build(cls, **kwargs):
@@ -230,7 +230,7 @@ class Attribute(
 ):
     default: Optional[str]
     fixed: Optional[str]
-    form: Optional[str]  # qualified | unqualified
+    form: Optional[Form]
     name: Optional[str]
     ref: Optional[str]
     type: Optional[str]
@@ -537,7 +537,7 @@ class Element(
     substitution_group: Optional[str]
     default: Optional[str]
     fixed: Optional[str]
-    form: Optional[str]
+    form: Optional[Form]
     block: Optional[List]
     final: Optional[List]
     simple_type: Optional[SimpleType]
@@ -616,13 +616,13 @@ class Redefined(AnnotationBase):
 @dataclass
 class Schema(AnnotationBase):
     target: Optional[str]
-    attribute_form_default: Optional[str]
-    element_form_default: Optional[str]
     block_default: Optional[str]
     final_default: Optional[str]
     target_namespace: Optional[str]
     version: Optional[str]
     xmlns: Optional[str]
+    element_form_default: Form = field(default=Form.UNQUALIFIED)
+    attribute_form_default: Form = field(default=Form.UNQUALIFIED)
     includes: ArrayList[Include] = field(default_factory=list)
     imports: ArrayList[Import] = field(default_factory=list)
     redefineds: ArrayList[Redefined] = field(default_factory=list)

--- a/xsdata/models/enums.py
+++ b/xsdata/models/enums.py
@@ -6,6 +6,11 @@ from lxml import etree
 XMLSchema = "http://www.w3.org/2001/XMLSchema"
 
 
+class Form(Enum):
+    QUALIFIED = "qualified"
+    UNQUALIFIED = "unqualified"
+
+
 class XSDType(Enum):
     ANY_URI = ("xs:anyURI", str)
     BASE64_BINARY = ("xs:base64Binary", str)
@@ -64,7 +69,7 @@ class XSDType(Enum):
         if pos == -1:
             return None
 
-        return __XSDType__.get("xs:" + code[pos + 1:])
+        return __XSDType__.get("xs:" + code[pos + 1 :])
 
     @classmethod
     def get_local(cls, code: str) -> Optional[str]:

--- a/xsdata/models/mixins.py
+++ b/xsdata/models/mixins.py
@@ -1,12 +1,27 @@
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 
+from xsdata.models.enums import Form, XSDType
+
 
 class TypedField(ABC):
     @property
     @abstractmethod
     def real_type(self) -> Optional[str]:
         pass
+
+    @property
+    def namespace(self):
+        form: Form = getattr(self, "form", Form.UNQUALIFIED)
+        if form == Form.UNQUALIFIED:
+            return None
+
+        real_type = self.real_type
+        prefix_pos = real_type.find(":")
+        if prefix_pos == -1 or XSDType.get_enum(real_type):
+            return None
+
+        return self.nsmap.get(real_type[:prefix_pos])
 
 
 class ExtendsMixin(ABC):

--- a/xsdata/models/render.py
+++ b/xsdata/models/render.py
@@ -9,10 +9,11 @@ from xsdata.models.elements import Schema
 @dataclass
 class Attr:
     name: str
-    type: str
-    help: Optional[str]
-    local_type: str
     local_name: str = field(init=False)
+    type: str
+    local_type: str
+    namespace: Optional[str]
+    help: Optional[str]
     forward_ref: bool = field(default=False)
     restrictions: dict = field(default_factory=dict)
     default: Optional[Any] = field(default=None)

--- a/xsdata/render/python/dataclass/filters.py
+++ b/xsdata/render/python/dataclass/filters.py
@@ -4,16 +4,14 @@ from xsdata.models.render import Class
 
 
 def arguments(data: dict):
-    def quote(value):
+    def prep(key, value):
         if isinstance(value, str) and not has_quotes(value):
-            return '"{}"'.format(value.replace('"', "'"))
-        return value
+            value = '"{}"'.format(value.replace('"', "'"))
+        return f"{key}={value}"
 
-    return ",\n".join([f"{key}={quote(value)}" for key, value in data.items()])
-
-
-def update(data: dict, more: dict):
-    return dict(data, **more)
+    return ",\n".join(
+        [prep(key, value) for key, value in data.items() if value is not None]
+    )
 
 
 def docstring(obj: Class):
@@ -36,3 +34,6 @@ def has_quotes(string: str):
         if string.startswith(quote) and string.endswith(quote):
             return True
     return False
+
+
+filters = {"arguments": arguments, "docstring": docstring}

--- a/xsdata/render/python/dataclass/renderer.py
+++ b/xsdata/render/python/dataclass/renderer.py
@@ -7,7 +7,7 @@ from toposort import toposort_flatten
 from xsdata.models.elements import Schema
 from xsdata.models.enums import XSDType
 from xsdata.models.render import Class, Renderer
-from xsdata.render.python.dataclass.filters import arguments, docstring, update
+from xsdata.render.python.dataclass.filters import filters
 from xsdata.render.python.dataclass.utils import replace_words
 from xsdata.utils import text
 from xsdata.utils.text import snake_case, strip_prefix
@@ -16,10 +16,11 @@ from xsdata.utils.text import snake_case, strip_prefix
 class DataclassRenderer(Renderer):
     def __init__(self):
         templates_dir = Path(__file__).parent.joinpath("templates")
-        self.env = Environment(loader=FileSystemLoader(str(templates_dir)),)
-        self.env.filters["arguments"] = arguments
-        self.env.filters["docstring"] = docstring
-        self.env.filters["update"] = update
+        self.env = Environment(
+            loader=FileSystemLoader(str(templates_dir)),
+            extensions=["jinja2.ext.do"],
+        )
+        self.env.filters.update(filters)
 
     def template(self, name: str) -> Template:
         return self.env.get_template("{}.jinja2".format(name))

--- a/xsdata/render/python/dataclass/templates/class.jinja2
+++ b/xsdata/render/python/dataclass/templates/class.jinja2
@@ -9,16 +9,18 @@ class {{ obj.name }}{{"({})".format(obj.extensions|join(', ')) if obj.extensions
 {%- for attr in obj.attrs %}
     {%- set display_type = '"{}.{}"'.format(outer|join('.'), attr.type) if attr.forward_ref else attr.type -%}
     {%- set display_type = 'List[{}]'.format(display_type) if attr.is_list else display_type -%}
-    {%- set field_params = {
-                  "name" : attr.local_name,
-                  "type" : attr.local_type,
-               }
+    {%- set field_params = dict(
+                  name=attr.local_name,
+                  type=attr.local_type,
+                  namespace=attr.namespace,
+                  ** attr.restrictions
+            )
     %}
     {{ attr.name }}: {{ display_type }} = field(
         {{ "default_factory" if attr.is_list else "default" }}=
         {{- "list" if attr.is_list else ('"{}"'.format(attr.default) if attr.default else attr.default) }},
         metadata=dict(
-            {{ field_params|update(attr.restrictions)|arguments|indent(12) }}
+            {{ field_params|arguments|indent(12) }}
         )
     )
 {%- endfor -%}


### PR DESCRIPTION
1. Parse the schema form for elements and attributes
2. Copy schema forms to elements and attributes without form
3. Use the element/attribute form and `real_type` reference `namespace:name` to add namespaces to all attributes.
4. Elements: nothing yet 
5. Update python dataclass renderer 