### PR TITLE
Implement enumerations

### DIFF
--- a/tests/codegen/python/dataclass/test_generator.py
+++ b/tests/codegen/python/dataclass/test_generator.py
@@ -1,13 +1,13 @@
 from pathlib import Path
-from unittest import TestCase, mock
+from unittest import mock
 
-from tests.unittest import ClassFactory, PackageFactory
+from tests.factories import ClassFactory, FactoryTestCase, PackageFactory
 from xsdata.codegen.python.dataclass.generator import DataclassGenerator
 from xsdata.codegen.resolver import DependenciesResolver
 from xsdata.models.elements import Schema
 
 
-class DataclassGeneratorTests(TestCase):
+class DataclassGeneratorTests(FactoryTestCase):
     @mock.patch.object(Path, "mkdir")
     @mock.patch.object(DependenciesResolver, "process")
     @mock.patch.object(DataclassGenerator, "render_module")

--- a/tests/codegen/python/test_generator.py
+++ b/tests/codegen/python/test_generator.py
@@ -1,12 +1,17 @@
-from unittest import TestCase, mock
+from unittest import mock
 
-from tests.unittest import AttrFactory, ClassFactory, PackageFactory
+from tests.factories import (
+    AttrFactory,
+    ClassFactory,
+    FactoryTestCase,
+    PackageFactory,
+)
 from xsdata.codegen.python.generator import (
     PythonAbstractGenerator as generator,
 )
 
 
-class PythonAbstractGeneratorTests(TestCase):
+class PythonAbstractGeneratorTests(FactoryTestCase):
     @mock.patch.object(generator, "process_attribute")
     @mock.patch.object(generator, "type_name")
     @mock.patch.object(generator, "class_name")

--- a/tests/codegen/test_resolver.py
+++ b/tests/codegen/test_resolver.py
@@ -1,12 +1,17 @@
 from collections.abc import Iterator
-from unittest import TestCase, mock
+from unittest import mock
 
-from tests.unittest import AttrFactory, ClassFactory, PackageFactory
+from tests.factories import (
+    AttrFactory,
+    ClassFactory,
+    FactoryTestCase,
+    PackageFactory,
+)
 from xsdata.codegen.resolver import DependenciesResolver
 from xsdata.models.elements import Schema
 
 
-class DependenciesResolverTest(TestCase):
+class DependenciesResolverTest(FactoryTestCase):
     def setUp(self) -> None:
         self.resolver = DependenciesResolver()
 

--- a/tests/codegen/test_resolver.py
+++ b/tests/codegen/test_resolver.py
@@ -13,6 +13,7 @@ from xsdata.models.elements import Schema
 
 class DependenciesResolverTest(FactoryTestCase):
     def setUp(self) -> None:
+        super(DependenciesResolverTest, self).setUp()
         self.resolver = DependenciesResolver()
 
     @mock.patch.object(DependenciesResolver, "resolve_imports")

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -16,7 +16,7 @@ from xsdata.models.enums import XSDType
 fixtures_dir = path.join(path.dirname(path.abspath(__file__)), "xsd")
 
 
-class TestCase(unittest.TestCase):
+class FactoryTestCase(unittest.TestCase):
     def setUp(self) -> None:
         ClassFactory.reset()
         AttrFactory.reset()

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,7 +1,6 @@
 import random
 import unittest
 from abc import ABC, abstractmethod
-from os import path
 
 from xsdata.models.codegen import Attr, Class, Package
 from xsdata.models.elements import (
@@ -13,17 +12,12 @@ from xsdata.models.elements import (
 )
 from xsdata.models.enums import XSDType
 
-fixtures_dir = path.join(path.dirname(path.abspath(__file__)), "xsd")
-
 
 class FactoryTestCase(unittest.TestCase):
     def setUp(self) -> None:
+        super(FactoryTestCase, self).setUp()
         ClassFactory.reset()
         AttrFactory.reset()
-
-    @staticmethod
-    def fixture_path(file_name):
-        return "{}/{}.xsd".format(fixtures_dir, file_name)
 
 
 class Factory(ABC):

--- a/tests/models/elements/test_attribute.py
+++ b/tests/models/elements/test_attribute.py
@@ -5,6 +5,10 @@ from xsdata.models.enums import UseType
 
 
 class AttributeTests(TestCase):
+    def test_property_is_attribute(self):
+        obj = Attribute.create()
+        self.assertTrue(obj)
+
     def test_property_real_type(self):
         obj = Attribute.create()
         self.assertEqual("xs:string", obj.real_type)
@@ -33,17 +37,17 @@ class AttributeTests(TestCase):
 
     def test_get_restrictions(self):
         obj = Attribute.create()
-        self.assertDictEqual({}, obj.get_restrictions())
+        self.assertEqual({}, obj.get_restrictions())
 
         obj.use = UseType.REQUIRED
         expected = dict(required=1)
-        self.assertDictEqual(expected, obj.get_restrictions())
+        self.assertEqual(expected, obj.get_restrictions())
 
         obj.simple_type = SimpleType.create(
             restriction=Restriction.create(length=Length.create(value=1))
         )
         expected.update(dict(length=1))
-        self.assertDictEqual(expected, obj.get_restrictions())
+        self.assertEqual(expected, obj.get_restrictions())
 
     def test_property_extensions(self):
         obj = Attribute.create()

--- a/tests/models/elements/test_element.py
+++ b/tests/models/elements/test_element.py
@@ -12,6 +12,10 @@ from xsdata.models.elements import (
 
 
 class ElementTests(TestCase):
+    def test_property_is_attribute(self):
+        obj = Element.create()
+        self.assertTrue(obj)
+
     def test_property_real_name(self):
         obj = Element.create(ref="bar")
         self.assertEqual("bar", obj.real_name)
@@ -58,10 +62,10 @@ class ElementTests(TestCase):
     def test_get_restrictions(self):
         obj = Element.create()
         expected = {"required": True}
-        self.assertDictEqual(expected, obj.get_restrictions())
+        self.assertEqual(expected, obj.get_restrictions())
 
         obj.simple_type = SimpleType.create(
             restriction=Restriction.create(length=Length.create(value=9))
         )
         expected.update({"length": 9})
-        self.assertDictEqual(expected, obj.get_restrictions())
+        self.assertEqual(expected, obj.get_restrictions())

--- a/tests/models/elements/test_enumeration.py
+++ b/tests/models/elements/test_enumeration.py
@@ -1,0 +1,29 @@
+from unittest import TestCase
+
+from xsdata.models.elements import Enumeration
+
+
+class EnumerationTests(TestCase):
+    def test_property_is_attribute(self):
+        obj = Enumeration.create()
+        self.assertTrue(obj)
+
+    def test_property_real_name(self):
+        obj = Enumeration.create(value="foo")
+        self.assertEqual("foo", obj.real_name)
+
+    def test_property_real_type(self):
+        obj = Enumeration.create()
+        self.assertEqual("xs:string", obj.real_type)
+
+    def test_property_default(self):
+        obj = Enumeration.create(value="foo")
+        self.assertEqual("foo", obj.default)
+
+    def test_property_namespace(self):
+        obj = Enumeration.create()
+        self.assertIsNone(obj.namespace)
+
+    def test_get_restrictions(self):
+        obj = Enumeration.create()
+        self.assertEqual({}, obj.get_restrictions())

--- a/tests/models/elements/test_list.py
+++ b/tests/models/elements/test_list.py
@@ -18,10 +18,10 @@ class ListTests(TestCase):
     def test_get_restrictions(self):
         obj = List.create()
         expected = dict(min_occurs=0, max_occurs=sys.maxsize)
-        self.assertDictEqual(expected, obj.get_restrictions())
+        self.assertEqual(expected, obj.get_restrictions())
 
         obj.simple_type = SimpleType.create(
             restriction=Restriction.create(length=Length.create(value=1))
         )
         expected.update(dict(length=1))
-        self.assertDictEqual(expected, obj.get_restrictions())
+        self.assertEqual(expected, obj.get_restrictions())

--- a/tests/models/elements/test_restriction.py
+++ b/tests/models/elements/test_restriction.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 from xsdata.models.elements import (
     Enumeration,
     FractionDigits,
+    Group,
     Length,
     MaxExclusive,
     MaxInclusive,
@@ -26,8 +27,33 @@ class RestrictionTests(TestCase):
         obj = Restriction.create()
         self.assertEqual("value", obj.real_name)
 
+    def test_property_is_attribute(self):
+        obj = Restriction.create()
+        self.assertTrue(obj.is_attribute)
+
+        obj = Restriction.create(group=Group.create())
+        self.assertFalse(obj.is_attribute)
+
+        self.assertEqual(
+            (
+                "group",
+                "all",
+                "choice",
+                "sequence",
+                "any_attribute",
+                "attributes",
+                "attribute_groups",
+                "enumerations",
+            ),
+            obj.CONTAINER_FIELDS,
+        )
+
+    def test_property_extensions(self):
+        obj = Restriction.create(base="foo")
+        self.assertEqual(["foo"], obj.extensions)
+
     def test_get_restrictions(self):
-        self.assertDictEqual({}, Restriction.create().get_restrictions())
+        self.assertEqual({}, Restriction.create().get_restrictions())
 
         obj = Restriction.create(
             min_exclusive=MinExclusive.create(value=1),
@@ -41,10 +67,9 @@ class RestrictionTests(TestCase):
             length=Length.create(value=9),
             white_space=WhiteSpace.create(value="collapse"),
             pattern=Pattern.create(value=".*"),
-            enumerations=Enumeration.create(value="str"),
+            enumerations=[Enumeration.create(value="str")],
         )
         expected = {
-            "enumerations": "str",
             "fraction_digits": 8,
             "length": 9,
             "max_exclusive": 4,
@@ -58,4 +83,4 @@ class RestrictionTests(TestCase):
             "white_space": "collapse",
         }
 
-        self.assertDictEqual(expected, obj.get_restrictions())
+        self.assertEqual(expected, obj.get_restrictions())

--- a/tests/models/elements/test_simple_content.py
+++ b/tests/models/elements/test_simple_content.py
@@ -1,12 +1,15 @@
 from unittest import TestCase
 
-from xsdata.models.elements import Extension, SimpleContent
+from xsdata.models.elements import Extension, Restriction, SimpleContent
 
 
 class SimpleContentTests(TestCase):
     def test_property_extension(self):
         obj = SimpleContent.create()
         self.assertEqual([], obj.extensions)
+
+        obj.restriction = Restriction.create(base="bar")
+        self.assertEqual(["bar"], obj.extensions)
 
         obj.extension = Extension.create(base="foo")
         self.assertEqual(["foo"], obj.extensions)

--- a/tests/models/elements/test_simple_type.py
+++ b/tests/models/elements/test_simple_type.py
@@ -32,12 +32,12 @@ class SimpleTypeTests(TestCase):
 
     def test_get_restrictions(self):
         obj = SimpleType.create()
-        self.assertDictEqual({}, obj.get_restrictions())
+        self.assertEqual({}, obj.get_restrictions())
 
         expected = dict(min_occurs=0, max_occurs=sys.maxsize)
         obj.list = List.create()
-        self.assertDictEqual(expected, obj.get_restrictions())
+        self.assertEqual(expected, obj.get_restrictions())
 
         expected = dict(length=2)
         obj.restriction = Restriction.create(length=Length.create(value=2))
-        self.assertDictEqual(expected, obj.get_restrictions())
+        self.assertEqual(expected, obj.get_restrictions())

--- a/tests/models/test_mixins.py
+++ b/tests/models/test_mixins.py
@@ -20,6 +20,7 @@ def get_subclasses(clazz: Type):
 
 class OccurrencesMixinTests(TestCase):
     def setUp(self) -> None:
+        super(OccurrencesMixinTests, self).setUp()
         self.subclasses = [c for _, c in get_subclasses(OccurrencesMixin)]
 
     def test_subclasses(self):
@@ -52,6 +53,7 @@ class OccurrencesMixinTests(TestCase):
 
 class TypedFieldTests(TestCase):
     def setUp(self) -> None:
+        super(TypedFieldTests, self).setUp()
         self.subclasses = [c for _, c in get_subclasses(TypedField)]
 
     def test_subclasses(self):

--- a/tests/models/test_mixins.py
+++ b/tests/models/test_mixins.py
@@ -3,7 +3,7 @@ from typing import Type
 from unittest import TestCase
 
 from xsdata.models import elements as el
-from xsdata.models.mixins import OccurrencesMixin, TypedField
+from xsdata.models.mixins import ElementBase, OccurrencesMixin, TypedField
 
 
 def get_subclasses(clazz: Type):
@@ -37,17 +37,17 @@ class OccurrencesMixinTests(TestCase):
         data = dict(min_occurs=1, max_occurs=2)
         for clazz in self.subclasses:
             obj = clazz.create(**data)
-            self.assertDictEqual(data, obj.get_restrictions())
+            self.assertEqual(data, obj.get_restrictions())
 
         data = dict(min_occurs=1, max_occurs=1)
         for clazz in self.subclasses:
             obj = clazz.create(**data)
-            self.assertDictEqual(dict(required=True), obj.get_restrictions())
+            self.assertEqual(dict(required=True), obj.get_restrictions())
 
         data = dict(min_occurs=0, max_occurs=1)
         for clazz in self.subclasses:
             obj = clazz.create(**data)
-            self.assertDictEqual(dict(), obj.get_restrictions())
+            self.assertEqual(dict(), obj.get_restrictions())
 
 
 class TypedFieldTests(TestCase):
@@ -55,7 +55,13 @@ class TypedFieldTests(TestCase):
         self.subclasses = [c for _, c in get_subclasses(TypedField)]
 
     def test_subclasses(self):
-        expected = [el.Attribute, el.Element, el.Restriction, el.SimpleType]
+        expected = [
+            el.Attribute,
+            el.Element,
+            el.Enumeration,
+            el.Restriction,
+            el.SimpleType,
+        ]
         self.assertEqual(expected, self.subclasses)
 
     def test_property_namespace_with_unqualified_form(self):
@@ -78,3 +84,9 @@ class TypedFieldTests(TestCase):
         obj = el.Element.create(type="ns:foo")
         obj.nsmap["ns"] = "bar"
         self.assertEqual("bar", obj.namespace)
+
+
+class ElementBaseTests(TestCase):
+    def test_is_attribute(self):
+        obj = ElementBase.create()
+        self.assertFalse(obj.is_attribute)

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -20,6 +20,7 @@ from xsdata.models.elements import (
 
 class ClassBuilderTests(FactoryTestCase):
     def setUp(self) -> None:
+        super(ClassBuilderTests, self).setUp()
         self.schema = Schema.create()
         self.builder = ClassBuilder(schema=self.schema)
 

--- a/tests/test_reducer.py
+++ b/tests/test_reducer.py
@@ -58,7 +58,7 @@ class ClassReducerTests(FactoryTestCase):
 
         obj = ClassFactory.create(
             type=SimpleType,
-            attrs=[AttrFactory.create(local_type="Enumeration")],
+            attrs=AttrFactory.list(1, local_type=TagType.ENUMERATION.cname),
         )
         self.assertFalse(ClassReducer.is_common(obj))
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -27,6 +27,7 @@ class FakeRenderer(AbstractGenerator):
 
 class CodeWriterTests(TestCase):
     def setUp(self) -> None:
+        super(CodeWriterTests, self).setUp()
         self.generators = copy.deepcopy(writer.generators)
 
     def tearDown(self) -> None:

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -2,11 +2,12 @@ import copy
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Iterator, Optional, Tuple
+from typing import Iterator, List, Optional, Tuple
 from unittest import TestCase
 
 from xsdata.codegen.generator import AbstractGenerator
 from xsdata.codegen.python.dataclass.generator import DataclassGenerator
+from xsdata.models.codegen import Class
 from xsdata.models.elements import Schema
 from xsdata.writer import writer
 
@@ -17,6 +18,11 @@ class FakeRenderer(AbstractGenerator):
 
     def render(self, *args, **kwargs) -> Iterator[Tuple[Path, str]]:
         yield Path(f"{self.dir}/test.txt"), "foobar"
+
+    def print(
+        self, schema: Schema, classes: List[Class], package: str
+    ) -> Iterator[Tuple[str, Class]]:
+        pass
 
 
 class CodeWriterTests(TestCase):

--- a/xsdata/builder.py
+++ b/xsdata/builder.py
@@ -8,18 +8,19 @@ from xsdata.models.elements import (
     AttributeGroup,
     ComplexType,
     Element,
-    ElementBase,
+    Enumeration,
     Restriction,
     Schema,
     SimpleType,
 )
+from xsdata.models.mixins import ElementBase
 
 logger = logging.getLogger(__name__)
 
 BaseElement = Union[
     Attribute, AttributeGroup, Element, ComplexType, SimpleType
 ]
-AttributeElement = Union[Attribute, Element, Restriction]
+AttributeElement = Union[Attribute, Element, Restriction, Enumeration]
 
 
 @dataclass
@@ -54,13 +55,12 @@ class ClassBuilder:
         return item
 
     def element_children(self, obj: ElementBase) -> Iterator[AttributeElement]:
-        """Recursively find and return all child elements that can be used to
-        codegen class attributes."""
-
+        """Recursively find and return all child elements that are qualified to
+        be class attributes."""
         for child in obj.children():
-            if isinstance(child, (Attribute, Element, Restriction)):
+            if child.is_attribute:
                 yield child
-            elif isinstance(child, ElementBase):
+            else:
                 yield from self.element_children(child)
 
     def build_class_attribute(self, parent: Class, obj: AttributeElement):

--- a/xsdata/codegen/python/dataclass/filters.py
+++ b/xsdata/codegen/python/dataclass/filters.py
@@ -16,14 +16,15 @@ def arguments(data: dict):
     )
 
 
-def docstring(obj: Class):
+def docstring(obj: Class, enum=False):
     lines = []
     if obj.help:
         lines.append(obj.help)
 
+    var_type = "cvar" if enum else "ivar"
     for attr in obj.attrs:
         description = attr.help.strip() if attr.help else ""
-        lines.append(f":ivar {attr.name}: {description}".strip())
+        lines.append(f":{var_type} {attr.name}: {description}".strip())
 
     return (
         format_code('"""\n{}\n"""'.format("\n".join(lines))) if lines else ""

--- a/xsdata/codegen/python/dataclass/generator.py
+++ b/xsdata/codegen/python/dataclass/generator.py
@@ -28,7 +28,8 @@ class DataclassGenerator(PythonAbstractGenerator):
         return self.template("module").render(output=output, imports=imports)
 
     def render_class(self, obj: Class) -> str:
-        return self.template("class").render(obj=obj)
+        template = "enum" if obj.is_enumeration else "class"
+        return self.template(template).render(obj=obj)
 
     def render(
         self, schema: Schema, classes: List[Class], package: str

--- a/xsdata/codegen/python/dataclass/templates/enum.jinja2
+++ b/xsdata/codegen/python/dataclass/templates/enum.jinja2
@@ -1,0 +1,9 @@
+{% set help = obj|docstring|trim %}
+
+class {{ obj.name }}(Enum):
+{%- if help %}
+{{ help|indent(4, first=True) }}
+{%- endif -%}
+{%- for attr in obj.attrs %}
+    {{ attr.name }} = {{ attr.default }}
+{%- endfor -%}

--- a/xsdata/codegen/python/dataclass/templates/enum.jinja2
+++ b/xsdata/codegen/python/dataclass/templates/enum.jinja2
@@ -1,4 +1,4 @@
-{% set help = obj|docstring|trim %}
+{% set help = obj|docstring(enum=True)|trim %}
 
 class {{ obj.name }}(Enum):
 {%- if help %}

--- a/xsdata/codegen/python/dataclass/templates/module.jinja2
+++ b/xsdata/codegen/python/dataclass/templates/module.jinja2
@@ -1,3 +1,4 @@
+from enum import Enum
 from dataclasses import dataclass, field
 from typing import List, Optional
 

--- a/xsdata/codegen/python/generator.py
+++ b/xsdata/codegen/python/generator.py
@@ -21,19 +21,17 @@ class PythonAbstractGenerator(AbstractGenerator, ABC):
         for inner in obj.inner:
             cls.process_class(inner, curr_parents)
 
-        attr_processor = (
-            cls.process_enumeration
-            if obj.is_enumeration
-            else cls.process_attribute
-        )
-
+        is_enum = obj.is_enumeration
         for attr in obj.attrs:
-            attr_processor(attr, curr_parents)
+            if is_enum:
+                cls.process_enumeration(attr)
+            else:
+                cls.process_attribute(attr, curr_parents)
 
         return obj
 
     @classmethod
-    def process_attribute(cls, attr: Attr, parents):
+    def process_attribute(cls, attr: Attr, parents) -> None:
         """Normalize attribute properties."""
         attr.name = cls.attribute_name(attr.name)
         attr.type = cls.attribute_type(attr, parents)
@@ -41,13 +39,13 @@ class PythonAbstractGenerator(AbstractGenerator, ABC):
         attr.default = cls.attribute_default(attr)
 
     @classmethod
-    def process_enumeration(cls, attr: Attr, parents):
+    def process_enumeration(cls, attr: Attr, *args) -> None:
         """Normalize attribute properties."""
         attr.name = cls.enumeration_name(attr.name)
         attr.default = cls.attribute_default(attr)
 
     @classmethod
-    def process_import(cls, package: Package):
+    def process_import(cls, package: Package) -> Package:
         """Normalize import package properties."""
         package.name = cls.class_name(package.name)
         if package.alias:

--- a/xsdata/codegen/resolver.py
+++ b/xsdata/codegen/resolver.py
@@ -7,6 +7,7 @@ from toposort import toposort_flatten
 from xsdata.models.codegen import Class, Package
 from xsdata.models.elements import Schema
 from xsdata.models.enums import XSDType
+from xsdata.utils.text import split_prefix
 
 
 @dataclass
@@ -67,10 +68,9 @@ class DependenciesResolver:
         collisions with the given list of classes and build a list of import
         packages."""
         for ref in self.import_classes():
-            has_ns = ref.find(":") > -1
-            prefix, name = ref.split(":") if has_ns else (None, ref)
+            prefix, name = split_prefix(ref)
             package = self.find_package(prefix, name)
-            alias = ref if has_ns and self.class_map.get(name) else None
+            alias = ref if prefix and self.class_map.get(name) else None
 
             self.add_import(name=name, package=package, alias=alias)
 
@@ -104,10 +104,6 @@ class DependenciesResolver:
             * Resolved processed {"{http://www.common/ns}address": "source.package"}
             * Request for (common, address) will return source.package
         """
-
-        if name == "typeElementStatus":
-            pass
-
         namespace = self.schema.nsmap.get(prefix)
         qname = etree.QName(namespace, name)
         return self.processed[qname.text]

--- a/xsdata/models/codegen.py
+++ b/xsdata/models/codegen.py
@@ -22,6 +22,10 @@ class Attr:
     def is_list(self):
         return int(self.restrictions.get("max_occurs", 1)) > 1
 
+    @property
+    def is_enumeration(self):
+        return self.local_type == "Enumeration"
+
 
 @dataclass
 class Class:
@@ -31,6 +35,10 @@ class Class:
     extensions: List[str] = field(default_factory=list)
     attrs: List[Attr] = field(default_factory=list)
     inner: List["Class"] = field(default_factory=list)
+
+    @property
+    def is_enumeration(self):
+        return self.attrs and self.attrs[0].is_enumeration
 
 
 @dataclass

--- a/xsdata/models/codegen.py
+++ b/xsdata/models/codegen.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field
 from typing import Any, List, Optional, Type
 
+from xsdata.models.enums import TagType
+
 
 @dataclass
 class Attr:
@@ -24,7 +26,7 @@ class Attr:
 
     @property
     def is_enumeration(self):
-        return self.local_type == "Enumeration"
+        return self.local_type == TagType.ENUMERATION.cname
 
 
 @dataclass

--- a/xsdata/models/codegen.py
+++ b/xsdata/models/codegen.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 from typing import Any, List, Optional, Type
 
 
-@dataclass(unsafe_hash=True)
+@dataclass
 class Attr:
     name: str
     local_name: str = field(init=False)
@@ -23,7 +23,7 @@ class Attr:
         return int(self.restrictions.get("max_occurs", 1)) > 1
 
 
-@dataclass(unsafe_hash=True)
+@dataclass
 class Class:
     name: str
     type: Type
@@ -33,7 +33,7 @@ class Class:
     inner: List["Class"] = field(default_factory=list)
 
 
-@dataclass(unsafe_hash=True)
+@dataclass
 class Package:
     name: str
     source: str

--- a/xsdata/models/enums.py
+++ b/xsdata/models/enums.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from lxml import etree
 
-from xsdata.utils.text import split_prefix
+from xsdata.utils.text import capitalize, split_prefix
 
 XMLSchema = "http://www.w3.org/2001/XMLSchema"
 
@@ -136,10 +136,17 @@ class TagType(Enum):
 
     @property
     def qname(self):
+        """Qualified name: {namespace}tag."""
         return etree.QName(XMLSchema, self.value)
+
+    @property
+    def cname(self):
+        """Class name."""
+        return capitalize(self.value)
 
     @classmethod
     def qnames(cls):
+        """All types indexed by their qname."""
         return {tag.qname: tag for tag in TagType}
 
 

--- a/xsdata/models/enums.py
+++ b/xsdata/models/enums.py
@@ -3,6 +3,8 @@ from typing import Optional
 
 from lxml import etree
 
+from xsdata.utils.text import split_prefix
+
 XMLSchema = "http://www.w3.org/2001/XMLSchema"
 
 
@@ -65,11 +67,8 @@ class XSDType(Enum):
 
     @classmethod
     def get_enum(cls, code: str) -> Optional["XSDType"]:
-        pos = code.find(":")
-        if pos == -1:
-            return None
-
-        return __XSDType__.get("xs:" + code[pos + 1 :])
+        prefix, suffix = split_prefix(code)
+        return __XSDType__.get("xs:" + suffix) if prefix else None
 
     @classmethod
     def get_local(cls, code: str) -> Optional[str]:

--- a/xsdata/parser.py
+++ b/xsdata/parser.py
@@ -6,14 +6,9 @@ from typing import List, Optional
 from lxml import etree
 
 from xsdata.models import elements
-from xsdata.models.elements import (
-    Attribute,
-    BaseModel,
-    Choice,
-    Element,
-    Schema,
-)
+from xsdata.models.elements import Attribute, Choice, Element, Schema
 from xsdata.models.enums import EventType, FormType, TagType
+from xsdata.models.mixins import BaseModel
 from xsdata.utils.text import capitalize, snake_case
 
 

--- a/xsdata/parser.py
+++ b/xsdata/parser.py
@@ -9,7 +9,7 @@ from xsdata.models import elements
 from xsdata.models.elements import Attribute, Choice, Element, Schema
 from xsdata.models.enums import EventType, FormType, TagType
 from xsdata.models.mixins import BaseModel
-from xsdata.utils.text import capitalize, snake_case
+from xsdata.utils.text import snake_case
 
 
 @dataclass
@@ -79,7 +79,7 @@ class SchemaParser:
                 )
 
             if event == EventType.START:
-                builder = getattr(elements, capitalize(tag.value))
+                builder = getattr(elements, tag.cname)
                 element = builder.from_element(elem)
                 self.elements.append(element)
             elif event == EventType.END:

--- a/xsdata/utils/text.py
+++ b/xsdata/utils/text.py
@@ -1,9 +1,17 @@
-from typing import List
+from typing import List, Tuple
 
 
 def strip_prefix(string: str, sep: str = ":") -> str:
-    pos = string.find(sep) + 1
-    return string[pos:] if pos else string
+    prefix, string = split_prefix(string, sep)
+    return string
+
+
+def split_prefix(string: str, sep: str = ":") -> Tuple:
+    index = string.find(sep)
+    if index == -1:
+        return None, string
+    else:
+        return string[:index], string[index + 1 :]
 
 
 def capitalize(string: str) -> str:

--- a/xsdata/writer.py
+++ b/xsdata/writer.py
@@ -36,12 +36,26 @@ class CodeWriter:
     ):
         engine = self.get_renderer(renderer)
         for package, item in engine.print(schema, classes, package):
-            extensions = sorted(item.extensions)
-            extends: str = f"({', '.join(extensions)})" if extensions else ""
-            print(f"{package}.{item.name}{extends}")
+            self.print_class(package, item)
 
-            for attr in sorted(item.attrs, key=lambda x: x.name):
-                print(f"    {attr.name}: {attr.type} = {attr.default}")
+    def print_class(self, package: str, obj: Class, indent: int = 0):
+
+        print(
+            f"\n{indent * ' '}{package}.{obj.name}({', '.join(sorted(obj.extensions))})"
+        )
+
+        for attr in sorted(obj.attrs, key=lambda x: x.name):
+            params = [("default", attr.default)]
+            params.extend(
+                [
+                    (key, value)
+                    for key, value in sorted(attr.restrictions.items())
+                ]
+            )
+            print(f"{(indent + 4) * ' '}{attr.name}: {attr.type} = {params}")
+
+        for inner in sorted(obj.inner, key=lambda x: x.name):
+            self.print_class(f"{package}.{obj.name}", inner, indent + 4)
 
 
 writer = CodeWriter()


### PR DESCRIPTION
Side effects:
- Restrictions that include container elements, group, all, choice, sequence attributes or attribute groups are now promoted to containers and are not eligible for attributes (ClassBuilder)
- Restrictions that include enumerations since we also want to to generate them are now promoted to container status like the above. (ClassBuilder, ClassReducer)
- Flattening extension bases now also takes into consideration references from other packages and prepends the namespace prefix to the attributes accordingly 
- All base classes for xsd element models moved to the mixins

The first side effect is pretty significant as it will improve the coverage for xsd schema features :)


See samples for the new enums
https://github.com/tefra/xsdata-samples/blob/658ee1aa5d09d86fa472e0ccf0772dd95ead18aa/samples/travelport/common_v48_0/common.py#L1626
