### PR TITLE
Resolve #143 ClassAnalyzer: flatten self references in inner classes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: tests/fixtures|docs/examples
 
 repos:
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v2.2.0
+    rev: v2.3.0
     hooks:
       - id: reorder-python-imports
   - repo: https://github.com/ambv/black

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -177,13 +177,22 @@ class AttrTypeFactory(Factory):
     counter = 65
 
     @classmethod
-    def create(cls, name=None, index=None, alias=None, native=False, forward_ref=False):
+    def create(
+        cls,
+        name=None,
+        index=None,
+        alias=None,
+        native=False,
+        forward_ref=False,
+        self_ref=False,
+    ):
 
         return cls.model(
             name=name or f"attr_{cls.next_letter()}",
             index=index or 0,
             alias=alias,
             native=native,
+            self_ref=self_ref,
             forward_ref=forward_ref,
         )
 

--- a/tests/formats/test_generators.py
+++ b/tests/formats/test_generators.py
@@ -9,7 +9,6 @@ from tests.factories import PackageFactory
 from xsdata.formats.dataclass.models.constants import XmlType
 from xsdata.formats.generators import AbstractGenerator
 from xsdata.formats.generators import PythonAbstractGenerator as generator
-from xsdata.models.enums import DataType
 from xsdata.models.enums import Namespace
 from xsdata.models.enums import Tag
 
@@ -377,11 +376,13 @@ class PythonAbstractGeneratorTests(FactoryTestCase):
         actual = generator.attribute_display_type(attr, parents)
         self.assertEqual('Optional["FooBar"]', actual)
 
+        parents = ["Parent", "Inner"]
         attr.types[0].forward_ref = True
         actual = generator.attribute_display_type(attr, parents)
-        self.assertEqual('Optional["Parent.FooBar"]', actual)
+        self.assertEqual('Optional["Parent.Inner"]', actual)
 
         parents = ["A", "Parent"]
+        attr.types[0].self_ref = False
         attr.restrictions.max_occurs = 2
         actual = generator.attribute_display_type(attr, parents)
         self.assertEqual('List["A.Parent.FooBar"]', actual)
@@ -415,6 +416,7 @@ class PythonAbstractGeneratorTests(FactoryTestCase):
         type_decimal = AttrTypeFactory.xs_decimal()
         type_bool = AttrTypeFactory.xs_bool()
         type_qname = AttrTypeFactory.xs_qname()
+        type_qmap = AttrTypeFactory.xs_qmap()
         type_tokens = AttrTypeFactory.xs_tokens()
 
         attr = AttrFactory.create(name="foo", types=[type_str])
@@ -430,6 +432,9 @@ class PythonAbstractGeneratorTests(FactoryTestCase):
         attr.default = "1"
         attr.types[0] = type_int
         self.assertEqual(1, generator.attribute_default(attr))
+
+        attr.types[0] = type_qmap
+        self.assertEqual("dict", generator.attribute_default(attr))
 
         attr.default = "true"
         attr.types[0] = type_bool

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -673,6 +673,14 @@ class ClassAnalyzerTests(FactoryTestCase):
         self.assertFalse(attr_type.forward_ref)
         mock_logger_warning.assert_called_once_with("Missing type: %s", "foo")
 
+    def test_flatten_attribute_type_with_self_reference(self):
+        target = ClassFactory.create()
+        attr = AttrFactory.create()
+        attr_type = AttrTypeFactory.create(name="foo", self_ref=True)
+
+        self.analyzer.flatten_attribute_type(target, attr, attr_type)
+        self.assertEqual("foo", attr_type.name)
+
     @mock.patch.object(ClassAnalyzer, "find_attribute")
     def test_add_substitution_attrs(self, mock_find_attribute):
         target = ClassFactory.elements(2)

--- a/xsdata/analyzer.py
+++ b/xsdata/analyzer.py
@@ -345,7 +345,7 @@ class ClassAnalyzer(ClassUtils):
             complex_source = self.find_attr_type(target, attr_type)
             if complex_source:
                 attr_type.self_ref = self.class_depends_on(complex_source, target)
-            else:
+            elif not attr_type.self_ref:
                 logger.warning("Missing type: %s", attr_type.name)
                 self.reset_attribute_type(attr_type)
 

--- a/xsdata/formats/generators.py
+++ b/xsdata/formats/generators.py
@@ -260,7 +260,11 @@ class PythonAbstractGenerator(AbstractGenerator, ABC):
                 if attr_type.alias
                 else cls.type_name(attr_type)
             )
-            if attr_type.forward_ref:
+
+            if attr_type.forward_ref and attr_type.self_ref:
+                outer_str = ".".join(parents)
+                type_name = f'"{outer_str}"'
+            elif attr_type.forward_ref:
                 outer_str = ".".join(parents)
                 type_name = f'"{outer_str}.{type_name}"'
             elif attr_type.self_ref:

--- a/xsdata/utils/classes.py
+++ b/xsdata/utils/classes.py
@@ -205,12 +205,19 @@ class ClassUtils:
     @classmethod
     def copy_inner_classes(cls, source: Class, target: Class):
         """
-        Copy inner classes from source to target class.
+        Copy safely inner classes from source to target class.
 
-        Check for duplicates by name and skip if it already exists.
+        Checks:
+            1. Inner is the target class, skip and mark as self reference
+            2. Inner with same name exists, skip
         """
         for inner in source.inner:
-            if not any(existing.name == inner.name for existing in target.inner):
+            if inner is target:
+                for attr in target.attrs:
+                    for attr_type in attr.types:
+                        if attr_type.forward_ref and attr_type.name == inner.name:
+                            attr_type.self_ref = True
+            elif not any(existing.name == inner.name for existing in target.inner):
                 target.inner.append(inner)
 
     @classmethod


### PR DESCRIPTION
Handle combination of forward references (inner classes) and self reference.

1. Copy attributes to avoid extending outer class
2. Update self reference flag during copy of inner classes
3. Update python dataclass generator to handle the scenario when both forward and self references are true.

```python

@dataclass
class Foo:
    """
    :ivar foo:
    :ivar bar:
    """
    class Meta:
        name = "foo"

    foo: Optional[object] = field(
        default=None,
        metadata=dict(
            type="Element",
            namespace="",
            required=True
        )
    )
    bar: Optional["Foo.Bar"] = field(
        default=None,
        metadata=dict(
            type="Element",
            namespace=""
        )
    )

    @dataclass
    class Bar:
        """
        :ivar foo:
        :ivar bar:
        """
        foo: Optional[object] = field(
            default=None,
            metadata=dict(
                type="Element",
                namespace="",
                required=True
            )
        )
        bar: Optional["Foo.Bar"] = field(
            default=None,
            metadata=dict(
                type="Element",
                namespace=""
            )
        )
```