### PR TITLE
Fix #230 XmlSerializer allow empty strings in attribute values.

### DIFF
--- a/tests/formats/dataclass/serializers/test_utils.py
+++ b/tests/formats/dataclass/serializers/test_utils.py
@@ -44,11 +44,25 @@ class SerializeUtilsTests(TestCase):
         mock_to_xml.assert_called_once_with(QName("b", "value"), self.namespaces)
 
     @mock.patch("xsdata.formats.dataclass.serializers.utils.to_xml", return_value="")
-    def test_set_attribute_with_empty_value(self, mock_to_xml):
+    def test_set_attribute_with_empty_string_value(self, mock_to_xml):
         SerializeUtils.set_attribute(self.element, "key", "value", self.namespaces)
-        self.assertNotIn("key", self.element.attrib)
+        self.assertEqual("", self.element.attrib["key"])
         self.assertEqual(0, len(self.namespaces.ns_map))
         mock_to_xml.assert_called_once_with("value", self.namespaces)
+
+    @mock.patch("xsdata.formats.dataclass.serializers.utils.to_xml")
+    def test_set_attribute_with_empty_token_list(self, mock_to_xml):
+        SerializeUtils.set_attribute(self.element, "key", [], self.namespaces)
+        self.assertNotIn("key", self.element.attrib)
+        self.assertEqual(0, len(self.namespaces.ns_map))
+        self.assertEqual(0, mock_to_xml.call_count)
+
+    @mock.patch("xsdata.formats.dataclass.serializers.utils.to_xml")
+    def test_set_attribute_with_value_none(self, mock_to_xml):
+        SerializeUtils.set_attribute(self.element, "key", None, self.namespaces)
+        self.assertNotIn("key", self.element.attrib)
+        self.assertEqual(0, len(self.namespaces.ns_map))
+        self.assertEqual(0, mock_to_xml.call_count)
 
     def test_set_attribute_xsi_nil(self):
         SerializeUtils.set_attribute(

--- a/xsdata/formats/dataclass/serializers/utils.py
+++ b/xsdata/formats/dataclass/serializers/utils.py
@@ -19,15 +19,16 @@ class SerializeUtils:
     @staticmethod
     def set_attribute(element: Element, key: Any, value: Any, namespaces: Namespaces):
         """Set element attribute from the given key and value."""
-        if key == QNames.XSI_NIL and (element.text or len(element) > 0):
+        if (
+            value is None
+            or (key == QNames.XSI_NIL and (element.text or len(element) > 0))
+            or (isinstance(value, list) and len(value) == 0)
+        ):
             return
 
         key = SerializeUtils.resolve_qname(key, namespaces)
         value = SerializeUtils.resolve_qname(value, namespaces)
-        value = to_xml(value, namespaces)
-
-        if value:
-            element.set(key, value)
+        element.set(key, to_xml(value, namespaces))
 
     @staticmethod
     def resolve_qname(value: Any, namespaces: Namespaces) -> Any:


### PR DESCRIPTION
XmlSerializer shouldn't ignore empty strings as attribute values, only `None` values or empty lists eg `xs:NMTOKENS`

Which seems to work well with w3c test suite as well tefra/xsdata-w3c-tests#32, the output samples now match the input 100%