### PR TITLE
Fix #137 Generate all xs:simpleType classes if no complexType available

### DIFF
--- a/tests/fixtures/defxmlschema/chapter08/example0812.py
+++ b/tests/fixtures/defxmlschema/chapter08/example0812.py
@@ -1,16 +1,25 @@
 from enum import Enum
+from dataclasses import dataclass, field
+from typing import Optional, Union
+from tests.fixtures.defxmlschema.chapter08.example0809 import (
+    SmlxsizeType,
+)
 
 
-class XsmlxsizeType(Enum):
+@dataclass
+class XsmlxsizeType:
     """
-    :cvar EXTRA_LARGE:
-    :cvar EXTRA_SMALL:
-    :cvar LARGE:
-    :cvar MEDIUM:
-    :cvar SMALL:
+    :ivar value:
     """
-    EXTRA_LARGE = "extra large"
-    EXTRA_SMALL = "extra small"
-    LARGE = "large"
-    MEDIUM = "medium"
-    SMALL = "small"
+    class Meta:
+        name = "XSMLXSizeType"
+
+    value: Optional[Union[SmlxsizeType, "XsmlxsizeType.Value"]] = field(
+        default=None,
+    )
+
+    class Value(Enum):
+        """
+        :cvar EXTRA_SMALL:
+        """
+        EXTRA_SMALL = "extra small"

--- a/tests/fixtures/defxmlschema/chapter08/xsi.py
+++ b/tests/fixtures/defxmlschema/chapter08/xsi.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+
+__NAMESPACE__ = "http://www.w3.org/2001/XMLSchema-instance"
+
+
+@dataclass
+class Nil:
+    class Meta:
+        name = "nil"
+        namespace = "http://www.w3.org/2001/XMLSchema-instance"
+
+
+@dataclass
+class NoNamespaceSchemaLocation:
+    class Meta:
+        name = "noNamespaceSchemaLocation"
+        namespace = "http://www.w3.org/2001/XMLSchema-instance"
+
+
+@dataclass
+class SchemaLocation:
+    class Meta:
+        name = "schemaLocation"
+        namespace = "http://www.w3.org/2001/XMLSchema-instance"
+
+
+@dataclass
+class Type:
+    class Meta:
+        name = "type"
+        namespace = "http://www.w3.org/2001/XMLSchema-instance"

--- a/tests/fixtures/defxmlschema/chapter10/example1010.py
+++ b/tests/fixtures/defxmlschema/chapter10/example1010.py
@@ -1,5 +1,8 @@
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import List
+from tests.fixtures.defxmlschema.chapter08.example0810 import (
+    SmlsizeType,
+)
 
 
 @dataclass
@@ -7,11 +10,10 @@ class AvailableSizesType:
     """
     :ivar value:
     """
-    value: Optional[str] = field(
-        default=None,
+    value: List[SmlsizeType] = field(
+        default_factory=list,
         metadata=dict(
-            name="value",
-            type="Restriction",
-            max_length=3.0
+            min_occurs=0,
+            max_occurs=9223372036854775807
         )
     )

--- a/tests/fixtures/defxmlschema/chapter10/example1016.py
+++ b/tests/fixtures/defxmlschema/chapter10/example1016.py
@@ -1,4 +1,6 @@
 from enum import Enum
+from dataclasses import dataclass, field
+from typing import List
 
 
 class SmlxsizeType(Enum):
@@ -12,3 +14,17 @@ class SmlxsizeType(Enum):
     LARGE = "large"
     MEDIUM = "medium"
     SMALL = "small"
+
+
+@dataclass
+class AvailableSizesType:
+    """
+    :ivar value:
+    """
+    value: List[SmlxsizeType] = field(
+        default_factory=list,
+        metadata=dict(
+            min_occurs=0,
+            max_occurs=9223372036854775807
+        )
+    )

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -158,10 +158,10 @@ class ClassAnalyzerTests(FactoryTestCase):
         mock_sanitize_attributes.assert_has_calls([mock.call(x) for x in expected])
 
     @mock.patch.object(ClassAnalyzer, "sanitize_attributes")
-    def test_fetch_classes_for_generation_return_simple_when_no_complex_types(
+    def test_fetch_classes_for_generation_when_no_complex_class_available(
         self, mock_sanitize_attributes
     ):
-        classes = ClassFactory.list(2, type=SimpleType)
+        classes = [ClassFactory.enumeration(2), ClassFactory.create(type=SimpleType)]
         self.analyzer.create_class_index(classes)
 
         actual = self.analyzer.fetch_classes_for_generation()

--- a/xsdata/analyzer.py
+++ b/xsdata/analyzer.py
@@ -92,18 +92,16 @@ class ClassAnalyzer(ClassUtils):
     def fetch_classes_for_generation(self) -> List[Class]:
         """
         Return the qualified classes to continue for code generation. Return
-        all if there are not primary classes.
+        all of them if there are no classes derived from xs:element or
+        xs:complexType.
 
         Qualifications:
             * not an abstract
             * type: element | complexType | simpleType with enumerations
         """
-        all_classes = [item for values in self.class_index.values() for item in values]
-        primary_classes = [
-            item for item in all_classes if item.is_enumeration or item.is_complex
-        ]
-
-        classes = primary_classes or all_classes
+        classes = [item for values in self.class_index.values() for item in values]
+        if any(item.is_complex for item in classes):
+            classes = list(filter(lambda x: x.is_enumeration or x.is_complex, classes))
 
         for target in classes:
             self.sanitize_attributes(target)


### PR DESCRIPTION
 ```console

xsdata https://gist.githubusercontent.com/nimish/ce45c437e82f9b565ca576f768af26fb/raw/dd55c57618619910424bfc91e6bcf9461d6b10ce/example.xsd --package foo --print


class Base(Enum):
    """
    :cvar A:
    :cvar B:
    :cvar C:
    :cvar D:
    """
    A = "A"
    B = "B"
    C = "C"
    D = "D"


class Variant(Enum):
    """
    :cvar A1:
    :cvar B1:
    :cvar C1:
    :cvar D1:
    """
    A1 = "A1"
    B1 = "B1"
    C1 = "C1"
    D1 = "D1"


@dataclass
class Extension:
    """
    :ivar value:
    """
    value: Optional[Union[Base, Variant, "Extension.Value"]] = field(
        default=None,
    )

    class Value(Enum):
        """
        :cvar E:
        :cvar F:
        """
        E = "E"
        F = "F"

```