### PR TITLE
Flatten attribute groups

### DIFF
--- a/xsdata/codegen/python/dataclass/filters.py
+++ b/xsdata/codegen/python/dataclass/filters.py
@@ -7,6 +7,8 @@ def arguments(data: dict):
     def prep(key, value):
         if isinstance(value, str) and not has_quotes(value):
             value = '"{}"'.format(value.replace('"', "'"))
+            if key == "pattern":
+                value = f"r{value}"
         return f"{key}={value}"
 
     return ",\n".join(

--- a/xsdata/codegen/resolver.py
+++ b/xsdata/codegen/resolver.py
@@ -80,7 +80,7 @@ class DependenciesResolver:
         """Create and append an import package to the list of imports, collect
         a map of aliases for when we process the list of classes to
         generate."""
-        if alias:
+        if alias is not None:
             self.aliases[alias] = alias
         self.imports.append(Package(name=name, source=package, alias=alias))
 


### PR DESCRIPTION
Notes:
Similar to the global simpe types, copy attributes, type, values to
referencing elements from attribute groups. The goal is to generate
as little classes as possible even if we have to repeat fields.

That's a nicer strategy than having multi-inheritance in the final
data classes and paves the way for fields ordering :)