### PR TITLE
Demote xsd:list elements to simple str attribute

### DIFF
--- a/tests/fixtures/defxmlschema/chapter10/chapter10.py
+++ b/tests/fixtures/defxmlschema/chapter10/chapter10.py
@@ -59,16 +59,14 @@ class SizesType:
             max_inclusive=54.0
         )
     )
-    available_sizes: List[Union[int, "SizesType.Value"]] = field(
+    available_sizes: List[str] = field(
         default_factory=list,
         metadata=dict(
             name="availableSizes",
             type="Element",
             namespace="",
             min_occurs=0,
-            max_occurs=9223372036854775807,
-            min_inclusive=2.0,
-            max_inclusive=18.0
+            max_occurs=9223372036854775807
         )
     )
     applicable_sizes: List[str] = field(

--- a/tests/fixtures/defxmlschema/chapter10/example1007.py
+++ b/tests/fixtures/defxmlschema/chapter10/example1007.py
@@ -1,6 +1,5 @@
-from enum import Enum
 from dataclasses import dataclass, field
-from typing import List, Union
+from typing import Optional
 
 
 @dataclass
@@ -8,20 +7,10 @@ class AvailableSizesType:
     """
     :ivar value:
     """
-    value: List[Union[int, "AvailableSizesType.Value"]] = field(
-        default_factory=list,
+    value: Optional[str] = field(
+        default=None,
         metadata=dict(
             name="value",
-            type="List",
-            min_occurs=0,
-            max_occurs=9223372036854775807,
-            min_inclusive=2.0,
-            max_inclusive=18.0
+            type="List"
         )
     )
-
-    class Value(Enum):
-        """
-        :cvar EMPTY:
-        """
-        EMPTY = ""

--- a/tests/fixtures/defxmlschema/chapter10/example1009.py
+++ b/tests/fixtures/defxmlschema/chapter10/example1009.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import List
+from typing import Optional
 
 
 @dataclass
@@ -7,14 +7,10 @@ class AvailableSizesType:
     """
     :ivar value:
     """
-    value: List[int] = field(
-        default_factory=list,
+    value: Optional[str] = field(
+        default=None,
         metadata=dict(
             name="value",
-            type="List",
-            min_occurs=0,
-            max_occurs=9223372036854775807,
-            min_inclusive=2.0,
-            max_inclusive=18.0
+            type="List"
         )
     )

--- a/tests/fixtures/defxmlschema/chapter10/example1012.py
+++ b/tests/fixtures/defxmlschema/chapter10/example1012.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import List
+from typing import Optional
 
 
 @dataclass
@@ -10,13 +10,11 @@ class AvailableSizesType:
     :ivar medium:
     :ivar large:
     """
-    value: List[str] = field(
-        default_factory=list,
+    value: Optional[str] = field(
+        default=None,
         metadata=dict(
             name="value",
-            type="List",
-            min_occurs=0,
-            max_occurs=9223372036854775807
+            type="List"
         )
     )
     small: str = field(

--- a/tests/fixtures/defxmlschema/chapter10/example1014.py
+++ b/tests/fixtures/defxmlschema/chapter10/example1014.py
@@ -1,8 +1,5 @@
 from dataclasses import dataclass, field
-from typing import List, Union
-from tests.fixtures.defxmlschema.chapter08.example0810 import (
-    SmlsizeType,
-)
+from typing import Optional
 
 
 @dataclass
@@ -12,15 +9,11 @@ class ApplicableSizesType:
     :ivar small_medium_large:
     :ivar value_2_4_6_8_10_12_14_16_18:
     """
-    value: List[Union[int, SmlsizeType]] = field(
-        default_factory=list,
+    value: Optional[str] = field(
+        default=None,
         metadata=dict(
             name="value",
-            type="List",
-            min_occurs=0,
-            max_occurs=9223372036854775807,
-            min_inclusive=2.0,
-            max_inclusive=18.0
+            type="List"
         )
     )
     small_medium_large: str = field(

--- a/tests/fixtures/defxmlschema/chapter10/example1015.py
+++ b/tests/fixtures/defxmlschema/chapter10/example1015.py
@@ -7,7 +7,7 @@ class VectorType:
     """
     :ivar value:
     """
-    value: Optional[int] = field(
+    value: Optional[str] = field(
         default=None,
         metadata=dict(
             name="value",

--- a/tests/fixtures/defxmlschema/chapter10/example1016.py
+++ b/tests/fixtures/defxmlschema/chapter10/example1016.py
@@ -1,19 +1,6 @@
 from enum import Enum
 
 
-class AvailableSizesType(Enum):
-    """
-    :cvar SMALL:
-    :cvar MEDIUM:
-    :cvar LARGE:
-    :cvar EXTRA_LARGE:
-    """
-    SMALL = "small"
-    MEDIUM = "medium"
-    LARGE = "large"
-    EXTRA_LARGE = "extra large"
-
-
 class SmlxsizeType(Enum):
     """
     :cvar SMALL:

--- a/tests/fixtures/defxmlschema/chapter10/example1018.py
+++ b/tests/fixtures/defxmlschema/chapter10/example1018.py
@@ -1,8 +1,5 @@
 from dataclasses import dataclass, field
-from typing import List, Union
-from tests.fixtures.defxmlschema.chapter08.example0809 import (
-    SmlxsizeType,
-)
+from typing import Optional
 
 
 @dataclass
@@ -10,14 +7,10 @@ class AvailableSizesType:
     """
     :ivar value:
     """
-    value: List[Union[int, SmlxsizeType]] = field(
-        default_factory=list,
+    value: Optional[str] = field(
+        default=None,
         metadata=dict(
             name="value",
-            type="List",
-            min_occurs=0,
-            max_occurs=9223372036854775807,
-            min_inclusive=2.0,
-            max_inclusive=18.0
+            type="List"
         )
     )

--- a/tests/fixtures/defxmlschema/chapter10/example1020.py
+++ b/tests/fixtures/defxmlschema/chapter10/example1020.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import List
+from typing import Optional
 
 
 @dataclass
@@ -7,12 +7,10 @@ class TwoDimensionalArray:
     """
     :ivar value:
     """
-    value: List[int] = field(
-        default_factory=list,
+    value: Optional[str] = field(
+        default=None,
         metadata=dict(
             name="value",
-            type="List",
-            min_occurs=0,
-            max_occurs=9223372036854775807
+            type="List"
         )
     )

--- a/tests/models/elements/test_list.py
+++ b/tests/models/elements/test_list.py
@@ -1,17 +1,10 @@
-import sys
 from unittest import TestCase
 
-from xsdata.models.elements import Length, List, Restriction, SimpleType
+from xsdata.models.elements import List
+from xsdata.models.enums import XSDType
 
 
 class ListTests(TestCase):
-    def test_type_property(self):
-        obj = List.create()
-        obj.type = "foo"
-
-        self.assertEqual("foo", obj.type)
-        self.assertEqual(obj.type, obj.item_type)
-
     def test_is_attribute(self):
         obj = List.create()
         self.assertTrue(obj.is_attribute)
@@ -22,21 +15,8 @@ class ListTests(TestCase):
 
     def test_real_type(self):
         obj = List.create()
-        self.assertIsNone(obj.real_type)
-
-        obj.simple_type = SimpleType.create()
-        self.assertIsNone(obj.real_type)
-
-        obj.item_type = "foo"
-        self.assertEqual("foo", obj.real_type)
+        self.assertEqual(XSDType.STRING.code, obj.real_type)
 
     def test_get_restrictions(self):
         obj = List.create()
-        expected = dict(min_occurs=0, max_occurs=sys.maxsize)
-        self.assertEqual(expected, obj.get_restrictions())
-
-        obj.simple_type = SimpleType.create(
-            restriction=Restriction.create(length=Length.create(value=1))
-        )
-        expected.update(dict(length=1))
-        self.assertEqual(expected, obj.get_restrictions())
+        self.assertEqual(dict(), obj.get_restrictions())

--- a/tests/models/elements/test_simple_type.py
+++ b/tests/models/elements/test_simple_type.py
@@ -1,7 +1,7 @@
-import sys
 from unittest import TestCase
 
 from xsdata.models.elements import Length, List, Restriction, SimpleType, Union
+from xsdata.models.enums import XSDType
 
 
 class SimpleTypeTests(TestCase):
@@ -26,7 +26,7 @@ class SimpleTypeTests(TestCase):
         self.assertEqual("thug", obj.real_type)
 
         obj.list = List.create(item_type="foo")
-        self.assertEqual("foo", obj.real_type)
+        self.assertEqual(XSDType.STRING.code, obj.real_type)
 
         obj.restriction = Restriction.create(base="bar")
         self.assertEqual("bar", obj.real_type)
@@ -34,10 +34,6 @@ class SimpleTypeTests(TestCase):
     def test_get_restrictions(self):
         obj = SimpleType.create()
         self.assertEqual({}, obj.get_restrictions())
-
-        expected = dict(min_occurs=0, max_occurs=sys.maxsize)
-        obj.list = List.create()
-        self.assertEqual(expected, obj.get_restrictions())
 
         expected = dict(length=2)
         obj.restriction = Restriction.create(length=Length.create(value=2))

--- a/xsdata/builder.py
+++ b/xsdata/builder.py
@@ -235,7 +235,7 @@ class ClassBuilder:
         """Check if the attribute element contains anonymous restriction with
         enumeration facet."""
         return (
-            isinstance(obj, (Attribute, Element, ListElement))
+            isinstance(obj, (Attribute, Element))
             and obj.type is None
             and obj.simple_type is not None
             and obj.simple_type.is_enumeration

--- a/xsdata/models/elements.py
+++ b/xsdata/models/elements.py
@@ -1,5 +1,4 @@
 import re
-import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any as Anything
@@ -123,16 +122,6 @@ class List(AnnotationBase, RestrictedField, NamedField):
     simple_type: SimpleType
 
     @property
-    def type(self):
-        """Property alias for item type."""
-        return self.item_type
-
-    @type.setter
-    def type(self, value):
-        """Property setter alias for item type."""
-        self.item_type = value
-
-    @property
     def is_attribute(self) -> bool:
         return True
 
@@ -142,18 +131,10 @@ class List(AnnotationBase, RestrictedField, NamedField):
 
     @property
     def real_type(self) -> Optional[str]:
-        if self.item_type:
-            return self.item_type
-        if self.simple_type:
-            return self.simple_type.real_type
-
-        return None
+        return XSDType.STRING.code
 
     def get_restrictions(self) -> Dict[str, Anything]:
-        restrictions = dict(min_occurs=0, max_occurs=sys.maxsize)
-        if self.simple_type:
-            restrictions.update(self.simple_type.get_restrictions())
-        return restrictions
+        return dict()
 
 
 @dataclass


### PR DESCRIPTION
The xsd list element is used to create space separated strings not lists of objects. 
Demote the list elements to simple str attributes, this way is not a nice solution since the user needs to search the manual to know the acceptable values and the format but at least the xml serializer/parser know creates valid by the schema output