### PR TITLE
Fix #204 Resolve types when default namespace doesn't match the target

### DIFF
--- a/tests/codegen/handlers/test_attribute_enum_union.py
+++ b/tests/codegen/handlers/test_attribute_enum_union.py
@@ -5,8 +5,6 @@ from tests.factories import FactoryTestCase
 from xsdata.codegen.container import ClassContainer
 from xsdata.codegen.handlers import AttributeEnumUnionHandler
 from xsdata.models.enums import Tag
-from xsdata.models.xsd import Element
-from xsdata.models.xsd import SimpleType
 
 
 class AttributeEnumUnionHandlerTests(FactoryTestCase):
@@ -21,8 +19,10 @@ class AttributeEnumUnionHandlerTests(FactoryTestCase):
                     name="value",
                     tag=Tag.UNION,
                     types=[
-                        AttrTypeFactory.create(name=self.root_enum.name),
-                        AttrTypeFactory.create(name=self.inner_enum.name, forward=True),
+                        AttrTypeFactory.create(qname=self.root_enum.name),
+                        AttrTypeFactory.create(
+                            qname=self.inner_enum.name, forward=True
+                        ),
                     ],
                 ),
             ],

--- a/tests/codegen/handlers/test_attribute_group.py
+++ b/tests/codegen/handlers/test_attribute_group.py
@@ -91,11 +91,11 @@ class AttributeGroupHandlerTests(FactoryTestCase):
         self.assertFalse(group_attr in target.attrs)
 
     def test_process_attribute_with_unknown_source(self):
-        group_attr = AttrFactory.attribute_group(name="foo:bar")
+        group_attr = AttrFactory.attribute_group(name="bar")
         target = ClassFactory.create()
         target.attrs.append(group_attr)
 
         with self.assertRaises(AnalyzerValueError) as cm:
             self.processor.process_attribute(target, group_attr)
 
-        self.assertEqual("Group attribute not found: `{foo}bar`", str(cm.exception))
+        self.assertEqual("Group attribute not found: `{xsdata}bar`", str(cm.exception))

--- a/tests/codegen/handlers/test_attribute_implied.py
+++ b/tests/codegen/handlers/test_attribute_implied.py
@@ -1,4 +1,5 @@
 from tests.factories import AttrFactory
+from tests.factories import AttrTypeFactory
 from tests.factories import ClassFactory
 from tests.factories import FactoryTestCase
 from xsdata.codegen.handlers import AttributeImpliedHandler
@@ -7,7 +8,7 @@ from xsdata.models.enums import DataType
 from xsdata.models.enums import Tag
 
 
-class AttributeImpliedTests(FactoryTestCase):
+class AttributeImpliedHandlerTests(FactoryTestCase):
     def setUp(self):
         super().setUp()
         self.processor = AttributeImpliedHandler
@@ -22,7 +23,7 @@ class AttributeImpliedTests(FactoryTestCase):
         expected = AttrFactory.create(
             name="content",
             index=0,
-            types=[AttrType(name=DataType.ANY_TYPE.code, native=True)],
+            types=[AttrTypeFactory.xs_any()],
             tag=Tag.ANY,
             namespace="##any",
         )

--- a/tests/codegen/handlers/test_attribute_type.py
+++ b/tests/codegen/handlers/test_attribute_type.py
@@ -169,7 +169,7 @@ class AttributeTypeHandlerTests(FactoryTestCase):
         attr = target.attrs[0]
         attr.restrictions.min_length = 2
         attr.types.clear()
-        attr.types.append(AttrTypeFactory.create(name=source.name))
+        attr.types.append(AttrTypeFactory.create(qname=source.name))
 
         self.assertEqual("Foobar", attr.types[0].name)
         self.processor.process_simple_dependency(source, target, attr, attr.types[0])
@@ -266,22 +266,21 @@ class AttributeTypeHandlerTests(FactoryTestCase):
         )
 
     def test_find_dependency(self):
-        target = ClassFactory.create()
-        attr_type = AttrTypeFactory.create(name="a")
+        attr_type = AttrTypeFactory.create(qname="a")
 
-        self.assertIsNone(self.processor.find_dependency(target, attr_type))
+        self.assertIsNone(self.processor.find_dependency(attr_type))
 
         abstract = ClassFactory.create(name="a", type=ComplexType, abstract=True)
         self.processor.container.add(abstract)
-        self.assertEqual(abstract, self.processor.find_dependency(target, attr_type))
+        self.assertEqual(abstract, self.processor.find_dependency(attr_type))
 
         element = ClassFactory.create(name="a", type=Element)
         self.processor.container.add(element)
-        self.assertEqual(element, self.processor.find_dependency(target, attr_type))
+        self.assertEqual(element, self.processor.find_dependency(attr_type))
 
         simple = ClassFactory.create(name="a", type=SimpleType)
         self.processor.container.add(simple)
-        self.assertEqual(simple, self.processor.find_dependency(target, attr_type))
+        self.assertEqual(simple, self.processor.find_dependency(attr_type))
 
     @mock.patch.object(Class, "dependencies")
     def test_cached_dependencies(self, mock_class_dependencies):

--- a/tests/codegen/handlers/test_class_extension.py
+++ b/tests/codegen/handlers/test_class_extension.py
@@ -285,18 +285,17 @@ class ClassExtensionHandlerTests(FactoryTestCase):
         mock_copy_attributes.assert_called_once_with(source, target, extension)
 
     def test_find_dependency(self):
-        target = ClassFactory.create()
-        attr_type = AttrTypeFactory.create(name="a")
+        attr_type = AttrTypeFactory.create(qname="a")
 
-        self.assertIsNone(self.processor.find_dependency(target, attr_type))
+        self.assertIsNone(self.processor.find_dependency(attr_type))
 
         complex = ClassFactory.create(name="a", type=ComplexType)
         self.processor.container.add(complex)
-        self.assertEqual(complex, self.processor.find_dependency(target, attr_type))
+        self.assertEqual(complex, self.processor.find_dependency(attr_type))
 
         simple = ClassFactory.create(name="a", type=SimpleType)
         self.processor.container.add(simple)
-        self.assertEqual(simple, self.processor.find_dependency(target, attr_type))
+        self.assertEqual(simple, self.processor.find_dependency(attr_type))
 
     def test_compare_attributes(self):
         source = ClassFactory.elements(2)

--- a/tests/codegen/models/test_attr_type.py
+++ b/tests/codegen/models/test_attr_type.py
@@ -24,7 +24,7 @@ class AttrTypeTests(FactoryTestCase):
         self.assertEqual(int, attr_type.native_type)
 
     def test_non_native_property(self):
-        attr_type = AttrTypeFactory.create(name="foo")
+        attr_type = AttrTypeFactory.create(qname="foo")
         self.assertIsNone(attr_type.native_name)
         self.assertIsNone(attr_type.native_code)
         self.assertIsNone(attr_type.native_type)

--- a/tests/codegen/test_container.py
+++ b/tests/codegen/test_container.py
@@ -42,11 +42,10 @@ class ClassContainerTests(FactoryTestCase):
         self.container.extend([class_a, class_b, class_c])
 
         self.assertIsNone(self.container.find(QName("nope")))
-        self.assertEqual(class_a, self.container.find(class_a.source_qname()))
-        self.assertEqual(class_b, self.container.find(class_b.source_qname()))
+        self.assertEqual(class_a, self.container.find(class_a.qname))
+        self.assertEqual(class_b, self.container.find(class_b.qname))
         self.assertEqual(
-            class_c,
-            self.container.find(class_b.source_qname(), lambda x: x.is_enumeration),
+            class_c, self.container.find(class_b.qname, lambda x: x.is_enumeration),
         )
         mock_process_class.assert_called_once_with(class_a)
 
@@ -64,6 +63,5 @@ class ClassContainerTests(FactoryTestCase):
         mock_process_class.side_effect = process_class
 
         self.assertEqual(
-            second,
-            self.container.find(first.source_qname(), lambda x: len(x.attrs) == 2),
+            second, self.container.find(first.qname, lambda x: len(x.attrs) == 2),
         )

--- a/tests/codegen/test_resolver.py
+++ b/tests/codegen/test_resolver.py
@@ -67,11 +67,14 @@ class DependenciesResolverTest(FactoryTestCase):
         mock_apply_aliases.assert_has_calls([mock.call(x) for x in expected])
 
     def test_apply_aliases(self):
-        self.resolver.aliases = {QName("d"): "IamD", QName("a"): "IamA"}
-        type_a = AttrTypeFactory.create(name="a")
-        type_b = AttrTypeFactory.create(name="b")
-        type_c = AttrTypeFactory.create(name="c")
-        type_d = AttrTypeFactory.create(name="d")
+        self.resolver.aliases = {
+            QName("xsdata", "d"): "IamD",
+            QName("xsdata", "a"): "IamA",
+        }
+        type_a = AttrTypeFactory.create(qname="a")
+        type_b = AttrTypeFactory.create(qname="b")
+        type_c = AttrTypeFactory.create(qname="c")
+        type_d = AttrTypeFactory.create(qname="d")
 
         obj = ClassFactory.create(
             name="a",
@@ -80,11 +83,9 @@ class DependenciesResolverTest(FactoryTestCase):
                 AttrFactory.create(name="b", types=[type_b]),
                 AttrFactory.create(name="c", types=[type_a, type_d]),
             ],
-            source_namespace=None,
             inner=[
                 ClassFactory.create(
                     name="b",
-                    source_namespace=None,
                     attrs=[
                         AttrFactory.create(name="c", types=[type_c]),
                         AttrFactory.create(name="d", types=[type_d]),
@@ -125,7 +126,7 @@ class DependenciesResolverTest(FactoryTestCase):
             QName("{thug}life"),  # life class exists add alias
             QName("{common}type"),  # type class doesn't exist add just the name
         ]
-        self.resolver.class_map = {class_life.source_qname(): class_life}
+        self.resolver.class_map = {class_life.qname: class_life}
         mock_import_classes.return_value = import_names
         mock_find_package.side_effect = ["first", "second", "third", "forth"]
 
@@ -159,9 +160,9 @@ class DependenciesResolverTest(FactoryTestCase):
 
     def test_find_package(self):
         class_a = ClassFactory.create()
-        self.resolver.packages[class_a.source_qname()] = "foo.bar"
+        self.resolver.packages[class_a.qname] = "foo.bar"
 
-        self.assertEqual("foo.bar", self.resolver.find_package(class_a.source_qname()))
+        self.assertEqual("foo.bar", self.resolver.find_package(class_a.qname))
         with self.assertRaises(ResolverValueError):
             self.resolver.find_package(QName("nope"))
 
@@ -172,7 +173,7 @@ class DependenciesResolverTest(FactoryTestCase):
 
     def test_create_class_map(self):
         classes = [ClassFactory.create(name=name) for name in "ab"]
-        expected = {obj.source_qname(): obj for obj in classes}
+        expected = {obj.qname: obj for obj in classes}
         self.assertEqual(expected, self.resolver.create_class_map(classes))
 
     def test_create_class_map_for_duplicate_classes(self):

--- a/tests/codegen/test_sanitizer.py
+++ b/tests/codegen/test_sanitizer.py
@@ -126,14 +126,14 @@ class ClassSanitizerTest(FactoryTestCase):
                 AttrFactory.create(
                     types=[
                         AttrTypeFactory.create(),
-                        AttrTypeFactory.create(name="foo"),
+                        AttrTypeFactory.create(qname="foo"),
                     ],
                     default="1",
                 ),
                 AttrFactory.create(
                     types=[
                         AttrTypeFactory.create(),
-                        AttrTypeFactory.create(name="bar", forward=True),
+                        AttrTypeFactory.create(qname="bar", forward=True),
                     ],
                     default="2",
                 ),

--- a/tests/codegen/test_transformer.py
+++ b/tests/codegen/test_transformer.py
@@ -17,6 +17,7 @@ from xsdata.models.xsd import Schema
 class SchemaTransformerTests(FactoryTestCase):
     def setUp(self):
         self.transformer = SchemaTransformer(print=True, output="pydata")
+        super().setUp()
 
     @mock.patch("xsdata.codegen.transformer.logger.info")
     @mock.patch.object(CodeWriter, "print")

--- a/tests/codegen/test_validator.py
+++ b/tests/codegen/test_validator.py
@@ -47,7 +47,7 @@ class ClassValidatorTests(FactoryTestCase):
         first = ClassFactory.create(
             extensions=[
                 ExtensionFactory.create(type=AttrTypeFactory.xs_bool()),
-                ExtensionFactory.create(type=AttrTypeFactory.create(name="foo")),
+                ExtensionFactory.create(type=AttrTypeFactory.create(qname="foo")),
             ]
         )
         second = ClassFactory.create(
@@ -125,8 +125,8 @@ class ClassValidatorTests(FactoryTestCase):
         source = ClassFactory.create()
         target = source.clone()
 
-        ext_a = ExtensionFactory.create(type=AttrTypeFactory.create(name=source.name))
-        ext_str = ExtensionFactory.create(type=AttrTypeFactory.create(name="foo"))
+        ext_a = ExtensionFactory.create(type=AttrTypeFactory.create(qname=source.name))
+        ext_str = ExtensionFactory.create(type=AttrTypeFactory.create(qname="foo"))
         target.extensions.append(ext_str)
         target.extensions.append(ext_a)
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -3,6 +3,8 @@ import unittest
 from abc import ABC
 from abc import abstractmethod
 
+from lxml.etree import QName
+
 from xsdata.codegen.models import Attr
 from xsdata.codegen.models import AttrType
 from xsdata.codegen.models import Class
@@ -65,8 +67,8 @@ class ClassFactory(Factory):
     def create(
         cls,
         name=None,
+        qname=None,
         namespace=None,
-        source_namespace="xsdata",
         type=None,
         abstract=False,
         mixed=False,
@@ -86,8 +88,8 @@ class ClassFactory(Factory):
         name = name or f"class_{cls.next_letter()}"
         return cls.model(
             name=name,
+            qname=qname or QName("xsdata", name),
             namespace=namespace,
-            source_namespace=source_namespace,
             abstract=abstract,
             mixed=mixed,
             nillable=nillable,
@@ -185,16 +187,21 @@ class AttrTypeFactory(Factory):
     @classmethod
     def create(
         cls,
-        name=None,
+        qname=None,
         index=None,
         alias=None,
         native=False,
         forward=False,
         circular=False,
     ):
+        if not qname:
+            qname = QName("xsdata", f"attr_{cls.next_letter()}")
+
+        if not isinstance(qname, QName):
+            qname = QName("xsdata", qname)
 
         return cls.model(
-            name=name or f"attr_{cls.next_letter()}",
+            qname=qname,
             index=index or 0,
             alias=alias,
             native=native,
@@ -204,43 +211,53 @@ class AttrTypeFactory(Factory):
 
     @classmethod
     def xs_string(cls):
-        return cls.create(name=DataType.STRING.code, native=True)
+        qname = QName(Namespace.XS.uri, DataType.STRING.code)
+        return cls.create(qname=qname, native=True)
 
     @classmethod
     def xs_int(cls):
-        return cls.create(name=DataType.INTEGER.code, native=True)
+        qname = QName(Namespace.XS.uri, DataType.INTEGER.code)
+        return cls.create(qname=qname, native=True)
 
     @classmethod
     def xs_positive_int(cls):
-        return cls.create(name=DataType.POSITIVE_INTEGER.code, native=True)
+        qname = QName(Namespace.XS.uri, DataType.POSITIVE_INTEGER.code)
+        return cls.create(qname=qname, native=True)
 
     @classmethod
     def xs_float(cls):
-        return cls.create(name=DataType.FLOAT.code, native=True)
+        qname = QName(Namespace.XS.uri, DataType.FLOAT.code)
+        return cls.create(qname=qname, native=True)
 
     @classmethod
     def xs_decimal(cls):
-        return cls.create(name=DataType.DECIMAL.code, native=True)
+        qname = QName(Namespace.XS.uri, DataType.DECIMAL.code)
+        return cls.create(qname=qname, native=True)
 
     @classmethod
     def xs_bool(cls):
-        return cls.create(name=DataType.BOOLEAN.code, native=True)
+        qname = QName(Namespace.XS.uri, DataType.BOOLEAN.code)
+        return cls.create(qname=qname, native=True)
 
     @classmethod
     def xs_any(cls):
-        return cls.create(name=DataType.ANY_TYPE.code, native=True)
+        qname = QName(Namespace.XS.uri, DataType.ANY_TYPE.code)
+        return cls.create(qname=qname, native=True)
 
     @classmethod
     def xs_qmap(cls):
-        return cls.create(name=DataType.QMAP.code, native=True)
+        qname = QName(Namespace.XS.uri, DataType.QMAP.code)
+        return cls.create(qname=qname, native=True)
 
     @classmethod
     def xs_qname(cls):
-        return cls.create(name=DataType.QNAME.code, native=True)
+        qname = QName(Namespace.XS.uri, DataType.QNAME.code)
+        return cls.create(qname=qname, native=True)
 
     @classmethod
     def xs_tokens(cls):
-        return cls.create(name=DataType.NMTOKENS.code, native=True)
+        qname = QName(Namespace.XS.uri, DataType.NMTOKENS.code)
+        return cls.create(qname=qname, native=True)
 
 
 class AttrFactory(Factory):
@@ -300,7 +317,11 @@ class AttrFactory(Factory):
 
     @classmethod
     def attribute_group(cls, **kwargs) -> Attr:
-        return cls.create(tag=Tag.ATTRIBUTE_GROUP, **kwargs)
+        return cls.create(
+            tag=Tag.ATTRIBUTE_GROUP,
+            types=[AttrTypeFactory.create(qname=kwargs.get("name"))],
+            **kwargs,
+        )
 
     @classmethod
     def group(cls, **kwargs) -> Attr:

--- a/tests/formats/dataclass/filters/test_attribute_default.py
+++ b/tests/formats/dataclass/filters/test_attribute_default.py
@@ -59,7 +59,7 @@ class AttributeDefaultTests(TestCase):
 
     def test_attribute_default_with_type_enum(self):
         attr = AttrFactory.create(
-            types=AttrTypeFactory.list(1, name="foo"), default="@enum@foo::bar"
+            types=AttrTypeFactory.list(1, qname="foo"), default="@enum@foo::bar"
         )
         self.assertEqual("Foo.BAR", attribute_default(attr))
 

--- a/tests/formats/dataclass/filters/test_attribute_type.py
+++ b/tests/formats/dataclass/filters/test_attribute_type.py
@@ -8,26 +8,26 @@ from xsdata.formats.dataclass.filters import attribute_type
 class AttributeTypeTests(TestCase):
     def test_attribute_type_with_default_value(self):
         attr = AttrFactory.create(
-            default="foo", types=AttrTypeFactory.list(1, name="foo_bar")
+            default="foo", types=AttrTypeFactory.list(1, qname="foo_bar")
         )
 
         self.assertEqual("FooBar", attribute_type(attr, []))
 
     def test_attribute_type_with_optional_value(self):
-        attr = AttrFactory.create(types=AttrTypeFactory.list(1, name="foo_bar"))
+        attr = AttrFactory.create(types=AttrTypeFactory.list(1, qname="foo_bar"))
 
         self.assertEqual("Optional[FooBar]", attribute_type(attr, []))
 
     def test_attribute_type_with_circularerence(self):
         attr = AttrFactory.create(
-            types=AttrTypeFactory.list(1, name="foo_bar", circular=True)
+            types=AttrTypeFactory.list(1, qname="foo_bar", circular=True)
         )
 
         self.assertEqual('Optional["FooBar"]', attribute_type(attr, ["Parent"]))
 
     def test_attribute_type_with_forwarderence(self):
         attr = AttrFactory.create(
-            types=AttrTypeFactory.list(1, name="foo_bar", forward=True)
+            types=AttrTypeFactory.list(1, qname="foo_bar", forward=True)
         )
         self.assertEqual(
             'Optional["Parent.Inner.FooBar"]', attribute_type(attr, ["Parent", "Inner"])
@@ -35,7 +35,7 @@ class AttributeTypeTests(TestCase):
 
     def test_attribute_type_with_forward_and_circularerence(self):
         attr = AttrFactory.create(
-            types=AttrTypeFactory.list(1, name="foo_bar", forward=True, circular=True)
+            types=AttrTypeFactory.list(1, qname="foo_bar", forward=True, circular=True)
         )
 
         self.assertEqual(
@@ -44,7 +44,7 @@ class AttributeTypeTests(TestCase):
 
     def test_attribute_type_with_list_type(self):
         attr = AttrFactory.create(
-            types=AttrTypeFactory.list(1, name="foo_bar", forward=True)
+            types=AttrTypeFactory.list(1, qname="foo_bar", forward=True)
         )
         attr.restrictions.max_occurs = 2
         self.assertEqual(
@@ -54,7 +54,7 @@ class AttributeTypeTests(TestCase):
     def test_attribute_type_with_alias(self):
         attr = AttrFactory.create(
             types=AttrTypeFactory.list(
-                1, name="foo_bar", forward=True, alias="Boss:Life"
+                1, qname="foo_bar", forward=True, alias="Boss:Life"
             )
         )
         attr.restrictions.max_occurs = 2
@@ -65,9 +65,7 @@ class AttributeTypeTests(TestCase):
     def test_attribute_type_with_multiple_types(self):
         attr = AttrFactory.create(
             types=[
-                AttrTypeFactory.create(
-                    name="thug:life", alias="Boss:Life", forward=True
-                ),
+                AttrTypeFactory.create(qname="life", alias="Boss:Life", forward=True),
                 AttrTypeFactory.xs_int(),
             ]
         )

--- a/tests/formats/dataclass/filters/test_names.py
+++ b/tests/formats/dataclass/filters/test_names.py
@@ -34,5 +34,5 @@ class NameTests(TestCase):
         type_str = AttrTypeFactory.xs_string()
         self.assertEqual("str", type_name(type_str))
 
-        type_foo_bar_bam = AttrTypeFactory.create(name="foo:bar_bam")
+        type_foo_bar_bam = AttrTypeFactory.create(qname="bar_bam")
         self.assertEqual("BarBam", type_name(type_foo_bar_bam))

--- a/tests/formats/dataclass/serializers/test_json.py
+++ b/tests/formats/dataclass/serializers/test_json.py
@@ -1,9 +1,14 @@
+import json
+from decimal import Decimal
 from unittest.case import TestCase
 
 from tests.fixtures.books import BookForm
 from tests.fixtures.books import Books
 from xsdata.formats.dataclass.serializers import DictFactory
 from xsdata.formats.dataclass.serializers import DictSerializer
+from xsdata.formats.dataclass.serializers.json import JsonEncoder
+from xsdata.models.enums import DataType
+from xsdata.models.enums import Namespace
 
 
 class DictSerializerTests(TestCase):
@@ -57,3 +62,13 @@ class DictSerializerTests(TestCase):
             ]
         }
         self.assertEqual(expected, actual)
+
+
+class JsonEncoderTests(TestCase):
+    def test_encode_enum(self):
+        actual = json.dumps({"enum": Namespace.XS}, cls=JsonEncoder)
+        self.assertEqual('{"enum": "http://www.w3.org/2001/XMLSchema"}', actual)
+
+    def test_encode_decimal(self):
+        actual = json.dumps({"decimal": Decimal(10.5)}, cls=JsonEncoder)
+        self.assertEqual('{"decimal": "10.5"}', actual)

--- a/tests/models/elements/test_element.py
+++ b/tests/models/elements/test_element.py
@@ -18,7 +18,10 @@ class ElementTests(TestCase):
 
     def test_property_default_type(self):
         obj = Element()
-        self.assertEqual(DataType.ANY_TYPE, obj.default_type)
+        self.assertEqual("anyType", obj.default_type)
+
+        obj = Element(ns_map={"foo": Namespace.XS.uri})
+        self.assertEqual("foo:anyType", obj.default_type)
 
     def test_property_raw_type(self):
         obj = Element(ns_map={"xs": Namespace.XS.uri})

--- a/tests/models/test_mixins.py
+++ b/tests/models/test_mixins.py
@@ -20,7 +20,10 @@ class ElementBaseTests(TestCase):
 
     def test_property_default_type(self):
         element = ElementBase()
-        self.assertEqual(DataType.STRING, element.default_type)
+        self.assertEqual("string", element.default_type)
+
+        element = ElementBase(ns_map={"xsd": Namespace.XS.uri})
+        self.assertEqual("xsd:string", element.default_type)
 
     def test_property_default_value(self):
         element = ElementBase()

--- a/xsdata/codegen/container.py
+++ b/xsdata/codegen/container.py
@@ -1,4 +1,5 @@
 from collections import UserDict
+from operator import attrgetter
 from operator import methodcaller
 from typing import Callable
 from typing import Dict
@@ -50,7 +51,7 @@ class ClassContainer(UserDict, ContainerInterface):
     @classmethod
     def from_list(cls, items: List[Class]) -> "ClassContainer":
         """Static constructor from a list of classes."""
-        return cls(group_by(items, methodcaller("source_qname")))
+        return cls(group_by(items, attrgetter("qname")))
 
     def iterate(self) -> Iterator[Class]:
         """Create an iterator for the class map values."""
@@ -92,7 +93,7 @@ class ClassContainer(UserDict, ContainerInterface):
 
     def add(self, item: Class):
         """Add class item to the container."""
-        self.data.setdefault(item.source_qname(), []).append(item)
+        self.data.setdefault(item.qname, []).append(item)
 
     def extend(self, items: List[Class]):
         """Add a list of classes the container."""

--- a/xsdata/codegen/handlers/attribute_enum_union.py
+++ b/xsdata/codegen/handlers/attribute_enum_union.py
@@ -30,8 +30,7 @@ class AttributeEnumUnionHandler(HandlerInterface):
             if attr_type.forward:
                 enums.extend(target.inner)
             elif not attr_type.native:
-                qname = target.source_qname(attr_type.name)
-                enums.append(self.container.find(qname))
+                enums.append(self.container.find(attr_type.qname))
             else:
                 enums.append(None)
 

--- a/xsdata/codegen/handlers/attribute_group.py
+++ b/xsdata/codegen/handlers/attribute_group.py
@@ -40,7 +40,7 @@ class AttributeGroupHandler(HandlerInterface):
 
         :raises AnalyzerValueError: if source class is not found.
         """
-        qname = target.source_qname(attr.name)
+        qname = attr.types[0].qname  # group attributes have one type only.
         source = self.container.find(
             qname, condition=lambda x: x.type in (AttributeGroup, Group)
         )

--- a/xsdata/codegen/handlers/attribute_implied.py
+++ b/xsdata/codegen/handlers/attribute_implied.py
@@ -1,8 +1,11 @@
+from lxml.etree import QName
+
 from xsdata.codegen.mixins import HandlerInterface
 from xsdata.codegen.models import Attr
 from xsdata.codegen.models import AttrType
 from xsdata.codegen.models import Class
 from xsdata.models.enums import DataType
+from xsdata.models.enums import Namespace
 from xsdata.models.enums import NamespaceType
 from xsdata.models.enums import Tag
 
@@ -23,7 +26,11 @@ class AttributeImpliedHandler(HandlerInterface):
             name="content",
             local_name="content",
             index=0,
-            types=[AttrType(name=DataType.ANY_TYPE.code, native=True)],
+            types=[
+                AttrType(
+                    qname=QName(Namespace.XS.uri, DataType.ANY_TYPE.code), native=True,
+                )
+            ],
             tag=Tag.ANY,
             namespace=NamespaceType.ANY.value,
         )

--- a/xsdata/codegen/handlers/attribute_mismatch.py
+++ b/xsdata/codegen/handlers/attribute_mismatch.py
@@ -1,3 +1,5 @@
+from lxml.etree import QName
+
 from xsdata.codegen.mixins import HandlerInterface
 from xsdata.codegen.models import AttrType
 from xsdata.codegen.models import Class
@@ -36,6 +38,7 @@ class AttributeMismatchHandler(HandlerInterface):
         if not enum_inner:
             enum_inner = Class(
                 name="value",
+                qname=QName(target.qname.namespace, "value"),
                 type=SimpleType,
                 module=target.module,
                 package=target.package,
@@ -43,7 +46,9 @@ class AttributeMismatchHandler(HandlerInterface):
                 abstract=False,
                 nillable=False,
             )
-            target.attrs[0].types.append(AttrType(name="value", forward=True))
+            target.attrs[0].types.append(
+                AttrType(qname=QName(target.qname.namespace, "value"), forward=True,)
+            )
             target.inner.append(enum_inner)
 
         enum_inner.attrs.extend(enumerations)

--- a/xsdata/codegen/handlers/attribute_type.py
+++ b/xsdata/codegen/handlers/attribute_type.py
@@ -17,6 +17,7 @@ from xsdata.codegen.utils import ClassUtils
 from xsdata.exceptions import AnalyzerValueError
 from xsdata.logger import logger
 from xsdata.models.enums import DataType
+from xsdata.models.enums import Namespace
 from xsdata.utils.collections import unique_sequence
 
 
@@ -61,7 +62,7 @@ class AttributeTypeHandler(HandlerInterface):
         if attr.restrictions.pattern:
             cls.reset_attribute_type(attr_type)
 
-    def find_dependency(self, target: Class, attr_type: AttrType) -> Optional[Class]:
+    def find_dependency(self, attr_type: AttrType) -> Optional[Class]:
         """
         Find dependency for the given attribute.
 
@@ -70,11 +71,10 @@ class AttributeTypeHandler(HandlerInterface):
             2. Non abstract
             3. anything
         """
-        qname = target.source_qname(attr_type.name)
         conditions = (lambda obj: not obj.is_complex, lambda x: not x.abstract, None)
 
         for condition in conditions:
-            result = self.container.find(qname, condition=condition)
+            result = self.container.find(attr_type.qname, condition=condition)
             if result:
                 return result
 
@@ -91,7 +91,7 @@ class AttributeTypeHandler(HandlerInterface):
         Simple stype: the rest
         """
 
-        source = self.find_dependency(target, attr_type)
+        source = self.find_dependency(attr_type)
         if not source:
             logger.warning("Missing type: %s", attr_type.name)
             self.reset_attribute_type(attr_type)
@@ -171,7 +171,7 @@ class AttributeTypeHandler(HandlerInterface):
     @classmethod
     def reset_attribute_type(cls, attr_type: AttrType):
         """Reset the attribute type to native string."""
-        attr_type.name = DataType.STRING.code
+        attr_type.qname = QName(Namespace.XS.uri, DataType.STRING.code)
         attr_type.native = True
         attr_type.circular = False
         attr_type.forward = False

--- a/xsdata/codegen/handlers/class_extension.py
+++ b/xsdata/codegen/handlers/class_extension.py
@@ -60,7 +60,7 @@ class ClassExtensionHandler(HandlerInterface):
 
     def process_dependency_extension(self, target: Class, extension: Extension):
         """User defined type flatten handler."""
-        source = self.find_dependency(target, extension.type)
+        source = self.find_dependency(extension.type)
         if not source:
             logger.warning("Missing extension type: %s", extension.type.name)
             target.extensions.remove(extension)
@@ -116,7 +116,7 @@ class ClassExtensionHandler(HandlerInterface):
         ):
             ClassUtils.copy_attributes(source, target, ext)
 
-    def find_dependency(self, target: Class, attr_type: AttrType) -> Optional[Class]:
+    def find_dependency(self, attr_type: AttrType) -> Optional[Class]:
         """
         Find dependency for the given extension type with priority.
 
@@ -128,9 +128,8 @@ class ClassExtensionHandler(HandlerInterface):
             lambda x: x.type is ComplexType,
         )
 
-        qname = target.source_qname(attr_type.name)
         for condition in conditions:
-            result = self.container.find(qname, condition=condition)
+            result = self.container.find(attr_type.qname, condition=condition)
             if result:
                 return result
 

--- a/xsdata/codegen/parsers/schema.py
+++ b/xsdata/codegen/parsers/schema.py
@@ -92,7 +92,7 @@ class SchemaParser(XmlParser):
     @staticmethod
     def set_namespace_map(element: Element, obj: ElementBase):
         """Add common namespaces like xml, xsi, xlink if they are missing."""
-        obj.ns_map = element.nsmap
+        obj.ns_map = {prefix: uri for prefix, uri in element.nsmap.items() if uri}
         namespaces = obj.ns_map.values()
         for namespace in Namespace:
             if namespace.uri not in namespaces:

--- a/xsdata/codegen/resolver.py
+++ b/xsdata/codegen/resolver.py
@@ -58,8 +58,7 @@ class DependenciesResolver:
         """Walk the attributes tree and set the type aliases."""
         for attr in obj.attrs:
             for attr_type in attr.types:
-                attr_type_qname = obj.source_qname(attr_type.name)
-                attr_type.alias = self.aliases.get(attr_type_qname)
+                attr_type.alias = self.aliases.get(attr_type.qname)
 
         collections.apply(obj.inner, self.apply_aliases)
 
@@ -100,9 +99,7 @@ class DependenciesResolver:
     @staticmethod
     def create_class_list(classes: List[Class]) -> List[str]:
         """Use topology sort to return a flat list for all the dependencies."""
-        return toposort_flatten(
-            {obj.source_qname(): set(obj.dependencies()) for obj in classes}
-        )
+        return toposort_flatten({obj.qname: set(obj.dependencies()) for obj in classes})
 
     @staticmethod
     def create_class_map(classes: List[Class]) -> Dict[QName, Class]:
@@ -110,9 +107,8 @@ class DependenciesResolver:
 
         result: Dict[QName, Class] = {}
         for obj in classes:
-            qname = obj.source_qname()
-            if qname in result:
+            if obj.qname in result:
                 raise ResolverValueError(f"Duplicate class: `{obj.name}`")
-            result[qname] = obj
+            result[obj.qname] = obj
 
         return result

--- a/xsdata/codegen/sanitizer.py
+++ b/xsdata/codegen/sanitizer.py
@@ -4,6 +4,8 @@ from typing import Callable
 from typing import List
 from typing import Optional
 
+from lxml.etree import QName
+
 from xsdata.codegen.container import ClassContainer
 from xsdata.codegen.models import Attr
 from xsdata.codegen.models import AttrType
@@ -124,9 +126,10 @@ class ClassSanitizer:
             for attr_type in attr.types:
                 if attr_type.name == inner.name:
                     attr_type.forward = False
-                    attr_type.name = name
+                    attr_type.qname = QName(inner.qname.namespace, name)
 
         inner.name = name
+        inner.qname = QName(inner.qname.namespace, name)
 
         self.container.add(inner)
 
@@ -253,7 +256,7 @@ class ClassSanitizer:
                 condition=lambda x: x.is_enumeration and x.name == attr_type.name,
             )
 
-        qname = source.source_qname(attr_type.name)
+        qname = attr_type.qname
         return self.container.find(qname, condition=lambda x: x.is_enumeration)
 
     @classmethod

--- a/xsdata/codegen/utils.py
+++ b/xsdata/codegen/utils.py
@@ -1,5 +1,4 @@
 import sys
-from typing import Optional
 
 from xsdata.codegen.models import Attr
 from xsdata.codegen.models import Class
@@ -21,14 +20,13 @@ class ClassUtils:
         The new attributes are prepended in the list unless if they are
         supposed to be last in a sequence.
         """
-        prefix = text.prefix(extension.type.name)
         target.extensions.remove(extension)
         target_attr_names = {text.suffix(attr.name) for attr in target.attrs}
 
         index = 0
         for attr in source.attrs:
             if text.suffix(attr.name) not in target_attr_names:
-                clone = cls.clone_attribute(attr, extension.restrictions, prefix)
+                clone = cls.clone_attribute(attr, extension.restrictions)
 
                 if attr.index == sys.maxsize:
                     target.attrs.append(clone)
@@ -46,10 +44,9 @@ class ClassUtils:
         together."""
         index = target.attrs.index(attr)
         target.attrs.pop(index)
-        prefix = text.prefix(attr.name)
 
         for source_attr in source.attrs:
-            clone = cls.clone_attribute(source_attr, attr.restrictions, prefix)
+            clone = cls.clone_attribute(source_attr, attr.restrictions)
             target.attrs.insert(index, clone)
             index += 1
 
@@ -66,23 +63,11 @@ class ClassUtils:
             target.extensions.append(clone)
 
     @classmethod
-    def clone_attribute(
-        cls, attr: Attr, restrictions: Restrictions, prefix: Optional[str] = None
-    ) -> Attr:
-        """
-        Clone the given attribute and merge its restrictions with the given
-        instance.
-
-        Prepend the given namespace prefix to the attribute name if
-        available.
-        """
+    def clone_attribute(cls, attr: Attr, restrictions: Restrictions) -> Attr:
+        """Clone the given attribute and merge its restrictions with the given
+        instance."""
         clone = attr.clone()
         clone.restrictions.merge(restrictions)
-        if prefix:
-            for attr_type in clone.types:
-                if not attr_type.native and attr_type.name.find(":") == -1:
-                    attr_type.name = f"{prefix}:{attr_type.name}"
-
         return clone
 
     @classmethod

--- a/xsdata/codegen/validator.py
+++ b/xsdata/codegen/validator.py
@@ -53,7 +53,7 @@ class ClassValidator:
             if ext.type.native:
                 return False
 
-            qname = source.source_qname(ext.type.name)
+            qname = ext.type.qname
             return qname not in self.container
 
         for target in list(classes):
@@ -65,7 +65,7 @@ class ClassValidator:
         """Handle classes with same namespace, name that are derived from the
         same xs type."""
 
-        grouped = group_by(classes, lambda x: f"{x.type.__name__}{x.source_qname()}")
+        grouped = group_by(classes, lambda x: f"{x.type.__name__}{x.qname}")
         for items in grouped.values():
             if len(items) == 1:
                 continue

--- a/xsdata/formats/dataclass/generator.py
+++ b/xsdata/formats/dataclass/generator.py
@@ -31,7 +31,7 @@ class DataclassGenerator(AbstractGenerator):
         Group classes into modules and yield an output per module and
         per package __init__.py file.
         """
-        packages = {obj.source_qname(): obj.target_module for obj in classes}
+        packages = {obj.qname: obj.target_module for obj in classes}
         resolver = DependenciesResolver(packages=packages)
 
         # Generate packages
@@ -68,7 +68,7 @@ class DataclassGenerator(AbstractGenerator):
         resolver.process(classes)
         imports = self.group_imports(resolver.sorted_imports())
         output = self.render_classes(resolver.sorted_classes())
-        namespace = classes[0].source_namespace
+        namespace = classes[0].qname.namespace
 
         return self.template("module").render(
             output=output, imports=imports, namespace=namespace

--- a/xsdata/formats/dataclass/parsers/json.py
+++ b/xsdata/formats/dataclass/parsers/json.py
@@ -27,13 +27,9 @@ class JsonParser(AbstractParser, XmlContext):
         """
         Recursively build the given model from the input dict data.
 
-        :raise TypeError: When parsing fails for any reason
+        :raise ParserError: When parsing fails for any reason
         """
         params = {}
-
-        if isinstance(data, list) and len(data) == 1:
-            data = data[0]
-
         for var in self.build(clazz).vars:
             value = self.get_value(data, var)
 

--- a/xsdata/formats/plantuml/generator.py
+++ b/xsdata/formats/plantuml/generator.py
@@ -17,7 +17,7 @@ class PlantUmlGenerator(AbstractGenerator):
 
     def render(self, classes: List[Class]) -> Iterator[GeneratorResult]:
         """Return a iterator of the generated results."""
-        packages = {obj.source_qname(): obj.target_module for obj in classes}
+        packages = {obj.qname: obj.target_module for obj in classes}
         resolver = DependenciesResolver(packages=packages)
 
         for module, cluster in self.group_by_module(classes).items():

--- a/xsdata/models/mixins.py
+++ b/xsdata/models/mixins.py
@@ -38,10 +38,12 @@ class ElementBase:
         return self.__class__.__name__
 
     @property
-    def default_type(self) -> DataType:
+    def default_type(self) -> str:
         """Return the default type if the given element has not specific
         type."""
-        return DataType.STRING
+        prefix = self.schema_prefix()
+        suffix = DataType.STRING.code
+        return f"{prefix}:{suffix}" if prefix else suffix
 
     @property
     def default_value(self) -> Any:

--- a/xsdata/models/xsd.py
+++ b/xsdata/models/xsd.py
@@ -1112,8 +1112,10 @@ class Element(AnnotationBase):
         return self.complex_type.is_mixed if self.complex_type else False
 
     @property
-    def default_type(self) -> DataType:
-        return DataType.ANY_TYPE
+    def default_type(self) -> str:
+        prefix = self.schema_prefix()
+        suffix = DataType.ANY_TYPE.code
+        return f"{prefix}:{suffix}" if prefix else suffix
 
     @property
     def raw_type(self) -> Optional[str]:


### PR DESCRIPTION
Awesome cases @ansFourtyTwo

If the target namespace doesn't match the default namespace in the schema there are some resolving issues when

1. Trying to match attribute types
2. Inner classes that are promoted to root
3. Substitutions groups

They seem easy to tackle but now I have a few test cases that fail in the w3c test suite, nothing major mostly edge cases but still I need to spend some time on this.

But for the `https://www.omg.org/spec/ReqIF/20110401/reqif.xsd` the code generator finishes without errors or major warnings :partying_face: 


```console
Parsing schema reqif.xsd
Parsing schema xsi.xsd
Compiling schema xsi.xsd
Builder: 4 main and 0 inner classes
Parsing schema xml.xsd
Compiling schema xml.xsd
Builder: 5 main and 2 inner classes
Parsing schema driver.xsd
Parsing schema xhtml-datatypes-1.xsd
Compiling schema xhtml-datatypes-1.xsd
Builder: 30 main and 1 inner classes
Parsing schema xhtml-framework-1.xsd
warning: Unassigned parsed object {http://www.w3.org/2001/XMLSchema}annotation
Parsing schema xhtml-attribs-1.xsd
Compiling schema xhtml-attribs-1.xsd
Builder: 12 main and 0 inner classes
Compiling schema xhtml-framework-1.xsd
Parsing schema xhtml-text-1.xsd
Parsing schema xhtml-blkphras-1.xsd
warning: Unassigned parsed object {http://www.w3.org/2001/XMLSchema}annotation
Compiling schema xhtml-blkphras-1.xsd
Builder: 29 main and 0 inner classes
Parsing schema xhtml-blkstruct-1.xsd
Compiling schema xhtml-blkstruct-1.xsd
Builder: 6 main and 0 inner classes
Parsing schema xhtml-inlphras-1.xsd
warning: Unassigned parsed object {http://www.w3.org/2001/XMLSchema}annotation
Compiling schema xhtml-inlphras-1.xsd
Builder: 33 main and 0 inner classes
Parsing schema xhtml-inlstruct-1.xsd
warning: Unassigned parsed object {http://www.w3.org/2001/XMLSchema}annotation
Compiling schema xhtml-inlstruct-1.xsd
Builder: 6 main and 0 inner classes
Compiling schema xhtml-text-1.xsd
Parsing schema xhtml-hypertext-1.xsd
Compiling schema xhtml-hypertext-1.xsd
Builder: 3 main and 0 inner classes
Parsing schema xhtml-list-1.xsd
Compiling schema xhtml-list-1.xsd
Builder: 18 main and 0 inner classes
Parsing schema xhtml-edit-1.xsd
Compiling schema xhtml-edit-1.xsd
Builder: 3 main and 0 inner classes
Parsing schema xhtml-pres-1.xsd
warning: Unassigned parsed object {http://www.w3.org/2001/XMLSchema}annotation
Parsing schema xhtml-blkpres-1.xsd
warning: Unassigned parsed object {http://www.w3.org/2001/XMLSchema}annotation
Compiling schema xhtml-blkpres-1.xsd
Builder: 3 main and 0 inner classes
Parsing schema xhtml-inlpres-1.xsd
warning: Unassigned parsed object {http://www.w3.org/2001/XMLSchema}annotation
Compiling schema xhtml-inlpres-1.xsd
Builder: 3 main and 0 inner classes
Compiling schema xhtml-pres-1.xsd
Parsing schema xhtml-inlstyle-1.xsd
Compiling schema xhtml-inlstyle-1.xsd
Builder: 1 main and 0 inner classes
Parsing schema xhtml-object-1.xsd
warning: Unassigned parsed object {http://www.w3.org/2001/XMLSchema}annotation
Parsing schema xhtml-param-1.xsd
warning: Unassigned parsed object {http://www.w3.org/2001/XMLSchema}annotation
Compiling schema xhtml-param-1.xsd
Builder: 3 main and 1 inner classes
Compiling schema xhtml-object-1.xsd
Builder: 3 main and 1 inner classes
Parsing schema xhtml-table-1.xsd
warning: Unassigned parsed object {http://www.w3.org/2001/XMLSchema}annotation
Compiling schema xhtml-table-1.xsd
Builder: 35 main and 5 inner classes
Compiling schema driver.xsd
Builder: 34 main and 0 inner classes
Compiling schema reqif.xsd
Builder: 41 main and 77 inner classes
Analyzer input: 272 main and 87 inner classes
Analyzer output: 181 main and 98 inner classes
Generating package: init
Generating package: init
Generating package: here.models.xhtml.xhtml_blkphras_1
Generating package: here.models.xhtml.xhtml_blkstruct_1
Generating package: here.models.xhtml.xhtml_inlphras_1
Generating package: here.models.xhtml.xhtml_inlstruct_1
Generating package: here.models.xhtml.xhtml_hypertext_1
Generating package: here.models.xhtml.xhtml_list_1
Generating package: here.models.xhtml.xhtml_edit_1
Generating package: here.models.xhtml.xhtml_blkpres_1
Generating package: here.models.xhtml.xhtml_inlpres_1
Generating package: here.models.xhtml.xhtml_param_1
Generating package: here.models.xhtml.xhtml_object_1
Generating package: here.models.xhtml.xhtml_table_1
Generating package: here.models.reqif
Generating package: here.models.xhtml.xhtml_attribs_1

```

