### PR TITLE
w3c xsd test suite fixes

### DIFF
--- a/tests/fixtures/defxmlschema/chapter18/xml.py
+++ b/tests/fixtures/defxmlschema/chapter18/xml.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class Space(Enum):
+    """
+    :cvar DEFAULT:
+    :cvar PRESERVE:
+    """
+    DEFAULT = "default"
+    PRESERVE = "preserve"

--- a/tests/models/elements/test_element.py
+++ b/tests/models/elements/test_element.py
@@ -45,6 +45,16 @@ class ElementTests(TestCase):
         obj = Element.create()
         self.assertIsNone(obj.extends)
 
+    def test_property_is_mixed(self):
+        obj = Element.create()
+        self.assertFalse(obj.is_mixed)
+
+        obj.complex_type = ComplexType.create()
+        self.assertFalse(obj.is_mixed)
+
+        obj.complex_type.mixed = True
+        self.assertTrue(obj.is_mixed)
+
     def test_get_restrictions(self):
         obj = Element.create(min_occurs=1, max_occurs=1)
         expected = {"required": True}

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -90,14 +90,16 @@ class ParserTests(TestCase):
         self.assertEqual(FormType.QUALIFIED, schema.attributes[0].form)
         self.assertEqual(FormType.QUALIFIED, schema.elements[0].form)
 
-    def test_with_empty_tags_are_ignored(self):
-        xsd = """<xs:complexType name="foo" />
-        <xs:element />
+    def test_empty_tags_without_children_are_ignored(self):
+        xsd = """<xs:complexType name="foo" /><xs:element />
+        <xs:annotation><xs:documentation></xs:documentation></xs:annotation>
         """
 
         schema = self.parser.from_xsd_string(wrap(xsd))
         self.assertEqual(0, len(schema.elements))
         self.assertEqual(1, len(schema.complex_types))
+        self.assertEqual(1, len(schema.annotations))
+        self.assertEqual(0, len(schema.annotations[0].documentations))
 
     def test_complex_type_with_sequence(self):
         xsd = """<xs:complexType name="allowablePointsOfSaleType">

--- a/xsdata/builder.py
+++ b/xsdata/builder.py
@@ -94,7 +94,8 @@ class ClassBuilder:
         native = False
 
         if prefix and (
-            prefix == "xml" or self.schema.nsmap.get(prefix) == Namespace.SCHEMA
+            prefix == Namespace.XML.prefix
+            or self.schema.nsmap.get(prefix) == Namespace.SCHEMA.uri
         ):
             name = suffix
             native = True

--- a/xsdata/formats/dataclass/serializers.py
+++ b/xsdata/formats/dataclass/serializers.py
@@ -187,8 +187,8 @@ class XmlSerializer(AbstractSerializer, ModelInspect):
     @staticmethod
     def set_nil_attribute(var: ClassVar, element: Element, namespaces: Set[str]):
         if var.is_nillable and element.text is None and len(element) == 0:
-            namespaces.add(Namespace.INSTANCE)
-            qname = QName(Namespace.INSTANCE, "nil")
+            namespaces.add(Namespace.INSTANCE.uri)
+            qname = QName(Namespace.INSTANCE.uri, "nil")
             element.set(qname, "true")
 
     @staticmethod

--- a/xsdata/formats/dataclass/utils.py
+++ b/xsdata/formats/dataclass/utils.py
@@ -1,3 +1,11 @@
+from string import printable
+from typing import List
+from typing import Set
+
+from lxml import etree
+
+from xsdata.formats.dataclass.serializers import XmlSerializer
+
 stop_words = [
     "and",
     "except",
@@ -39,8 +47,22 @@ def safe_snake(string: str) -> str:
     if not string:
         return "empty"
 
+    string = "".join([ch for ch in string if ch in printable])
     if string.lower() in stop_words:
         return f"{string}_value"
-    if string[0].isdigit():
+    elif string[0].isdigit():
         return f"value_{string}"
-    return string
+    elif string[0] == "-" and string[1].isdigit():
+        return f"value_minus_{string[1:]}"
+    else:
+        return string
+
+
+def tostring(elements: List):
+    root = etree.Element("xsdata")
+    namespaces: Set[str] = set()
+    XmlSerializer.set_any_children(root, elements, namespaces)
+    nsmap = {f"ns{index}": ns for index, ns in enumerate(sorted(namespaces))}
+    etree.cleanup_namespaces(root, top_nsmap=nsmap)
+    xml = etree.tostring(root, pretty_print=True).decode()
+    return xml[xml.find(">") + 1 :].replace("</xsdata>", "").strip()

--- a/xsdata/models/elements.py
+++ b/xsdata/models/elements.py
@@ -982,7 +982,7 @@ class Schema(AnnotationBase):
     """
 
     class Meta:
-        namespace = Namespace.SCHEMA
+        namespace = Namespace.SCHEMA.uri
 
     target: Optional[str] = attribute(default=None)
     block_default: Optional[str] = attribute(default=None)

--- a/xsdata/models/elements.py
+++ b/xsdata/models/elements.py
@@ -860,6 +860,13 @@ class Element(AnnotationBase, NamedField, OccurrencesMixin):
         return True
 
     @property
+    def is_mixed(self) -> bool:
+        if self.complex_type:
+            return self.complex_type.is_mixed
+
+        return False
+
+    @property
     def real_type(self) -> Optional[str]:
         if self.type:
             return self.type

--- a/xsdata/models/elements.py
+++ b/xsdata/models/elements.py
@@ -7,12 +7,9 @@ from typing import Dict
 from typing import Iterator
 from typing import List as ArrayList
 from typing import Optional
-from typing import Set
 from typing import Union as UnionType
 
-from lxml import etree
-
-from xsdata.formats.dataclass.serializers import XmlSerializer
+from xsdata.formats.dataclass.utils import tostring
 from xsdata.models.enums import DataType
 from xsdata.models.enums import FormType
 from xsdata.models.enums import Namespace
@@ -65,13 +62,7 @@ class Documentation(ElementBase):
         if not self.elements:
             return None
 
-        root = etree.Element("xsdata")
-        namespaces: Set[str] = set()
-        XmlSerializer.set_any_children(root, self.elements, namespaces)
-        nsmap = {f"ns{index}": ns for index, ns in enumerate(sorted(namespaces))}
-        etree.cleanup_namespaces(root, top_nsmap=nsmap)
-        xml = etree.tostring(root, pretty_print=True).decode()
-        return xml[xml.find(">") + 1 :].replace("</xsdata>", "").strip()
+        return tostring(self.elements)
 
 
 @dataclass

--- a/xsdata/models/enums.py
+++ b/xsdata/models/enums.py
@@ -5,10 +5,19 @@ from typing import Optional
 from lxml.etree import QName
 
 
-class Namespace:
+class Namespace(Enum):
     SCHEMA = "http://www.w3.org/2001/XMLSchema"
     XML = "http://www.w3.org/XML/1998/namespace"
     INSTANCE = "http://www.w3.org/2001/XMLSchema-instance"
+    XLINK = "http://www.w3.org/1999/xlink"
+
+    @property
+    def uri(self):
+        return self.value
+
+    @property
+    def prefix(self):
+        return self.name.lower()
 
 
 class FormType(Enum):

--- a/xsdata/models/mixins.py
+++ b/xsdata/models/mixins.py
@@ -76,7 +76,7 @@ class BaseModel:
     @classmethod
     def create(cls: Type[T], **kwargs) -> T:
         if not kwargs.get("nsmap"):
-            kwargs.update({"nsmap": {"xs": Namespace.SCHEMA}})
+            kwargs.update({"nsmap": {"xs": Namespace.SCHEMA.uri}})
 
         kwargs = {
             text.snake_case(etree.QName(key).localname): value

--- a/xsdata/parser.py
+++ b/xsdata/parser.py
@@ -45,7 +45,7 @@ class SchemaParser(XmlParser):
     def end_node(self, element: etree.Element) -> Optional[T]:
         """Override parent method to skip empty elements and to set the object
         index."""
-        if not element.attrib and element.text is None:
+        if not element.attrib and element.text is None and len(element) == 0:
             self.queue.pop()
             return None
 

--- a/xsdata/parser.py
+++ b/xsdata/parser.py
@@ -123,11 +123,18 @@ class SchemaParser(XmlParser):
         """Elements inside a sequence inherit min|max occur counter if it is
         not set."""
         if isinstance(obj, xsd.Sequence):
-            for child in obj.elements:
-                if child.min_occurs is None:
-                    child.min_occurs = obj.min_occurs
-                if child.max_occurs is None:
-                    child.max_occurs = obj.max_occurs
+
+            for element in obj.elements:
+                if element.min_occurs is None:
+                    element.min_occurs = obj.min_occurs
+                if element.max_occurs is None:
+                    element.max_occurs = obj.max_occurs
+
+            for any_element in obj.any:
+                if any_element.min_occurs is None:
+                    any_element.min_occurs = obj.min_occurs
+                if any_element.max_occurs is None:
+                    any_element.max_occurs = obj.max_occurs
 
     @classmethod
     def parse_value(cls, tp: Type, value: Any) -> Any:

--- a/xsdata/schemas/xlink.xsd
+++ b/xsdata/schemas/xlink.xsd
@@ -1,0 +1,270 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.w3.org/1999/xlink" xmlns:xlink="http://www.w3.org/1999/xlink">
+
+ <xs:annotation>
+  <xs:documentation>This schema document provides attribute declarations and
+attribute group, complex type and simple type definitions which can be used in
+the construction of user schemas to define the structure of particular linking
+constructs, e.g.
+<![CDATA[
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:xl="http://www.w3.org/1999/xlink">
+
+ <xs:import namespace="http://www.w3.org/1999/xlink"
+            location="http://www.w3.org/1999/xlink.xsd">
+
+ <xs:element name="mySimple">
+  <xs:complexType>
+   ...
+   <xs:attributeGroup ref="xl:simpleAttrs"/>
+   ...
+  </xs:complexType>
+ </xs:element>
+ ...
+</xs:schema>]]></xs:documentation>
+ </xs:annotation>
+
+ <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+
+ <xs:attribute name="type" type="xlink:typeType"/>
+
+ <xs:simpleType name="typeType">
+  <xs:restriction base="xs:token">
+   <xs:enumeration value="simple"/>
+   <xs:enumeration value="extended"/>
+   <xs:enumeration value="title"/>
+   <xs:enumeration value="resource"/>
+   <xs:enumeration value="locator"/>
+   <xs:enumeration value="arc"/>
+  </xs:restriction>
+ </xs:simpleType>
+
+ <xs:attribute name="href" type="xlink:hrefType"/>
+
+ <xs:simpleType name="hrefType">
+  <xs:restriction base="xs:anyURI"/>
+ </xs:simpleType>
+
+ <xs:attribute name="role" type="xlink:roleType"/>
+
+ <xs:simpleType name="roleType">
+  <xs:restriction base="xs:anyURI">
+   <xs:minLength value="1"/>
+  </xs:restriction>
+ </xs:simpleType>
+
+ <xs:attribute name="arcrole" type="xlink:arcroleType"/>
+
+ <xs:simpleType name="arcroleType">
+  <xs:restriction base="xs:anyURI">
+   <xs:minLength value="1"/>
+  </xs:restriction>
+ </xs:simpleType>
+
+ <xs:attribute name="title" type="xlink:titleAttrType"/>
+
+ <xs:simpleType name="titleAttrType">
+  <xs:restriction base="xs:string"/>
+ </xs:simpleType>
+
+ <xs:attribute name="show" type="xlink:showType"/>
+
+ <xs:simpleType name="showType">
+  <xs:restriction base="xs:token">
+   <xs:enumeration value="new"/>
+   <xs:enumeration value="replace"/>
+   <xs:enumeration value="embed"/>
+   <xs:enumeration value="other"/>
+   <xs:enumeration value="none"/>
+  </xs:restriction>
+ </xs:simpleType>
+
+ <xs:attribute name="actuate" type="xlink:actuateType"/>
+
+ <xs:simpleType name="actuateType">
+  <xs:restriction base="xs:token">
+   <xs:enumeration value="onLoad"/>
+   <xs:enumeration value="onRequest"/>
+   <xs:enumeration value="other"/>
+   <xs:enumeration value="none"/>
+  </xs:restriction>
+ </xs:simpleType>
+
+ <xs:attribute name="label" type="xlink:labelType"/>
+
+ <xs:simpleType name="labelType">
+  <xs:restriction base="xs:NCName"/>
+ </xs:simpleType>
+
+ <xs:attribute name="from" type="xlink:fromType"/>
+
+ <xs:simpleType name="fromType">
+  <xs:restriction base="xs:NCName"/>
+ </xs:simpleType>
+
+ <xs:attribute name="to" type="xlink:toType"/>
+
+ <xs:simpleType name="toType">
+  <xs:restriction base="xs:NCName"/>
+ </xs:simpleType>
+
+ <xs:attributeGroup name="simpleAttrs">
+  <xs:attribute ref="xlink:type" fixed="simple"/>
+  <xs:attribute ref="xlink:href"/>
+  <xs:attribute ref="xlink:role"/>
+  <xs:attribute ref="xlink:arcrole"/>
+  <xs:attribute ref="xlink:title"/>
+  <xs:attribute ref="xlink:show"/>
+  <xs:attribute ref="xlink:actuate"/>
+ </xs:attributeGroup>
+
+ <xs:group name="simpleModel">
+  <xs:sequence>
+   <xs:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+  </xs:sequence>
+ </xs:group>
+
+ <xs:complexType mixed="true" name="simple">
+  <xs:annotation>
+   <xs:documentation>
+    Intended for use as the type of user-declared elements to make them
+    simple links.
+   </xs:documentation>
+  </xs:annotation>
+  <xs:group ref="xlink:simpleModel"/>
+  <xs:attributeGroup ref="xlink:simpleAttrs"/>
+ </xs:complexType>
+
+ <xs:attributeGroup name="extendedAttrs">
+  <xs:attribute ref="xlink:type" fixed="extended" use="required"/>
+  <xs:attribute ref="xlink:role"/>
+  <xs:attribute ref="xlink:title"/>
+ </xs:attributeGroup>
+
+ <xs:group name="extendedModel">
+   <xs:choice>
+    <xs:element ref="xlink:title"/>
+    <xs:element ref="xlink:resource"/>
+    <xs:element ref="xlink:locator"/>
+    <xs:element ref="xlink:arc"/>
+  </xs:choice>
+ </xs:group>
+
+ <xs:complexType name="extended">
+  <xs:annotation>
+   <xs:documentation>
+    Intended for use as the type of user-declared elements to make them
+    extended links.
+    Note that the elements referenced in the content model are all abstract.
+    The intention is that by simply declaring elements with these as their
+    substitutionGroup, all the right things will happen.
+   </xs:documentation>
+  </xs:annotation>
+  <xs:group ref="xlink:extendedModel" minOccurs="0" maxOccurs="unbounded"/>
+  <xs:attributeGroup ref="xlink:extendedAttrs"/>
+ </xs:complexType>
+
+ <xs:element name="title" type="xlink:titleEltType" abstract="true"/>
+
+ <xs:attributeGroup name="titleAttrs">
+  <xs:attribute ref="xlink:type" fixed="title" use="required"/>
+  <xs:attribute ref="xml:lang">
+   <xs:annotation>
+    <xs:documentation>
+     xml:lang is not required, but provides much of the
+     motivation for title elements in addition to attributes, and so
+     is provided here for convenience.
+    </xs:documentation>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:attributeGroup>
+
+ <xs:group name="titleModel">
+  <xs:sequence>
+   <xs:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+  </xs:sequence>
+ </xs:group>
+
+ <xs:complexType mixed="true" name="titleEltType">
+  <xs:group ref="xlink:titleModel"/>
+  <xs:attributeGroup ref="xlink:titleAttrs"/>
+ </xs:complexType>
+
+ <xs:element name="resource" type="xlink:resourceType" abstract="true"/>
+
+ <xs:attributeGroup name="resourceAttrs">
+  <xs:attribute ref="xlink:type" fixed="resource" use="required"/>
+  <xs:attribute ref="xlink:role"/>
+  <xs:attribute ref="xlink:title"/>
+  <xs:attribute ref="xlink:label"/>
+ </xs:attributeGroup>
+
+ <xs:group name="resourceModel">
+  <xs:sequence>
+   <xs:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+  </xs:sequence>
+ </xs:group>
+
+ <xs:complexType mixed="true" name="resourceType">
+  <xs:group ref="xlink:resourceModel"/>
+  <xs:attributeGroup ref="xlink:resourceAttrs"/>
+ </xs:complexType>
+
+ <xs:element name="locator" type="xlink:locatorType" abstract="true"/>
+
+ <xs:attributeGroup name="locatorAttrs">
+  <xs:attribute ref="xlink:type" fixed="locator" use="required"/>
+  <xs:attribute ref="xlink:href" use="required"/>
+  <xs:attribute ref="xlink:role"/>
+  <xs:attribute ref="xlink:title"/>
+  <xs:attribute ref="xlink:label">
+   <xs:annotation>
+    <xs:documentation>
+     label is not required, but locators have no particular
+     XLink function if they are not labeled.
+    </xs:documentation>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:attributeGroup>
+
+ <xs:group name="locatorModel">
+  <xs:sequence>
+   <xs:element ref="xlink:title" minOccurs="0" maxOccurs="unbounded"/>
+  </xs:sequence>
+ </xs:group>
+
+ <xs:complexType name="locatorType">
+  <xs:group ref="xlink:locatorModel"/>
+  <xs:attributeGroup ref="xlink:locatorAttrs"/>
+ </xs:complexType>
+
+ <xs:element name="arc" type="xlink:arcType" abstract="true"/>
+
+ <xs:attributeGroup name="arcAttrs">
+  <xs:attribute ref="xlink:type" fixed="arc" use="required"/>
+  <xs:attribute ref="xlink:arcrole"/>
+  <xs:attribute ref="xlink:title"/>
+  <xs:attribute ref="xlink:show"/>
+  <xs:attribute ref="xlink:actuate"/>
+  <xs:attribute ref="xlink:from"/>
+  <xs:attribute ref="xlink:to">
+   <xs:annotation>
+    <xs:documentation>
+     from and to have default behavior when values are missing
+    </xs:documentation>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:attributeGroup>
+
+ <xs:group name="arcModel">
+  <xs:sequence>
+   <xs:element ref="xlink:title" minOccurs="0" maxOccurs="unbounded"/>
+  </xs:sequence>
+ </xs:group>
+
+ <xs:complexType name="arcType">
+  <xs:group ref="xlink:arcModel"/>
+  <xs:attributeGroup ref="xlink:arcAttrs"/>
+ </xs:complexType>
+
+</xs:schema>

--- a/xsdata/schemas/xml.xsd
+++ b/xsdata/schemas/xml.xsd
@@ -1,0 +1,34 @@
+<?xml version='1.0'?>
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="http://www.w3.org/1999/xhtml"
+           xml:lang="en">
+
+    <xs:attribute name="lang">
+        <xs:simpleType>
+            <xs:union memberTypes="xs:language">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value=""/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:union>
+        </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="space">
+        <xs:simpleType>
+            <xs:restriction base="xs:NCName">
+                <xs:enumeration value="default"/>
+                <xs:enumeration value="preserve"/>
+            </xs:restriction>
+        </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="base" type="xs:anyURI"/>
+    <xs:attribute name="id" type="xs:ID"/>
+    <xs:attributeGroup name="specialAttrs">
+        <xs:attribute ref="xml:base"/>
+        <xs:attribute ref="xml:lang"/>
+        <xs:attribute ref="xml:space"/>
+        <xs:attribute ref="xml:id"/>
+    </xs:attributeGroup>
+</xs:schema>


### PR DESCRIPTION
- Elements can be mixed
- SchemaParser shouldn't skip elements with children
- Add copies of common schemas xlink and xml
- Filter non-printable characters before applying naming conventions
- Any element inherits min/max occurs from sequence