### PR TITLE
Resolve #151 ClassAnalyzer issues with enum fields with default values

### DIFF
--- a/tests/formats/dataclass/test_generator.py
+++ b/tests/formats/dataclass/test_generator.py
@@ -96,17 +96,6 @@ class DataclassGeneratorTests(FactoryTestCase):
         )
         self.assertEqual(expected, actual)
 
-    def test_prepare_imports(self):
-        packages = [
-            PackageFactory.create(name="foo", source="omg"),
-            PackageFactory.create(name="bar", source="omg"),
-            PackageFactory.create(name="thug", source="life"),
-        ]
-        expected = {"omg": packages[:2], "life": packages[2:]}
-
-        actual = DataclassGenerator().prepare_imports(packages)
-        self.assertEqual(expected, actual)
-
     def test_module_name(self):
         self.assertEqual("foo_bar", DataclassGenerator.module_name("fooBar"))
         self.assertEqual("foo_bar_wtf", DataclassGenerator.module_name("fooBar.wtf"))

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -906,16 +906,14 @@ class ClassAnalyzerTests(FactoryTestCase):
             self.analyzer.sanitize_attribute_default_value(target, attr)
             actual.append(attr.default)
 
-        self.assertEqual([None, 2, None, "@enum@hit.winner"], actual)
+        self.assertEqual([None, 2, 2, "@enum@hit.winner"], actual)
 
         attr = AttrFactory.create(
             default="missing", types=AttrTypeFactory.list(1, name="hit")
         )
 
-        with self.assertRaises(AnalyzerError) as cm:
-            self.analyzer.sanitize_attribute_default_value(target, attr)
-
-        self.assertEqual("Unknown enumeration hit: missing", str(cm.exception))
+        self.analyzer.sanitize_attribute_default_value(target, attr)
+        self.assertEqual("missing", attr.default)
 
     @mock.patch.object(ClassAnalyzer, "flatten_class")
     def test_class_depends_on_has_a_depth_limit(self, *args):

--- a/xsdata/analyzer.py
+++ b/xsdata/analyzer.py
@@ -17,6 +17,7 @@ from xsdata.models.codegen import Class
 from xsdata.models.codegen import Extension
 from xsdata.utils import text
 from xsdata.utils.classes import ClassUtils
+from xsdata.utils.collections import group_by
 from xsdata.utils.collections import unique_sequence
 
 
@@ -33,9 +34,7 @@ class ClassAnalyzer(ClassUtils):
     MAX_DEPENDENCY_CHECK_DEPTH = 5
 
     processed: List = field(default_factory=list)
-    class_index: Dict[QName, List[Class]] = field(
-        default_factory=lambda: defaultdict(list)
-    )
+    class_index: Dict[QName, List[Class]] = field(default_factory=dict)
     substitutions_index: Dict[QName, List[Attr]] = field(
         default_factory=lambda: defaultdict(list)
     )
@@ -109,9 +108,7 @@ class ClassAnalyzer(ClassUtils):
 
     def create_class_index(self, classes: List[Class]):
         """Group classes by their fully qualified name."""
-        self.class_index.clear()
-        for item in classes:
-            self.class_index[item.source_qname()].append(item)
+        self.class_index = group_by(classes, lambda x: x.source_qname())
 
     def create_substitutions_index(self):
         """Create reference attributes for all the classes substitutions and

--- a/xsdata/formats/dataclass/filters.py
+++ b/xsdata/formats/dataclass/filters.py
@@ -144,8 +144,8 @@ def attribute_default(attr: Attr, ns_map: Optional[Dict] = None) -> Any:
             default_value = quoteattr(
                 " ".join(filter(None, map(str.strip, re.split(r"\s+", default_value))))
             )
-        elif not data_types and default_value.startswith("@enum@"):
-            source, enumeration = default_value[6:].split(".")
+        elif default_value.startswith("@enum@"):
+            source, enumeration = default_value[6:].split(".", 1)
             attr_type = next(
                 attr_type
                 for attr_type in attr.types

--- a/xsdata/formats/mixins.py
+++ b/xsdata/formats/mixins.py
@@ -1,6 +1,7 @@
 from abc import ABC
 from abc import abstractmethod
 from pathlib import Path
+from typing import Dict
 from typing import Iterator
 from typing import List
 from typing import Optional
@@ -11,6 +12,9 @@ from jinja2 import FileSystemLoader
 from jinja2 import Template
 
 from xsdata.models.codegen import Class
+from xsdata.utils.collections import group_by
+from xsdata.utils.package import module_path
+from xsdata.utils.package import package_path
 
 
 class AbstractGenerator(ABC):
@@ -35,3 +39,11 @@ class AbstractGenerator(ABC):
     @classmethod
     def package_name(cls, name: str) -> str:
         return name
+
+    @classmethod
+    def group_by_package(cls, classes: List[Class]) -> Dict[Path, List[Class]]:
+        return group_by(classes, lambda x: package_path(x.target_module))
+
+    @classmethod
+    def group_by_module(cls, classes: List[Class]) -> Dict[Path, List[Class]]:
+        return group_by(classes, lambda x: module_path(x.target_module))

--- a/xsdata/formats/plantuml/generator.py
+++ b/xsdata/formats/plantuml/generator.py
@@ -1,6 +1,4 @@
-from collections import defaultdict
 from pathlib import Path
-from typing import Dict
 from typing import Iterator
 from typing import List
 from typing import Tuple
@@ -13,13 +11,6 @@ from xsdata.resolver import DependenciesResolver
 class PlantUmlGenerator(AbstractGenerator):
     templates_dir = Path(__file__).parent.joinpath("templates")
 
-    def render_module(self, output: str) -> str:
-        return self.template("module").render(output=output)
-
-    def render_class(self, obj: Class) -> str:
-        template = "enum" if obj.is_enumeration else "class"
-        return self.template(template).render(obj=obj)
-
     def render(self, classes: List[Class]) -> Iterator[Tuple[Path, str, str]]:
         """Given  a list of classes return to the writer factory the target
         file path full module path and the rendered code."""
@@ -27,19 +18,23 @@ class PlantUmlGenerator(AbstractGenerator):
         packages = {obj.source_qname(): obj.target_module for obj in classes}
         resolver = DependenciesResolver(packages=packages)
 
-        groups: Dict[str, List] = defaultdict(list)
-        for obj in classes:
-            groups[obj.target_module].append(obj)
+        for module, cluster in self.group_by_module(classes).items():
+            output = self.render_module(resolver, cluster)
+            pck = cluster[0].target_module
+            yield module.with_suffix(".pu"), pck, output
 
-        for target_module, cluster in groups.items():
-            resolver.process(cluster)
-            output = self.render_classes(resolver.sorted_classes())
-            file_path = Path.cwd().joinpath(target_module.replace(".", "/") + ".pu")
-
-            yield file_path, target_module, self.render_module(output=output)
+    def render_module(
+        self, resolver: DependenciesResolver, classes: List[Class]
+    ) -> str:
+        resolver.process(classes)
+        output = self.render_classes(resolver.sorted_classes())
+        return self.template("module").render(output=output)
 
     def render_classes(self, classes: List[Class]) -> str:
-        """Sort classes by name and return the rendered output."""
         classes = sorted(classes, key=lambda x: x.name)
         output = "\n".join(map(self.render_class, classes)).strip()
         return f"\n{output}\n"
+
+    def render_class(self, obj: Class) -> str:
+        template = "enum" if obj.is_enumeration else "class"
+        return self.template(template).render(obj=obj)

--- a/xsdata/utils/classes.py
+++ b/xsdata/utils/classes.py
@@ -1,6 +1,5 @@
 import re
 import sys
-from collections import defaultdict
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -17,6 +16,7 @@ from xsdata.models.enums import DataType
 from xsdata.models.enums import NamespaceType
 from xsdata.models.enums import Tag
 from xsdata.utils import text
+from xsdata.utils.collections import group_by
 
 
 class ClassUtils:
@@ -296,10 +296,7 @@ class ClassUtils:
     @classmethod
     def merge_redefined_classes(cls, classes: List[Class]):
         """Merge original and redefined classes."""
-        grouped: Dict[str, List[Class]] = defaultdict(list)
-        for item in classes:
-            grouped[f"{item.type.__name__}{item.source_qname()}"].append(item)
-
+        grouped = group_by(classes, lambda x: f"{x.type.__name__}{x.source_qname()}")
         for items in grouped.values():
             if len(items) == 1:
                 continue

--- a/xsdata/utils/collections.py
+++ b/xsdata/utils/collections.py
@@ -1,4 +1,7 @@
+from collections import defaultdict
 from typing import Any
+from typing import Callable
+from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Sequence
@@ -18,3 +21,10 @@ def unique_sequence(items: Sequence, key: Optional[str] = None) -> List:
         return True
 
     return [item for item in items if is_new(item)]
+
+
+def group_by(items: Sequence, key: Callable) -> Dict[Any, List]:
+    result = defaultdict(list)
+    for item in items:
+        result[key(item)].append(item)
+    return result

--- a/xsdata/utils/package.py
+++ b/xsdata/utils/package.py
@@ -1,0 +1,12 @@
+import functools
+from pathlib import Path
+
+
+@functools.lru_cache(maxsize=50)
+def package_path(package: str) -> Path:
+    return Path.cwd().joinpath(package.replace(".", "/")).parent
+
+
+@functools.lru_cache(maxsize=50)
+def module_path(package: str) -> Path:
+    return Path.cwd().joinpath(package.replace(".", "/"))


### PR DESCRIPTION
The algorithm that sets the proper `Class.Member` as default value for enum fields has multiple issues:

1. enum unions are attempting to overwrite the default value
2. enum members are processed multiple types
3. unions of enums and any other type resulted in string literal render