### PR TITLE
Enhance ClassReducer to respect the order of attributes

### DIFF
--- a/tests/codegen/python/test_generator.py
+++ b/tests/codegen/python/test_generator.py
@@ -3,6 +3,7 @@ from unittest import mock
 from tests.factories import (
     AttrFactory,
     ClassFactory,
+    ExtensionFactory,
     FactoryTestCase,
     PackageFactory,
 )
@@ -22,16 +23,28 @@ class PythonAbstractGeneratorTests(FactoryTestCase):
         mock_class_name.side_effect = lambda x: f"@{x}"
         mock_type_name.side_effect = lambda x: f"!{x}"
 
-        a = ClassFactory.create(name="a", extensions=["m", "n"])
+        a = ClassFactory.create(
+            name="a",
+            extensions=[
+                ExtensionFactory.create(name="m"),
+                ExtensionFactory.create(name="n"),
+            ],
+        )
         a.attrs = [AttrFactory.create(name=x) for x in "bcd"]
         e = ClassFactory.create(name="e")
         e.attrs = [AttrFactory.create(name=x) for x in "fgh"]
 
-        i = ClassFactory.create(name="i", extensions=["o"])
+        i = ClassFactory.create(
+            name="i", extensions=ExtensionFactory.list(1, name="o")
+        )
         i.attrs = [AttrFactory.create(name=x) for x in "jkl"]
         a.inner = [e, i]
 
         generator.process_class(a)
+
+        self.assertEqual("!m", a.extensions[0].name)
+        self.assertEqual("!n", a.extensions[1].name)
+        self.assertEqual("!o", i.extensions[0].name)
 
         mock_class_name.assert_has_calls(
             [mock.call("a"), mock.call("e"), mock.call("i")]

--- a/tests/codegen/test_resolver.py
+++ b/tests/codegen/test_resolver.py
@@ -4,6 +4,7 @@ from unittest import mock
 from tests.factories import (
     AttrFactory,
     ClassFactory,
+    ExtensionFactory,
     FactoryTestCase,
     PackageFactory,
 )
@@ -215,7 +216,13 @@ class DependenciesResolverTest(FactoryTestCase):
         second = ClassFactory.create(
             name="l", attrs=[AttrFactory.create(name="m", type="o")],
         )
-        third = ClassFactory.create(name="p", extensions=["xs:int", "a"])
+        third = ClassFactory.create(
+            name="p",
+            extensions=[
+                ExtensionFactory.create(name="xs:int"),
+                ExtensionFactory.create(name="a"),
+            ],
+        )
 
         classes = [first, second, third]
         expected = ["c:g", "i", "o", "l", "a", "p"]

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -2,7 +2,7 @@ import random
 import unittest
 from abc import ABC, abstractmethod
 
-from xsdata.models.codegen import Attr, Class, Package
+from xsdata.models.codegen import Attr, Class, Extension, Package
 from xsdata.models.elements import (
     Attribute,
     ComplexType,
@@ -117,4 +117,17 @@ class PackageFactory(Factory):
             name=name or f"package_{cls.next()}",
             source=source or "target",
             alias=alias or None,
+        )
+
+
+class ExtensionFactory(Factory):
+    model = Extension
+    counter = 65
+
+    @classmethod
+    def create(cls, name=None, index=None):
+
+        return cls.model(
+            name=name or f"ext_{cls.next()}",
+            index=cls.counter if index is None else index,
         )

--- a/xsdata/codegen/python/dataclass/templates/class.jinja2
+++ b/xsdata/codegen/python/dataclass/templates/class.jinja2
@@ -1,7 +1,7 @@
 {% set help = obj|docstring|trim %}
 
 @dataclass
-class {{ obj.name }}{{"({})".format(obj.extensions|join(', ')) if obj.extensions }}:
+class {{ obj.name }}{{"({})".format(obj.extensions|join(', ', attribute="name")) if obj.extensions }}:
 {%- if help %}
 {{ help|indent(4, first=True) }}
 {%- endif -%}

--- a/xsdata/codegen/python/generator.py
+++ b/xsdata/codegen/python/generator.py
@@ -15,7 +15,9 @@ class PythonAbstractGenerator(AbstractGenerator, ABC):
         classes recursively."""
         parents = parents or []
         obj.name = cls.class_name(obj.name)
-        obj.extensions = [cls.type_name(ext) for ext in obj.extensions]
+
+        for extension in obj.extensions:
+            extension.name = cls.type_name(extension.name)
 
         curr_parents = parents + [obj.name]
         for inner in obj.inner:

--- a/xsdata/codegen/resolver.py
+++ b/xsdata/codegen/resolver.py
@@ -130,7 +130,7 @@ class DependenciesResolver:
             * Filter the standard xsd types
         """
         deps = {attr.type for attr in obj.attrs if not attr.forward_ref}
-        deps.update(obj.extensions)
+        deps.update(ext.name for ext in obj.extensions)
         for inner in obj.inner:
             deps.update(self.collect_deps(inner))
 

--- a/xsdata/formats/dict/parser.py
+++ b/xsdata/formats/dict/parser.py
@@ -33,8 +33,10 @@ class DictParser(ModelInspect):
                     if field.is_list
                     else field.type(value)
                 )
-
-        return model(**params)
+        try:
+            return model(**params)
+        except Exception as e:
+            raise TypeError("Serialization failed")
 
     @staticmethod
     def parse_value(data: Dict, field: Field):

--- a/xsdata/formats/inspect.py
+++ b/xsdata/formats/inspect.py
@@ -63,6 +63,8 @@ class ModelInspect:
             )
 
     def get_type_hints(self, model):
+        if model == "TpaExtensions":
+            foo = True
         if model not in self.cache:
             self.cache[model] = get_type_hints(model)
         return self.cache[model]

--- a/xsdata/formats/xml/serializer.py
+++ b/xsdata/formats/xml/serializer.py
@@ -71,7 +71,15 @@ class XmlSerializer(ModelInspect):
                 parent.set(f.local_name, self.render_value(value))
             else:
                 value = value if type(value) is list else [value]
-                qname = self.render_tag(f.local_name, f.namespace)
+                if f.namespace:
+                    qname = self.render_tag(f.local_name, f.namespace)
+                elif parent.prefix:
+                    qname = self.render_tag(
+                        f.local_name, parent.nsmap[parent.prefix]
+                    )
+                else:
+                    qname = f.local_name
+
                 for val in value:
                     sub_element = SubElement(parent, qname)
                     self.render_node(val, sub_element)

--- a/xsdata/models/codegen.py
+++ b/xsdata/models/codegen.py
@@ -67,6 +67,12 @@ class Attr:
 
 
 @dataclass
+class Extension:
+    name: str
+    index: int
+
+
+@dataclass
 class Class:
     name: str
     type: Type
@@ -74,7 +80,7 @@ class Class:
     namespace: Optional[str] = field(default=None)
     local_name: str = field(init=False)
     help: Optional[str] = field(default=None)
-    extensions: List[str] = field(default_factory=list)
+    extensions: List[Extension] = field(default_factory=list)
     attrs: List[Attr] = field(default_factory=list)
     inner: List["Class"] = field(default_factory=list)
 

--- a/xsdata/writer.py
+++ b/xsdata/writer.py
@@ -40,9 +40,8 @@ class CodeWriter:
 
     def print_class(self, package: str, obj: Class, indent: int = 0):
 
-        print(
-            f"\n{indent * ' '}{package}.{obj.name}({', '.join(sorted(obj.extensions))})"
-        )
+        extensions = ", ".join(sorted([ext.name for ext in obj.extensions]))
+        print(f"\n{indent * ' '}{package}.{obj.name}({extensions})")
 
         for attr in sorted(obj.attrs, key=lambda x: x.name):
             params = [("default", attr.default)]


### PR DESCRIPTION
Notes:
Sounds simple but I had to promote extensions to objects
in order to keep the initial indexing from the schema parser
during the ClassBuilder process.

Bones:
Serializer inherit the parent namespace when the current element
namespace is empty.