### PR TITLE
Resolve #157 XmlSerializer should never use a wild var qname

### DIFF
--- a/tests/formats/dataclass/serializers/test_xml.py
+++ b/tests/formats/dataclass/serializers/test_xml.py
@@ -259,10 +259,8 @@ class XmlSerializerTests(TestCase):
             child, var.nillable, self.namespaces
         )
 
-        self.assertEqual(var.qname, child.tag)
-        self.assertEqual(
-            {"ns0": "http://www.w3.org/1999/xhtml"}, self.namespaces.ns_map
-        )
+        self.assertEqual("SizeType", child.tag)
+        self.assertEqual(0, len(self.namespaces.ns_map))
 
     @mock.patch.object(SerializeUtils, "set_nil_attribute")
     @mock.patch.object(XmlSerializer, "render_node")
@@ -271,7 +269,7 @@ class XmlSerializerTests(TestCase):
     ):
         root = Element("root")
         value = SizeType()
-        value.qname = "foo"
+        value.qname = QName("foo")
         meta = self.serializer.context.build(DescriptionType)
         var = meta.find_var(mode=FindMode.WILDCARD)
 

--- a/xsdata/formats/dataclass/parsers/utils.py
+++ b/xsdata/formats/dataclass/parsers/utils.py
@@ -92,9 +92,7 @@ class ParserUtils:
     @classmethod
     def bind_element_param(cls, params: Dict, var: XmlVar, value: Any) -> bool:
         if var.is_list:
-            if var.name not in params:
-                params[var.name] = list()
-            params[var.name].append(value)
+            params.setdefault(var.name, []).append(value)
         elif var.name not in params:
             params[var.name] = value
         else:

--- a/xsdata/formats/dataclass/serializers/xml.py
+++ b/xsdata/formats/dataclass/serializers/xml.py
@@ -117,11 +117,15 @@ class XmlSerializer(AbstractSerializer):
     def render_element_node(
         self, parent: Element, value: Any, var: XmlVar, namespaces: Namespaces
     ):
-        qname = value.qname if hasattr(value, "qname") else var.qname
+        if hasattr(value, "qname"):
+            qname = value.qname
+        elif var.is_wildcard:
+            meta = self.context.fetch(value.__class__, QName(parent).namespace)
+            qname = meta.qname
+        else:
+            qname = var.qname
 
-        if isinstance(qname, QName):
-            namespaces.add(qname.namespace)
-
+        namespaces.add(qname.namespace)
         sub_element = SubElement(parent, qname)
         self.render_node(sub_element, value, namespaces)
         self.set_xsi_type(sub_element, value, var, namespaces)


### PR DESCRIPTION
A wildcard field qualified name should never be used on serialize,

In order or preference:
1. Generic object `AnyElement.qname`
2. Dataclass object hidden field `Model.qname`
3. Dataclass object meta `name` / `namespace`

The second case is kind of a hack but it's necessary until I figure how to parse fields with type any union of multiple dataclasses.
