### PR TITLE
Fix #116 - Unset local names when possible

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -229,9 +229,11 @@ class AttrFactory(Factory):
     def create(
         cls,
         name=None,
+        local_name=None,
         index=None,
         types=None,
         tag=None,
+        xml_type=None,
         namespace=None,
         help=None,
         default=None,
@@ -241,9 +243,10 @@ class AttrFactory(Factory):
         name = name or f"attr_{cls.next_letter()}"
         return cls.model(
             name=name,
-            local_name=name,
+            local_name=local_name or name,
             index=cls.counter if index is None else index,
             types=types or [AttrTypeFactory.xs_string()],
+            xml_type=xml_type,
             tag=tag or random.choice(cls.types).__name__,
             namespace=namespace or None,
             help=help or None,

--- a/xsdata/formats/dataclass/generator.py
+++ b/xsdata/formats/dataclass/generator.py
@@ -7,24 +7,14 @@ from typing import List
 from typing import Tuple
 
 from xsdata.formats.dataclass.filters import filters
-from xsdata.formats.dataclass.models.constants import XmlType
 from xsdata.formats.generators import PythonAbstractGenerator
-from xsdata.models.codegen import Attr
 from xsdata.models.codegen import Class
 from xsdata.models.codegen import Package
-from xsdata.models.enums import Tag
 from xsdata.resolver import DependenciesResolver
 
 
 class DataclassGenerator(PythonAbstractGenerator):
     templates_dir = Path(__file__).parent.joinpath("templates")
-    xml_type_map = {
-        Tag.ELEMENT: XmlType.ELEMENT,
-        Tag.ANY: XmlType.WILDCARD,
-        Tag.ANY_ATTRIBUTE: XmlType.ATTRIBUTES,
-        Tag.ATTRIBUTE: XmlType.ATTRIBUTE,
-        None: XmlType.TEXT,
-    }
 
     def __init__(self):
         super(DataclassGenerator, self).__init__()
@@ -109,10 +99,3 @@ class DataclassGenerator(PythonAbstractGenerator):
         for obj in imports:
             result[obj.source].append(self.process_import(obj))
         return result
-
-    @classmethod
-    def process_attribute(cls, target: Class, attr: Attr, parents: List[str]):
-        super(DataclassGenerator, cls).process_attribute(target, attr, parents)
-        attr.xml_type = cls.xml_type_map.get(attr.tag)
-        if attr.xml_type in (XmlType.ATTRIBUTES, XmlType.WILDCARD, None):
-            attr.local_name = None


### PR DESCRIPTION
Avoid rendering metadata local name when it's not really necessary.

This is something already happening for xs:any or xs:anyAttribute, let's do it for attributes where local name matches the field name as well, less noise