### PR TITLE
Replace depth limit with cache in circular dependency check

### DIFF
--- a/tests/models/codegen/test_attr_type.py
+++ b/tests/models/codegen/test_attr_type.py
@@ -1,0 +1,30 @@
+from tests.factories import AttrTypeFactory
+from tests.factories import FactoryTestCase
+
+
+class AttrTypeTests(FactoryTestCase):
+    def test_property_is_dependency(self):
+
+        attr_type = AttrTypeFactory.create(forward=True, native=True, circular=True)
+        self.assertFalse(attr_type.is_dependency)
+
+        attr_type.forward = False
+        self.assertFalse(attr_type.is_dependency)
+
+        attr_type.native = False
+        self.assertFalse(attr_type.is_dependency)
+
+        attr_type.circular = False
+        self.assertTrue(attr_type.is_dependency)
+
+    def test_native_property(self):
+        attr_type = AttrTypeFactory.xs_int()
+        self.assertEqual("int", attr_type.native_name)
+        self.assertEqual("integer", attr_type.native_code)
+        self.assertEqual(int, attr_type.native_type)
+
+    def test_non_native_property(self):
+        attr_type = AttrTypeFactory.create(name="foo")
+        self.assertIsNone(attr_type.native_name)
+        self.assertIsNone(attr_type.native_code)
+        self.assertIsNone(attr_type.native_type)

--- a/tests/models/codegen/test_class.py
+++ b/tests/models/codegen/test_class.py
@@ -27,9 +27,10 @@ class ClassTests(FactoryTestCase):
                     ]
                 ),
             ],
-            extensions=ExtensionFactory.list(
-                1, type=AttrTypeFactory.create(name="xs:localElement")
-            ),
+            extensions=[
+                ExtensionFactory.create(type=AttrTypeFactory.create(name="xs:foobar")),
+                ExtensionFactory.create(type=AttrTypeFactory.create(name="xs:foobar")),
+            ],
             inner=[
                 ClassFactory.create(
                     attrs=AttrFactory.list(2, types=AttrTypeFactory.list(1, name="foo"))
@@ -40,7 +41,7 @@ class ClassTests(FactoryTestCase):
         expected = [
             QName("{http://www.w3.org/2001/XMLSchema}openAttrs"),
             QName("{http://www.w3.org/2001/XMLSchema}localAttribute"),
-            QName("{http://www.w3.org/2001/XMLSchema}localElement"),
+            QName("{http://www.w3.org/2001/XMLSchema}foobar"),
             QName("{xsdata}foo"),
         ]
         self.assertEqual(expected, list(obj.dependencies()))


### PR DESCRIPTION
Because the circular check has a limit some attributes were left falsely marked as circular after the main process of flattening attributes.

I replaced the depth limit with a cache to avoid evaluating same types more than one.
This also provided a nice performance boost in the generator overall for some very complex schema.

The process time for  the multi cache schemas from the common types it decreased from **30s** to **16s**
```console
xsdata --package output.multicacheschemas Common-Types/src/main/resources/schemas/HL7V3/NE2008/multicacheschemas
```