### PR TITLE
Fix #165 ClassBuilder: filter invalid redefine/override children

### DIFF
--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -10,6 +10,7 @@ from tests.factories import FactoryTestCase
 from xsdata.builder import ClassBuilder
 from xsdata.models.codegen import Restrictions
 from xsdata.models.elements import Alternative
+from xsdata.models.elements import Annotation
 from xsdata.models.elements import Attribute
 from xsdata.models.elements import AttributeGroup
 from xsdata.models.elements import ComplexContent
@@ -60,13 +61,13 @@ class ClassBuilderTests(FactoryTestCase):
         redefine_group = Group.create()
         redefine_attribute_group = AttributeGroup.create()
         mock_redefine_children.side_effect = [
-            [redefine_simple_type, redefine_group],
-            [redefine_attribute_group],
+            [redefine_simple_type, redefine_group, Annotation.create()],
+            [redefine_attribute_group, Annotation.create()],
         ]
 
         mock_override_children.side_effect = [
-            [override_element, override_attribute],
-            [override_complex_type],
+            [override_element, Annotation.create(), override_attribute],
+            [Annotation.create(), override_complex_type],
         ]
         mock_build_class.side_effect = classes = ClassFactory.list(18)
 

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -226,7 +226,7 @@ class SchemaTransformerTests(FactoryTestCase):
         mock_count_classes,
         mock_logger_info,
     ):
-        schema = Schema.create()
+        schema = Schema.create(location="edo.xsd")
         classes = ClassFactory.list(2)
 
         mock_builder_build.return_value = classes
@@ -237,7 +237,7 @@ class SchemaTransformerTests(FactoryTestCase):
         mock_builder_build.assert_called_once_with()
         mock_logger_info.assert_has_calls(
             [
-                mock.call("Compiling schema..."),
+                mock.call("Compiling schema %s", schema.location),
                 mock.call("Builder: %d main and %d inner classes", 2, 4),
             ]
         )

--- a/xsdata/builder.py
+++ b/xsdata/builder.py
@@ -10,8 +10,11 @@ from xsdata.models.codegen import AttrType
 from xsdata.models.codegen import Class
 from xsdata.models.codegen import Extension
 from xsdata.models.codegen import Restrictions
+from xsdata.models.elements import Attribute
+from xsdata.models.elements import AttributeGroup
 from xsdata.models.elements import ComplexType
 from xsdata.models.elements import Element
+from xsdata.models.elements import Group
 from xsdata.models.elements import Schema
 from xsdata.models.elements import SimpleType
 from xsdata.models.enums import DataType
@@ -30,11 +33,17 @@ class ClassBuilder:
         """Generate classes from schema and redefined elements."""
         classes: List[Class] = []
 
+        def is_valid(item: ElementBase) -> bool:
+            return isinstance(
+                item,
+                (SimpleType, ComplexType, Group, AttributeGroup, Element, Attribute),
+            )
+
         for override in self.schema.overrides:
-            classes.extend(map(self.build_class, override.children()))
+            classes.extend(map(self.build_class, filter(is_valid, override.children())))
 
         for redefine in self.schema.redefines:
-            classes.extend(map(self.build_class, redefine.children()))
+            classes.extend(map(self.build_class, filter(is_valid, redefine.children())))
 
         classes.extend(map(self.build_class, self.schema.simple_types))
         classes.extend(map(self.build_class, self.schema.attribute_groups))

--- a/xsdata/transformer.py
+++ b/xsdata/transformer.py
@@ -104,7 +104,7 @@ class SchemaTransformer:
     def generate_classes(self, schema: Schema, package: str) -> List[Class]:
         """Convert the given schema tree to codegen classes and use the writer
         factory to either generate or print the result code."""
-        logger.info("Compiling schema...")
+        logger.info("Compiling schema %s", schema.location)
         classes = ClassBuilder(schema=schema, package=package).build()
 
         class_num, inner_num = self.count_classes(classes)


### PR DESCRIPTION
Not all `ElementBase` classes are candidates for class generation