### PR TITLE
Resolve #206 Introduce --ns-struct to group classes by target namespace

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: tests/fixtures|docs/examples
 
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.6.1
+    rev: v2.7.0
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
@@ -37,12 +37,12 @@ repos:
       - id: docformatter
         args: ["--in-place", "--pre-summary-newline"]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.781
+    rev: v0.782
     hooks:
       - id: mypy
         additional_dependencies: [tokenize-rt]
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.9.0
+    rev: v1.10.0
     hooks:
       - id: setup-cfg-fmt
   - repo: https://github.com/PyCQA/doc8

--- a/docs/codegen.rst
+++ b/docs/codegen.rst
@@ -23,7 +23,7 @@ definitions.
     $ xsdata http://www.gstatic.com/localfeed/local_feed.xsd --package feeds --print
 
 
-Package
+package
 -------
 
 The package option defines where the target module(s) will be created inside the
@@ -34,12 +34,12 @@ If the main xsd has any parent include or import you should adjust the target pa
 .. admonition:: Note
     :class: hint
 
-    The cli is relying on the `os.path.commonpath` to create the package structure and
-    doesn't do any conflict resolution, which shouldn't be an issue if you use the cli
-    with a single source (directory or remote/local file).
+    The cli is relying on the `os.path.commonpath` of the schemas locations to
+    create the final package structure. If you prefer a more flat structure or
+    you have circular import errors check the option :ref:`ns-struct`.
 
 
-Output
+output
 ------
 
 The output option changes the generation format.
@@ -47,18 +47,26 @@ The output option changes the generation format.
 * ``pydata``: Python lib `dataclasses <https://docs.python.org/3/library/dataclasses.html>`_
 * ``plantuml``: `PlantUML <https://plantuml.com/class-diagram>`_ class diagram
 
-Verbosity
+verbosity
 ---------
 
 The verbosity option changes what messages will be printed.
 
 Available options: ``CRITICAL``, ``ERROR``, ``WARNING``, ``INFO`` or ``DEBUG``
 
-Print
+print
 -----
 
 The print flag overwrites the verbosity level to `Error` and print to stdOut the output
 result without writing to the target file.
+
+
+ns-struct
+---------
+
+The ns-struct flag bypasses the default behavior and groups classes by the target
+namespace they were defined. This option creates a more flat package structure and
+solves any circular import errors.
 
 
 .. admonition:: Examples

--- a/tests/codegen/handlers/test_attribute_group.py
+++ b/tests/codegen/handlers/test_attribute_group.py
@@ -47,8 +47,8 @@ class AttributeGroupHandlerTests(FactoryTestCase):
 
     @mock.patch.object(ClassUtils, "copy_group_attributes")
     def test_process_attribute_with_group(self, mock_copy_group_attributes):
-        complex_bar = ClassFactory.create(type=ComplexType, name="bar")
-        group_bar = ClassFactory.create(type=Group, name="bar")
+        complex_bar = ClassFactory.create(qname="bar", type=ComplexType)
+        group_bar = ClassFactory.create(qname="bar", type=Group)
         group_attr = AttrFactory.attribute_group(name="bar")
         target = ClassFactory.create()
         target.attrs.append(group_attr)
@@ -64,8 +64,8 @@ class AttributeGroupHandlerTests(FactoryTestCase):
 
     @mock.patch.object(ClassUtils, "copy_group_attributes")
     def test_process_attribute_with_attribute_group(self, mock_copy_group_attributes):
-        complex_bar = ClassFactory.create(type=ComplexType, name="bar")
-        group_bar = ClassFactory.create(type=AttributeGroup, name="bar")
+        complex_bar = ClassFactory.create(qname="bar", type=ComplexType)
+        group_bar = ClassFactory.create(qname="bar", type=AttributeGroup)
         group_attr = AttrFactory.attribute_group(name="bar")
         target = ClassFactory.create()
         target.attrs.append(group_attr)
@@ -81,7 +81,7 @@ class AttributeGroupHandlerTests(FactoryTestCase):
 
     def test_process_attribute_with_circular_reference(self):
         group_attr = AttrFactory.attribute_group(name="bar")
-        target = ClassFactory.create(name="bar", type=Group)
+        target = ClassFactory.create(qname="bar", type=Group)
         target.attrs.append(group_attr)
 
         target.status = Status.PROCESSING

--- a/tests/codegen/handlers/test_attribute_substitution.py
+++ b/tests/codegen/handlers/test_attribute_substitution.py
@@ -9,7 +9,6 @@ from tests.factories import FactoryTestCase
 from xsdata.codegen.container import ClassContainer
 from xsdata.codegen.handlers import AttributeSubstitutionHandler
 from xsdata.codegen.models import AttrType
-from xsdata.codegen.utils import ClassUtils
 
 
 class AttributeSubstitutionHandlerTests(FactoryTestCase):

--- a/tests/codegen/handlers/test_attribute_substitution.py
+++ b/tests/codegen/handlers/test_attribute_substitution.py
@@ -96,7 +96,7 @@ class AttributeSubstitutionHandlerTests(FactoryTestCase):
         )
 
     def test_create_substitution(self):
-        item = ClassFactory.elements(1, name="bar", qname=QName("foo", "bar"))
+        item = ClassFactory.elements(1, qname=QName("foo", "bar"))
         actual = self.processor.create_substitution(item)
 
         expected = AttrFactory.create(

--- a/tests/codegen/handlers/test_attribute_type.py
+++ b/tests/codegen/handlers/test_attribute_type.py
@@ -161,7 +161,7 @@ class AttributeTypeHandlerTests(FactoryTestCase):
 
     @mock.patch.object(ClassUtils, "copy_inner_classes")
     def test_process_simple_dependency(self, mock_copy_inner_classes):
-        source = ClassFactory.elements(1, name="Foobar")
+        source = ClassFactory.elements(1, qname="Foobar")
         source.attrs[0].restrictions.max_length = 100
         source.attrs[0].restrictions.min_length = 1
 
@@ -270,15 +270,15 @@ class AttributeTypeHandlerTests(FactoryTestCase):
 
         self.assertIsNone(self.processor.find_dependency(attr_type))
 
-        abstract = ClassFactory.create(name="a", type=ComplexType, abstract=True)
+        abstract = ClassFactory.create(qname="a", type=ComplexType, abstract=True)
         self.processor.container.add(abstract)
         self.assertEqual(abstract, self.processor.find_dependency(attr_type))
 
-        element = ClassFactory.create(name="a", type=Element)
+        element = ClassFactory.create(qname="a", type=Element)
         self.processor.container.add(element)
         self.assertEqual(element, self.processor.find_dependency(attr_type))
 
-        simple = ClassFactory.create(name="a", type=SimpleType)
+        simple = ClassFactory.create(qname="a", type=SimpleType)
         self.processor.container.add(simple)
         self.assertEqual(simple, self.processor.find_dependency(attr_type))
 

--- a/tests/codegen/handlers/test_class_extension.py
+++ b/tests/codegen/handlers/test_class_extension.py
@@ -289,11 +289,11 @@ class ClassExtensionHandlerTests(FactoryTestCase):
 
         self.assertIsNone(self.processor.find_dependency(attr_type))
 
-        complex = ClassFactory.create(name="a", type=ComplexType)
+        complex = ClassFactory.create(qname="a", type=ComplexType)
         self.processor.container.add(complex)
         self.assertEqual(complex, self.processor.find_dependency(attr_type))
 
-        simple = ClassFactory.create(name="a", type=SimpleType)
+        simple = ClassFactory.create(qname="a", type=SimpleType)
         self.processor.container.add(simple)
         self.assertEqual(simple, self.processor.find_dependency(attr_type))
 

--- a/tests/codegen/mappers/test_schema.py
+++ b/tests/codegen/mappers/test_schema.py
@@ -12,7 +12,6 @@ from tests.factories import FactoryTestCase
 from xsdata.codegen.mappers.schema import SchemaMapper
 from xsdata.codegen.models import Class
 from xsdata.codegen.models import Restrictions
-from xsdata.models.enums import DataType
 from xsdata.models.enums import FormType
 from xsdata.models.enums import Tag
 from xsdata.models.xsd import Alternative
@@ -147,7 +146,6 @@ class SchemaMapperTests(FactoryTestCase):
         mock_element_namespace.assert_called_once_with(element, "target_ns")
 
         expected = ClassFactory.create(
-            name="name",
             qname=QName("target_ns", "name"),
             type=Element,
             help="sos",
@@ -308,7 +306,7 @@ class SchemaMapperTests(FactoryTestCase):
     def test_build_class_attribute_types_when_obj_has_inner_class(
         self, mock_build_inner_classes, mock_real_type
     ):
-        inner_class = ClassFactory.create(name="foo")
+        inner_class = ClassFactory.create(qname="foo")
         mock_real_type.return_value = " xs:integer  xs:string "
         mock_build_inner_classes.return_value = [inner_class]
 

--- a/tests/codegen/models/test_attr.py
+++ b/tests/codegen/models/test_attr.py
@@ -88,9 +88,6 @@ class AttrTests(FactoryTestCase):
         attr.namespace = Namespace.XSI.value
         self.assertFalse(attr.is_xsi_type)
 
-        attr.name = "xsi:type"
-        self.assertTrue(attr.is_xsi_type)
-
         attr.name = "type"
         self.assertTrue(attr.is_xsi_type)
 

--- a/tests/codegen/test_container.py
+++ b/tests/codegen/test_container.py
@@ -19,9 +19,9 @@ class ClassContainerTests(FactoryTestCase):
 
     def test_from_list(self):
         classes = [
-            ClassFactory.create(type=Element, name="foo"),
-            ClassFactory.create(type=ComplexType, name="foo"),
-            ClassFactory.create(type=ComplexType, name="foobar"),
+            ClassFactory.create(qname="foo", type=Element),
+            ClassFactory.create(qname="foo", type=ComplexType),
+            ClassFactory.create(qname="foobar", type=ComplexType),
         ]
         container = ClassContainer.from_list(classes)
 
@@ -35,9 +35,9 @@ class ClassContainerTests(FactoryTestCase):
 
     @mock.patch.object(ClassContainer, "process_class")
     def test_find(self, mock_process_class):
-        class_a = ClassFactory.create(name="a")
-        class_b = ClassFactory.create(name="b", status=Status.PROCESSED)
-        class_c = ClassFactory.enumeration(2, name="b", status=Status.PROCESSING)
+        class_a = ClassFactory.create(qname="a")
+        class_b = ClassFactory.create(qname="b", status=Status.PROCESSED)
+        class_c = ClassFactory.enumeration(2, qname="b", status=Status.PROCESSING)
 
         self.container.extend([class_a, class_b, class_c])
 
@@ -51,8 +51,8 @@ class ClassContainerTests(FactoryTestCase):
 
     @mock.patch.object(ClassContainer, "process_class")
     def test_find_repeat_on_condition_and_not_processed(self, mock_process_class):
-        first = ClassFactory.elements(2, name="a")
-        second = ClassFactory.elements(2, name="a")
+        first = ClassFactory.elements(2, qname="a")
+        second = ClassFactory.elements(2, qname="a")
         self.container.extend([first, second])
 
         def process_class(x: Class):

--- a/tests/codegen/test_resolver.py
+++ b/tests/codegen/test_resolver.py
@@ -58,7 +58,7 @@ class DependenciesResolverTest(FactoryTestCase):
         mock_apply_aliases.side_effect = lambda x: x
 
         self.resolver.class_list = ["a", "b", "c", "d"]
-        self.resolver.class_map = {x: ClassFactory.create(name=x) for x in "ca"}
+        self.resolver.class_map = {x: ClassFactory.create(qname=x) for x in "ca"}
 
         result = self.resolver.sorted_classes()
         expected = [self.resolver.class_map[x] for x in "ac"]
@@ -77,7 +77,7 @@ class DependenciesResolverTest(FactoryTestCase):
         type_d = AttrTypeFactory.create(qname="d")
 
         obj = ClassFactory.create(
-            name="a",
+            qname="a",
             attrs=[
                 AttrFactory.create(name="a", types=[type_a]),
                 AttrFactory.create(name="b", types=[type_b]),
@@ -85,7 +85,7 @@ class DependenciesResolverTest(FactoryTestCase):
             ],
             inner=[
                 ClassFactory.create(
-                    name="b",
+                    qname="b",
                     attrs=[
                         AttrFactory.create(name="c", types=[type_c]),
                         AttrFactory.create(name="d", types=[type_d]),
@@ -119,7 +119,7 @@ class DependenciesResolverTest(FactoryTestCase):
     def test_resolve_imports(
         self, mock_import_classes, mock_find_package, mock_add_import
     ):
-        class_life = ClassFactory.create(name="life")
+        class_life = ClassFactory.create(qname="life")
         import_names = [
             QName("foo"),  # cool
             QName("bar"),  # cool
@@ -172,12 +172,12 @@ class DependenciesResolverTest(FactoryTestCase):
         self.assertEqual(["a", "c", "e", "f"], self.resolver.import_classes())
 
     def test_create_class_map(self):
-        classes = [ClassFactory.create(name=name) for name in "ab"]
+        classes = [ClassFactory.create(qname=name) for name in "ab"]
         expected = {obj.qname: obj for obj in classes}
         self.assertEqual(expected, self.resolver.create_class_map(classes))
 
     def test_create_class_map_for_duplicate_classes(self):
-        classes = ClassFactory.list(2, name="a")
+        classes = ClassFactory.list(2, qname="a")
         with self.assertRaises(ResolverValueError) as cm:
             self.resolver.create_class_map(classes)
 

--- a/tests/codegen/test_sanitizer.py
+++ b/tests/codegen/test_sanitizer.py
@@ -85,7 +85,7 @@ class ClassSanitizerTest(FactoryTestCase):
     def test_process_attribute_default_with_xsi_type(self):
         target = ClassFactory.create()
         attr = AttrFactory.create(
-            fixed=True, default=2, name="xsi:type", namespace=Namespace.XSI.uri
+            fixed=True, default=2, name="type", namespace=Namespace.XSI.uri
         )
         self.sanitizer.process_attribute_default(target, attr)
         self.assertFalse(attr.fixed)
@@ -217,7 +217,7 @@ class ClassSanitizerTest(FactoryTestCase):
             self.assertEqual(expected[idx], res.asdict())
 
     def test_process_attribute_name(self):
-        attr = AttrFactory.create(name="foo:a")
+        attr = AttrFactory.create(name="a")
 
         self.sanitizer.process_attribute_name(attr)
         self.assertEqual("a", attr.name)

--- a/tests/codegen/test_sanitizer.py
+++ b/tests/codegen/test_sanitizer.py
@@ -104,13 +104,13 @@ class ClassSanitizerTest(FactoryTestCase):
     def test_process_attribute_default_enum(
         self, mock_find_enum, mock_promote_inner_class, mock_logger_warning
     ):
-        enum_one = ClassFactory.enumeration(1, name="root")
+        enum_one = ClassFactory.enumeration(1, qname="root")
         enum_one.attrs[0].default = "1"
         enum_one.attrs[0].name = "one"
-        enum_two = ClassFactory.enumeration(1, name="inner")
+        enum_two = ClassFactory.enumeration(1, qname="inner")
         enum_two.attrs[0].default = "2"
         enum_two.attrs[0].name = "two"
-        enum_three = ClassFactory.enumeration(1, name="missing_member")
+        enum_three = ClassFactory.enumeration(1, qname="missing_member")
 
         mock_find_enum.side_effect = [
             None,
@@ -121,7 +121,7 @@ class ClassSanitizerTest(FactoryTestCase):
         ]
 
         target = ClassFactory.create(
-            name="target",
+            qname="target",
             attrs=[
                 AttrFactory.create(
                     types=[
@@ -161,8 +161,8 @@ class ClassSanitizerTest(FactoryTestCase):
         missing_external = AttrTypeFactory.create("bar")
         matching_inner = AttrTypeFactory.create("foobar", forward=True)
         missing_inner = AttrTypeFactory.create("barfoo", forward=True)
-        enumeration = ClassFactory.enumeration(1, name="foo")
-        inner = ClassFactory.enumeration(1, name="foobar")
+        enumeration = ClassFactory.enumeration(1, qname="foo")
+        inner = ClassFactory.enumeration(1, qname="foobar")
 
         target = ClassFactory.create(
             attrs=[
@@ -313,7 +313,7 @@ class ClassSanitizerTest(FactoryTestCase):
         self.assertEqual(1, len_sequential(target))
 
     def test_find_inner(self):
-        inner_a = ClassFactory.create(name="a")
+        inner_a = ClassFactory.create(qname="a")
         inner_b = ClassFactory.enumeration(2)
         target = ClassFactory.create(inner=[inner_a, inner_b])
 

--- a/tests/codegen/test_transformer.py
+++ b/tests/codegen/test_transformer.py
@@ -16,7 +16,9 @@ from xsdata.models.xsd import Schema
 
 class SchemaTransformerTests(FactoryTestCase):
     def setUp(self):
-        self.transformer = SchemaTransformer(print=True, output="pydata")
+        self.transformer = SchemaTransformer(
+            print=True, output="pydata", ns_struct=False
+        )
         super().setUp()
 
     @mock.patch("xsdata.codegen.transformer.logger.info")
@@ -50,7 +52,9 @@ class SchemaTransformerTests(FactoryTestCase):
         mock_process_schema.assert_has_calls(list(map(mock.call, urls)))
         mock_assign_packages.assert_called_once_with(package)
         mock_analyze_classes.assert_called_once_with(schema_classes)
-        mock_writer_designate.assert_called_once_with(analyzer_classes, "pydata")
+        mock_writer_designate.assert_called_once_with(
+            analyzer_classes, "pydata", package, self.transformer.ns_struct
+        )
         mock_writer_print.assert_called_once_with(analyzer_classes, "pydata")
         mock_logger_into.assert_has_calls(
             [
@@ -91,7 +95,9 @@ class SchemaTransformerTests(FactoryTestCase):
         mock_process_schema.assert_has_calls(list(map(mock.call, urls)))
         mock_assign_packages.assert_called_once_with(package)
         mock_analyze_classes.assert_called_once_with(schema_classes)
-        mock_writer_designate.assert_called_once_with(analyzer_classes, "pydata")
+        mock_writer_designate.assert_called_once_with(
+            analyzer_classes, "pydata", package, self.transformer.ns_struct
+        )
         mock_writer_write.assert_called_once_with(analyzer_classes, "pydata")
         mock_logger_into.assert_has_calls(
             [

--- a/tests/codegen/test_validator.py
+++ b/tests/codegen/test_validator.py
@@ -101,9 +101,9 @@ class ClassValidatorTests(FactoryTestCase):
         )
 
     def test_mark_strict_types(self):
-        one = ClassFactory.create(name="foo", type=Element)
-        two = ClassFactory.create(name="foo", type=ComplexType)
-        three = ClassFactory.create(name="foo", type=SimpleType)
+        one = ClassFactory.create(qname="foo", type=Element)
+        two = ClassFactory.create(qname="foo", type=ComplexType)
+        three = ClassFactory.create(qname="foo", type=SimpleType)
 
         self.validator.mark_strict_types([one, two, three])
 
@@ -111,8 +111,8 @@ class ClassValidatorTests(FactoryTestCase):
         self.assertTrue(two.strict_type)  # Marked as abstract
         self.assertFalse(three.strict_type)  # Is common
 
-        four = ClassFactory.create(name="bar", type=Attribute)
-        five = ClassFactory.create(name="bar", type=AttributeGroup)
+        four = ClassFactory.create(qname="bar", type=Attribute)
+        five = ClassFactory.create(qname="bar", type=AttributeGroup)
         self.validator.mark_strict_types([four, five])
         self.assertFalse(four.strict_type)  # No element in group
         self.assertFalse(five.strict_type)  # No element in group

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -66,7 +66,6 @@ class ClassFactory(Factory):
     @classmethod
     def create(
         cls,
-        name=None,
         qname=None,
         namespace=None,
         type=None,
@@ -85,10 +84,14 @@ class ClassFactory(Factory):
         status=Status.RAW,
         container=None,
     ):
-        name = name or f"class_{cls.next_letter()}"
+        if not qname:
+            qname = QName("xsdata", f"class_{cls.next_letter()}")
+
+        if not isinstance(qname, QName):
+            qname = QName("xsdata", qname)
+
         return cls.model(
-            name=name,
-            qname=qname or QName("xsdata", name),
+            qname=qname,
             namespace=namespace,
             abstract=abstract,
             mixed=mixed,

--- a/tests/fixtures/common/models/hl7_v3/ne2008/coreschemas/datatypes.py
+++ b/tests/fixtures/common/models/hl7_v3/ne2008/coreschemas/datatypes.py
@@ -732,7 +732,6 @@ class IvlInt(SxcmInt):
                                two of the three properties high, low, and width need
                                to be stated and the third can be derived.
     :ivar high: The high limit of the interval.
-    :ivar hl7_org_v3_high:
     :ivar center: The arithmetic mean of the interval (low plus high
                                divided by 2). The purpose of distinguishing the center
                                as a semantic property is for conversions of intervals
@@ -765,16 +764,8 @@ class IvlInt(SxcmInt):
             type="Element",
             namespace="urn:hl7-org:v3",
             min_occurs=0,
-            max_occurs=2,
+            max_occurs=3,
             sequential=True
-        )
-    )
-    hl7_org_v3_high: Optional[IvxbInt] = field(
-        default=None,
-        metadata=dict(
-            name="high",
-            type="Element",
-            namespace="urn:hl7-org:v3"
         )
     )
     center: Optional[IntType] = field(
@@ -798,7 +789,6 @@ class IvlMo(SxcmMo):
                                two of the three properties high, low, and width need
                                to be stated and the third can be derived.
     :ivar high: The high limit of the interval.
-    :ivar hl7_org_v3_high:
     :ivar center: The arithmetic mean of the interval (low plus high
                                divided by 2). The purpose of distinguishing the center
                                as a semantic property is for conversions of intervals
@@ -831,16 +821,8 @@ class IvlMo(SxcmMo):
             type="Element",
             namespace="urn:hl7-org:v3",
             min_occurs=0,
-            max_occurs=2,
+            max_occurs=3,
             sequential=True
-        )
-    )
-    hl7_org_v3_high: Optional[IvxbMo] = field(
-        default=None,
-        metadata=dict(
-            name="high",
-            type="Element",
-            namespace="urn:hl7-org:v3"
         )
     )
     center: Optional[Mo] = field(
@@ -864,7 +846,6 @@ class IvlPq(SxcmPq):
                                two of the three properties high, low, and width need
                                to be stated and the third can be derived.
     :ivar high: The high limit of the interval.
-    :ivar hl7_org_v3_high:
     :ivar center: The arithmetic mean of the interval (low plus high
                                divided by 2). The purpose of distinguishing the center
                                as a semantic property is for conversions of intervals
@@ -897,16 +878,8 @@ class IvlPq(SxcmPq):
             type="Element",
             namespace="urn:hl7-org:v3",
             min_occurs=0,
-            max_occurs=2,
+            max_occurs=3,
             sequential=True
-        )
-    )
-    hl7_org_v3_high: Optional[IvxbPq] = field(
-        default=None,
-        metadata=dict(
-            name="high",
-            type="Element",
-            namespace="urn:hl7-org:v3"
         )
     )
     center: Optional[Pq] = field(
@@ -930,7 +903,6 @@ class IvlReal(SxcmReal):
                                two of the three properties high, low, and width need
                                to be stated and the third can be derived.
     :ivar high: The high limit of the interval.
-    :ivar hl7_org_v3_high:
     :ivar center: The arithmetic mean of the interval (low plus high
                                divided by 2). The purpose of distinguishing the center
                                as a semantic property is for conversions of intervals
@@ -963,16 +935,8 @@ class IvlReal(SxcmReal):
             type="Element",
             namespace="urn:hl7-org:v3",
             min_occurs=0,
-            max_occurs=2,
+            max_occurs=3,
             sequential=True
-        )
-    )
-    hl7_org_v3_high: Optional[IvxbReal] = field(
-        default=None,
-        metadata=dict(
-            name="high",
-            type="Element",
-            namespace="urn:hl7-org:v3"
         )
     )
     center: Optional[Real] = field(
@@ -1129,7 +1093,6 @@ class IvlPpdPq(SxcmPpdPq):
                                two of the three properties high, low, and width need
                                to be stated and the third can be derived.
     :ivar high: The high limit of the interval.
-    :ivar hl7_org_v3_high:
     :ivar center: The arithmetic mean of the interval (low plus high
                                divided by 2). The purpose of distinguishing the center
                                as a semantic property is for conversions of intervals
@@ -1162,16 +1125,8 @@ class IvlPpdPq(SxcmPpdPq):
             type="Element",
             namespace="urn:hl7-org:v3",
             min_occurs=0,
-            max_occurs=2,
+            max_occurs=3,
             sequential=True
-        )
-    )
-    hl7_org_v3_high: Optional[IvxbPpdPq] = field(
-        default=None,
-        metadata=dict(
-            name="high",
-            type="Element",
-            namespace="urn:hl7-org:v3"
         )
     )
     center: Optional[PpdPq] = field(
@@ -1195,7 +1150,6 @@ class IvlPpdTs(SxcmPpdTs):
                                two of the three properties high, low, and width need
                                to be stated and the third can be derived.
     :ivar high: The high limit of the interval.
-    :ivar hl7_org_v3_high:
     :ivar center: The arithmetic mean of the interval (low plus high
                                divided by 2). The purpose of distinguishing the center
                                as a semantic property is for conversions of intervals
@@ -1228,16 +1182,8 @@ class IvlPpdTs(SxcmPpdTs):
             type="Element",
             namespace="urn:hl7-org:v3",
             min_occurs=0,
-            max_occurs=2,
+            max_occurs=3,
             sequential=True
-        )
-    )
-    hl7_org_v3_high: Optional[IvxbPpdTs] = field(
-        default=None,
-        metadata=dict(
-            name="high",
-            type="Element",
-            namespace="urn:hl7-org:v3"
         )
     )
     center: Optional[PpdTs] = field(

--- a/tests/fixtures/common/models/hl7_v3/ne2008/coreschemas/datatypes_base.py
+++ b/tests/fixtures/common/models/hl7_v3/ne2008/coreschemas/datatypes_base.py
@@ -3990,13 +3990,6 @@ class IvlTsExplicit:
                                     two of the three properties high, low, and width need
                                     to be stated and the third can be derived.
     :ivar high: The high limit of the interval.
-    :ivar hl7_org_v3_high:
-    :ivar hl7_org_v3_width: The difference between high and low boundary. The
-                                purpose of distinguishing a width property is to
-                                handle all cases of incomplete information
-                                symmetrically. In any interval representation only
-                                two of the three properties high, low, and width need
-                                to be stated and the third can be derived.
     :ivar center: The arithmetic mean of the interval (low plus high
                                 divided by 2). The purpose of distinguishing the center
                                 as a semantic property is for conversions of intervals
@@ -4021,11 +4014,14 @@ class IvlTsExplicit:
             required=True
         )
     )
-    width: Optional[PqExplicit] = field(
-        default=None,
+    width: List[PqExplicit] = field(
+        default_factory=list,
         metadata=dict(
             type="Element",
-            namespace="urn:hl7-org:v3"
+            namespace="urn:hl7-org:v3",
+            min_occurs=0,
+            max_occurs=3,
+            sequential=True
         )
     )
     high: List[IvxbTsExplicit] = field(
@@ -4034,25 +4030,8 @@ class IvlTsExplicit:
             type="Element",
             namespace="urn:hl7-org:v3",
             min_occurs=0,
-            max_occurs=2
-        )
-    )
-    hl7_org_v3_high: Optional[IvxbTsExplicit] = field(
-        default=None,
-        metadata=dict(
-            name="high",
-            type="Element",
-            namespace="urn:hl7-org:v3"
-        )
-    )
-    hl7_org_v3_width: List[PqExplicit] = field(
-        default_factory=list,
-        metadata=dict(
-            name="width",
-            type="Element",
-            namespace="urn:hl7-org:v3",
-            min_occurs=0,
-            max_occurs=2
+            max_occurs=3,
+            sequential=True
         )
     )
     center: Optional[TsExplicit] = field(
@@ -5458,7 +5437,6 @@ class IvlTs(SxcmTs):
                                two of the three properties high, low, and width need
                                to be stated and the third can be derived.
     :ivar high: The high limit of the interval.
-    :ivar hl7_org_v3_high:
     :ivar center: The arithmetic mean of the interval (low plus high
                                divided by 2). The purpose of distinguishing the center
                                as a semantic property is for conversions of intervals
@@ -5491,16 +5469,8 @@ class IvlTs(SxcmTs):
             type="Element",
             namespace="urn:hl7-org:v3",
             min_occurs=0,
-            max_occurs=2,
+            max_occurs=3,
             sequential=True
-        )
-    )
-    hl7_org_v3_high: Optional[IvxbTs] = field(
-        default=None,
-        metadata=dict(
-            name="high",
-            type="Element",
-            namespace="urn:hl7-org:v3"
         )
     )
     center: Optional[Ts] = field(

--- a/tests/fixtures/defxmlschema/chapter12.json
+++ b/tests/fixtures/defxmlschema/chapter12.json
@@ -16,7 +16,7 @@
             ],
             "description": [
                 {
-                    "www_w3_org_1999_xhtml_element": [
+                    "w3_org_1999_xhtml_element": [
                         "This shirt is the",
                         {
                             "qname": "{http://www.w3.org/1999/xhtml}b",

--- a/tests/fixtures/defxmlschema/chapter12.py
+++ b/tests/fixtures/defxmlschema/chapter12.py
@@ -19,9 +19,9 @@ class ColorType:
 @dataclass
 class DescriptionType:
     """
-    :ivar www_w3_org_1999_xhtml_element:
+    :ivar w3_org_1999_xhtml_element:
     """
-    www_w3_org_1999_xhtml_element: List[object] = field(
+    w3_org_1999_xhtml_element: List[object] = field(
         default_factory=list,
         metadata=dict(
             type="Wildcard",

--- a/tests/formats/dataclass/filters/test_names.py
+++ b/tests/formats/dataclass/filters/test_names.py
@@ -16,7 +16,7 @@ class NameTests(TestCase):
 
     def test_attribute_name(self):
         self.assertEqual("foo", attribute_name("foo"))
-        self.assertEqual("bar", attribute_name("foo:bar"))
+        self.assertEqual("foo_bar", attribute_name("foo:bar"))
         self.assertEqual("foo_bar", attribute_name("FooBar"))
         self.assertEqual("none_value", attribute_name("None"))
         self.assertEqual("br_eak_value", attribute_name("BrEak"))

--- a/tests/formats/dataclass/test_generator.py
+++ b/tests/formats/dataclass/test_generator.py
@@ -105,6 +105,7 @@ class DataclassGeneratorTests(FactoryTestCase):
         self.assertEqual("mod_1111", DataclassGenerator.module_name("1111"))
         self.assertEqual("xs_string", DataclassGenerator.module_name("xs:string"))
         self.assertEqual("foo_bar_bam", DataclassGenerator.module_name("foo:bar_bam"))
+        self.assertEqual("bar_bam", DataclassGenerator.module_name("urn:bar_bam"))
 
     def test_package_name(self):
         self.assertEqual(

--- a/tests/models/elements/test_any.py
+++ b/tests/models/elements/test_any.py
@@ -31,9 +31,11 @@ class AnyTests(TestCase):
         obj.namespace = "foo"
         self.assertEqual("foo_element", obj.real_name)
 
-        obj.namespace = None
-        with self.assertRaises(SchemaValueError):
-            obj.real_name
+        obj.namespace = "http://www.xsdata.com/somewhere.xsd"
+        self.assertEqual("xsdata_com/somewhere_element", obj.real_name)
+
+        obj.namespace = "http://foo http://bar"
+        self.assertEqual("foo_bar_element", obj.real_name)
 
     def test_get_restrictions(self):
         obj = Any(min_occurs=1, max_occurs=2)

--- a/tests/models/elements/test_any_attribute.py
+++ b/tests/models/elements/test_any_attribute.py
@@ -28,9 +28,11 @@ class AnyAttributeTests(TestCase):
         obj.namespace = "foo"
         self.assertEqual("foo_attributes", obj.real_name)
 
-        obj.namespace = None
-        with self.assertRaises(SchemaValueError):
-            obj.real_name
+        obj.namespace = "http://www.xsdata.com/somewhere.xsd"
+        self.assertEqual("xsdata_com/somewhere_attributes", obj.real_name)
+
+        obj.namespace = "http://foo http://bar"
+        self.assertEqual("foo_bar_attributes", obj.real_name)
 
     def test_property_real_type(self):
         obj = AnyAttribute(ns_map={"xs": Namespace.XS.uri})

--- a/tests/models/test_mixins.py
+++ b/tests/models/test_mixins.py
@@ -151,10 +151,10 @@ class ElementBaseTests(TestCase):
         with self.assertRaises(SchemaValueError):
             element.real_name
 
-        element.ref = "foo"
+        element.ref = "bar:foo"
         self.assertEqual("foo", element.real_name)
 
-        element.name = "bar"
+        element.name = "foo:bar"
         self.assertEqual("bar", element.real_name)
 
     def test_property_real_type(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,7 +27,7 @@ class CliTests(TestCase):
         source = fixtures.joinpath("chapter03.xsd")
         result = self.runner.invoke(cli, [str(source), "--package", "foo"])
         self.assertIsNone(result.exception)
-        mock_init.assert_called_once_with(output="pydata", print=False)
+        mock_init.assert_called_once_with(output="pydata", print=False, ns_struct=False)
 
         self.assertEqual([source.as_uri()], mock_process.call_args[0][0])
         self.assertEqual("foo", mock_process.call_args[0][1])
@@ -43,7 +43,9 @@ class CliTests(TestCase):
         self.assertEqual([source.as_uri()], mock_process.call_args[0][0])
         self.assertEqual("foo", mock_process.call_args[0][1])
 
-        mock_init.assert_called_once_with(output="plantuml", print=False)
+        mock_init.assert_called_once_with(
+            output="plantuml", print=False, ns_struct=False
+        )
 
     @mock.patch.object(SchemaTransformer, "process")
     @mock.patch.object(SchemaTransformer, "__init__", return_value=None)
@@ -56,7 +58,21 @@ class CliTests(TestCase):
         self.assertEqual("foo", mock_process.call_args[0][1])
         self.assertEqual(logging.ERROR, logger.getEffectiveLevel())
 
-        mock_init.assert_called_once_with(output="pydata", print=True)
+        mock_init.assert_called_once_with(output="pydata", print=True, ns_struct=False)
+
+    @mock.patch.object(SchemaTransformer, "process")
+    @mock.patch.object(SchemaTransformer, "__init__", return_value=None)
+    def test_ns_struct_mode(self, mock_init, mock_process):
+        source = fixtures.joinpath("chapter03.xsd")
+        result = self.runner.invoke(
+            cli, [str(source), "--package", "foo", "--ns-struct"]
+        )
+
+        self.assertIsNone(result.exception)
+        self.assertEqual([source.as_uri()], mock_process.call_args[0][0])
+        self.assertEqual("foo", mock_process.call_args[0][1])
+
+        mock_init.assert_called_once_with(output="pydata", print=False, ns_struct=True)
 
     def test_resolve_source(self):
         file = fixtures.joinpath("chapter03.xsd")

--- a/tests/utils/test_text.py
+++ b/tests/utils/test_text.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 from xsdata.utils.text import capitalize
+from xsdata.utils.text import clean_uri
 from xsdata.utils.text import pascal_case
 from xsdata.utils.text import snake_case
 
@@ -31,3 +32,10 @@ class TextTests(TestCase):
     def test_capitalize(self):
         self.assertEqual("UserName", capitalize("userName"))
         self.assertEqual(".userName", capitalize(".userName"))
+
+    def test_clean_uri(self):
+        self.assertEqual("a", clean_uri("urn:a"))
+        self.assertEqual("a_com/b", clean_uri("http://a.com/b.xsd"))
+        self.assertEqual("a_com/b", clean_uri("http://www.a.com/b.xsd"))
+        self.assertEqual("a_com/b", clean_uri("https://a.com/b.wsdl"))
+        self.assertEqual("a_com/b", clean_uri("https://www.a.com/b.xsd"))

--- a/tests/utils/test_text.py
+++ b/tests/utils/test_text.py
@@ -34,6 +34,7 @@ class TextTests(TestCase):
         self.assertEqual(".userName", capitalize(".userName"))
 
     def test_clean_uri(self):
+        self.assertEqual("any", clean_uri("##any"))
         self.assertEqual("a", clean_uri("urn:a"))
         self.assertEqual("a_com/b", clean_uri("http://a.com/b.xsd"))
         self.assertEqual("a_com/b", clean_uri("http://www.a.com/b.xsd"))

--- a/xsdata/cli.py
+++ b/xsdata/cli.py
@@ -18,9 +18,18 @@ outputs = click.Choice(writer.formats)
 @click.option("--package", required=True, help="Target Package")
 @click.option("--output", type=outputs, help="Output Format", default="pydata")
 @click.option("--print", is_flag=True, default=False, help="Print output")
+@click.option(
+    "--ns-struct",
+    is_flag=True,
+    default=False,
+    help=(
+        "Use namespaces to group classes in the same module. "
+        "Useful against circular import errors."
+    ),
+)
 @click.version_option(get_distribution("xsdata").version)
 @click_log.simple_verbosity_option(logger)
-def cli(source: str, package: str, output: str, print: bool):
+def cli(source: str, package: str, output: str, print: bool, ns_struct: bool):
     """
     Convert schema definitions to code.
 
@@ -30,7 +39,7 @@ def cli(source: str, package: str, output: str, print: bool):
         logger.setLevel(logging.ERROR)
 
     uris = resolve_source(source)
-    transformer = SchemaTransformer(output=output, print=print)
+    transformer = SchemaTransformer(output=output, print=print, ns_struct=ns_struct)
     transformer.process(list(uris), package)
 
 

--- a/xsdata/codegen/handlers/attribute_merge.py
+++ b/xsdata/codegen/handlers/attribute_merge.py
@@ -26,6 +26,8 @@ class AttributeMergeHandler(HandlerInterface):
             if not existing:
                 result.append(attr)
             elif not (attr.is_attribute or attr.is_enumeration):
+                existing.help = existing.help or attr.help
+
                 min_occurs = existing.restrictions.min_occurs or 0
                 max_occurs = existing.restrictions.max_occurs or 1
                 attr_min_occurs = attr.restrictions.min_occurs or 0

--- a/xsdata/codegen/handlers/attribute_mismatch.py
+++ b/xsdata/codegen/handlers/attribute_mismatch.py
@@ -37,7 +37,6 @@ class AttributeMismatchHandler(HandlerInterface):
         )
         if not enum_inner:
             enum_inner = Class(
-                name="value",
                 qname=QName(target.qname.namespace, "value"),
                 type=SimpleType,
                 module=target.module,

--- a/xsdata/codegen/handlers/attribute_substitution.py
+++ b/xsdata/codegen/handlers/attribute_substitution.py
@@ -14,7 +14,6 @@ from xsdata.codegen.models import AttrType
 from xsdata.codegen.models import Class
 from xsdata.codegen.utils import ClassUtils
 from xsdata.utils import collections
-from xsdata.utils import text
 
 Substitutions = Optional[Dict[QName, List[Attr]]]
 
@@ -77,12 +76,11 @@ class AttributeSubstitutionHandler(HandlerInterface):
         """Create an attribute with type that refers to the given source class
         and namespaced qualified name."""
 
-        name = text.suffix(source.name)
         return Attr(
-            name=name,
-            local_name=name,
+            name=source.name,
+            local_name=source.name,
             index=0,
-            types=[AttrType(qname=QName(source.qname.namespace, name))],
+            types=[AttrType(qname=QName(source.qname.namespace, source.name))],
             tag=source.type.__name__,
             namespace=source.namespace,
         )

--- a/xsdata/codegen/mappers/schema.py
+++ b/xsdata/codegen/mappers/schema.py
@@ -63,7 +63,6 @@ class SchemaMapper:
     ) -> Class:
         """Build and return a class instance."""
         instance = Class(
-            name=obj.real_name,
             qname=QName(target_namespace, obj.real_name),
             abstract=obj.is_abstract,
             namespace=cls.element_namespace(obj, target_namespace),

--- a/xsdata/codegen/mappers/schema.py
+++ b/xsdata/codegen/mappers/schema.py
@@ -223,13 +223,11 @@ class SchemaMapper:
             return
 
         name = obj.real_name
-        target.ns_map.update(obj.ns_map)
-
         target.attrs.append(
             Attr(
                 index=obj.index,
                 name=name,
-                local_name=text.suffix(name),
+                local_name=name,
                 default=obj.default_value,
                 fixed=obj.is_fixed,
                 types=types,

--- a/xsdata/codegen/models.py
+++ b/xsdata/codegen/models.py
@@ -20,7 +20,6 @@ from xsdata.models.enums import Tag
 from xsdata.models.mixins import ElementBase
 from xsdata.models.xsd import ComplexType
 from xsdata.models.xsd import Element
-from xsdata.utils import text
 
 xml_type_map = {
     Tag.ELEMENT: XmlType.ELEMENT,
@@ -224,7 +223,7 @@ class Attr:
     types: List[AttrType] = field(default_factory=list)
     display_type: Optional[str] = field(default=None)
     namespace: Optional[str] = field(default=None)
-    help: Optional[str] = field(default=None)
+    help: Optional[str] = field(default=None, compare=False)
     restrictions: Restrictions = field(default_factory=Restrictions, compare=False)
 
     @property
@@ -286,7 +285,7 @@ class Attr:
         xsi:type."""
         return (
             QNames.XSI_TYPE.namespace == self.namespace
-            and QNames.XSI_TYPE.localname == text.suffix(self.name)
+            and QNames.XSI_TYPE.localname == self.name
         )
 
     @property

--- a/xsdata/codegen/models.py
+++ b/xsdata/codegen/models.py
@@ -340,7 +340,7 @@ class Class:
     Model representation of a dataclass with fields, base/inner classes and
     additional metadata settings.
 
-    :param name:
+    :param qname:
     :param type:
     :param module:
     :param mixed:
@@ -360,7 +360,6 @@ class Class:
     :param source_namespace:
     """
 
-    name: str
     qname: QName
     type: Type
     module: str
@@ -378,6 +377,11 @@ class Class:
     attrs: List[Attr] = field(default_factory=list)
     inner: List["Class"] = field(default_factory=list)
     ns_map: Dict = field(default_factory=dict)
+
+    @property
+    def name(self) -> str:
+        """Shortcut for qname local name."""
+        return self.qname.localname
 
     @property
     def has_suffix_attr(self) -> bool:

--- a/xsdata/codegen/sanitizer.py
+++ b/xsdata/codegen/sanitizer.py
@@ -128,7 +128,6 @@ class ClassSanitizer:
                     attr_type.forward = False
                     attr_type.qname = QName(inner.qname.namespace, name)
 
-        inner.name = name
         inner.qname = QName(inner.qname.namespace, name)
 
         self.container.add(inner)

--- a/xsdata/codegen/sanitizer.py
+++ b/xsdata/codegen/sanitizer.py
@@ -193,7 +193,7 @@ class ClassSanitizer:
             else:
                 attr.name = re.sub("[^0-9a-zA-Z]", " ", attr.name).strip()
         else:
-            attr.name = re.sub("[^0-9a-zA-Z]", " ", text.suffix(attr.name)).strip()
+            attr.name = re.sub("[^0-9a-zA-Z]", " ", attr.name).strip()
 
         if not attr.name:
             attr.name = "value"
@@ -234,7 +234,7 @@ class ClassSanitizer:
                 first, second = items
                 if first.tag == second.tag and any((first.namespace, second.namespace)):
                     change = second if second.namespace else first
-                    change.name = f"{change.namespace}_{change.name}"
+                    change.name = f"{text.clean_uri(change.namespace)}_{change.name}"
                 else:
                     change = second if second.is_attribute else first
                     change.name = f"{change.name}_{change.tag}"

--- a/xsdata/codegen/transformer.py
+++ b/xsdata/codegen/transformer.py
@@ -42,6 +42,7 @@ class SchemaTransformer:
 
     print: bool
     output: str
+    ns_struct: bool
     class_map: Dict[str, List[Class]] = field(init=False, default_factory=dict)
     processed: List[str] = field(init=False, default_factory=list)
 
@@ -69,7 +70,7 @@ class SchemaTransformer:
                 "Analyzer output: %d main and %d inner classes", class_num, inner_num
             )
 
-            writer.designate(classes, self.output)
+            writer.designate(classes, self.output, package, self.ns_struct)
             if self.print:
                 writer.print(classes, self.output)
             else:

--- a/xsdata/codegen/utils.py
+++ b/xsdata/codegen/utils.py
@@ -4,7 +4,6 @@ from xsdata.codegen.models import Attr
 from xsdata.codegen.models import Class
 from xsdata.codegen.models import Extension
 from xsdata.codegen.models import Restrictions
-from xsdata.utils import text
 
 
 class ClassUtils:
@@ -21,11 +20,11 @@ class ClassUtils:
         supposed to be last in a sequence.
         """
         target.extensions.remove(extension)
-        target_attr_names = {text.suffix(attr.name) for attr in target.attrs}
+        target_attr_names = {attr.name for attr in target.attrs}
 
         index = 0
         for attr in source.attrs:
-            if text.suffix(attr.name) not in target_attr_names:
+            if attr.name not in target_attr_names:
                 clone = cls.clone_attribute(attr, extension.restrictions)
 
                 if attr.index == sys.maxsize:

--- a/xsdata/codegen/validator.py
+++ b/xsdata/codegen/validator.py
@@ -8,7 +8,6 @@ from xsdata.codegen.models import Class
 from xsdata.codegen.models import Extension
 from xsdata.codegen.utils import ClassUtils
 from xsdata.models.enums import Tag
-from xsdata.utils import text
 from xsdata.utils.collections import group_by
 
 
@@ -120,7 +119,7 @@ class ClassValidator:
         """Search for any target class extensions that is a circular
         reference."""
         for ext in target.extensions:
-            if text.suffix(ext.type.name) == target.name:
+            if ext.type.name == target.name:
                 return ext
 
         return None
@@ -130,7 +129,7 @@ class ClassValidator:
         """Search for any target class attributes that is a circular
         reference."""
         for attr in target.attrs:
-            if text.suffix(attr.name) == target.name:
+            if attr.name == target.name:
                 return attr
 
         return None

--- a/xsdata/codegen/writer.py
+++ b/xsdata/codegen/writer.py
@@ -52,13 +52,33 @@ class CodeWriter:
         for result in engine.render(classes):
             print(result.source, end="")
 
-    def designate(self, classes: List[Class], output: str):
-        """Normalize the target package and module names by the given output
-        generator."""
+    def designate(
+        self, classes: List[Class], output: str, package: str, ns_struct: bool
+    ):
+        """
+        Normalize the target package and module names by the given output
+        generator.
+
+        :param classes: a list of codegen class instances
+        :param output: target output format
+        :param package: the original user provided package name
+        :param ns_struct: use the target namespaces to group the classes in the same
+            module.
+        """
         modules = {}
         packages = {}
 
         for obj in classes:
+
+            if ns_struct:
+                if not obj.qname.namespace:
+                    raise CodeGenerationError(
+                        f"Class `{obj.name}` target namespace "
+                        f"is empty, avoid option `--ns-struct`"
+                    )
+
+                obj.package = package
+                obj.module = obj.qname.namespace
 
             if obj.package is None:
                 raise CodeGenerationError(

--- a/xsdata/formats/dataclass/filters.py
+++ b/xsdata/formats/dataclass/filters.py
@@ -29,7 +29,7 @@ def class_name(name: str) -> str:
 @functools.lru_cache(maxsize=50)
 def attribute_name(name: str) -> str:
     """Apply python conventions for instance variable names."""
-    return text.snake_case(utils.safe_snake(text.suffix(name)))
+    return text.snake_case(utils.safe_snake(name))
 
 
 @functools.lru_cache(maxsize=50)
@@ -40,7 +40,7 @@ def constant_name(name: str) -> str:
 
 def type_name(attr_type: AttrType) -> str:
     """Return native python type name or apply class name conventions."""
-    return attr_type.native_name or class_name(text.suffix(attr_type.name))
+    return attr_type.native_name or class_name(attr_type.name)
 
 
 def attribute_metadata(attr: Attr, parent_namespace: Optional[str]) -> Dict:
@@ -147,9 +147,7 @@ def attribute_default(attr: Attr, ns_map: Optional[Dict] = None) -> Any:
         elif default_value.startswith("@enum@"):
             source, enumeration = default_value[6:].split("::", 1)
             attr_type = next(
-                attr_type
-                for attr_type in attr.types
-                if text.suffix(attr_type.name) == source
+                attr_type for attr_type in attr.types if attr_type.name == source
             )
             if attr_type.alias:
                 source = attr_type.alias

--- a/xsdata/formats/dataclass/generator.py
+++ b/xsdata/formats/dataclass/generator.py
@@ -107,7 +107,7 @@ class DataclassGenerator(AbstractGenerator):
     @classmethod
     def module_name(cls, module: str) -> str:
         """Convert the given module name to safe snake case."""
-        return text.snake_case(utils.safe_snake(module, default="mod"))
+        return text.snake_case(utils.safe_snake(text.clean_uri(module), default="mod"))
 
     @classmethod
     def package_name(cls, package: str) -> str:

--- a/xsdata/models/mixins.py
+++ b/xsdata/models/mixins.py
@@ -151,7 +151,7 @@ class ElementBase:
         """
         name = getattr(self, "name", None) or getattr(self, "ref", None)
         if name:
-            return name
+            return text.suffix(name)
 
         raise SchemaValueError(f"Schema class `{self.class_name}` unknown real name.")
 

--- a/xsdata/models/xsd.py
+++ b/xsdata/models/xsd.py
@@ -149,7 +149,7 @@ class AnyAttribute(AnnotationBase):
     :param process_contents: (lax | skip | strict) : strict
     """
 
-    namespace: Optional[str] = attribute(default="##any")
+    namespace: str = attribute(default="##any")
     process_contents: Optional[ProcessType] = attribute(name="processContents")
 
     def __post_init__(self):
@@ -165,13 +165,8 @@ class AnyAttribute(AnnotationBase):
 
     @property
     def real_name(self) -> str:
-        if self.namespace is None:
-            raise SchemaValueError("Wildcards namespace can't be None.")
-
-        namespace = (
-            self.namespace[2:] if self.namespace.startswith("##") else self.namespace
-        )
-        return f"{namespace}_attributes"
+        clean_ns = "_".join(map(text.clean_uri, self.namespace.split(" ")))
+        return f"{clean_ns}_attributes"
 
     @property
     def real_type(self) -> Optional[str]:
@@ -410,9 +405,9 @@ class Any(AnnotationBase):
     :param process_contents: (lax | skip | strict) : strict
     """
 
+    namespace: str = attribute(default="##any")
     min_occurs: int = attribute(default=1, name="minOccurs")
     max_occurs: UnionType[int, str] = attribute(default=1, name="maxOccurs")
-    namespace: Optional[str] = attribute(default="##any")
     process_contents: Optional[ProcessType] = attribute(name="processContents")
 
     def __post_init__(self):
@@ -424,13 +419,8 @@ class Any(AnnotationBase):
 
     @property
     def real_name(self) -> str:
-        if self.namespace is None:
-            raise SchemaValueError("Wildcards namespace can't be None.")
-
-        namespace = (
-            self.namespace[2:] if self.namespace.startswith("##") else self.namespace
-        )
-        return f"{namespace}_element"
+        clean_ns = "_".join(map(text.clean_uri, self.namespace.split(" ")))
+        return f"{clean_ns}_element"
 
     @property
     def raw_namespace(self) -> Optional[str]:

--- a/xsdata/utils/text.py
+++ b/xsdata/utils/text.py
@@ -68,6 +68,9 @@ def snake_case(string: str) -> str:
 
 def clean_uri(namespace: str) -> str:
     """Remove common prefixes and suffixes from a uri string."""
+    if namespace[:2] == "##":
+        namespace = namespace[2:]
+
     prefix, suffix = split(namespace)
 
     if prefix == "urn":

--- a/xsdata/utils/text.py
+++ b/xsdata/utils/text.py
@@ -64,3 +64,17 @@ def snake_case(string: str) -> str:
             if result and result[-1] != "_":
                 result.append("_")
     return "".join(result).strip("_")
+
+
+def clean_uri(namespace: str) -> str:
+    """Remove common prefixes and suffixes from a uri string."""
+    prefix, suffix = split(namespace)
+
+    if prefix == "urn":
+        namespace = suffix
+    elif prefix in ("http", "https"):
+        namespace = suffix[2:]
+
+    return "_".join(
+        [part for part in namespace.split(".") if part not in ("www", "xsd", "wsdl")]
+    )


### PR DESCRIPTION
By default the cli is using the original schemas structure
to assign classes to packages and modules

The new option will group all classes by the target namespace
they were originally defined and write them in the same module
inside the user provided package name.


`xsdata https://www.omg.org/spec/ReqIF/20110401/reqif.xsd --package here.models --ns-struct`

```console

Analyzer input: 272 main and 87 inner classes
Analyzer output: 181 main and 98 inner classes
Generating package: init
Generating package: here.models.w3_org_1999_xhtml
Generating package: here.models.omg_org_spec_req_if_20110401_reqif
Generating package: here.models.w3_org_xml_1998_namespace
```

This more flat structure seems to work nice for complex schemas and takes care of any nasty circular import errors.

