### PR TITLE
Don't filter out "mixed" unions -- address #137

### DIFF
--- a/xsdata/analyzer.py
+++ b/xsdata/analyzer.py
@@ -100,7 +100,7 @@ class ClassAnalyzer(ClassUtils):
         """
         all_classes = [item for values in self.class_index.values() for item in values]
         primary_classes = [
-            item for item in all_classes if item.is_enumeration or item.is_complex
+            item for item in all_classes if item.is_enumeration or item.is_complex or item.inner
         ]
 
         classes = primary_classes or all_classes


### PR DESCRIPTION
This seems to work -- generates an inner "Value" class for these. 

The flattening of attributes sometimes generates a bunch of garbage Value types though, since they aren't "native"