### PR TITLE
Less lxml

### DIFF
--- a/tests/codegen/handlers/test_attribute_enum_union.py
+++ b/tests/codegen/handlers/test_attribute_enum_union.py
@@ -19,9 +19,9 @@ class AttributeEnumUnionHandlerTests(FactoryTestCase):
                     name="value",
                     tag=Tag.UNION,
                     types=[
-                        AttrTypeFactory.create(qname=self.root_enum.name),
+                        AttrTypeFactory.create(qname=self.root_enum.qname),
                         AttrTypeFactory.create(
-                            qname=self.inner_enum.name, forward=True
+                            qname=self.inner_enum.qname, forward=True
                         ),
                     ],
                 ),

--- a/tests/codegen/handlers/test_attribute_group.py
+++ b/tests/codegen/handlers/test_attribute_group.py
@@ -98,4 +98,4 @@ class AttributeGroupHandlerTests(FactoryTestCase):
         with self.assertRaises(AnalyzerValueError) as cm:
             self.processor.process_attribute(target, group_attr)
 
-        self.assertEqual("Group attribute not found: `{xsdata}bar`", str(cm.exception))
+        self.assertEqual("Group attribute not found: `bar`", str(cm.exception))

--- a/tests/codegen/handlers/test_attribute_substitution.py
+++ b/tests/codegen/handlers/test_attribute_substitution.py
@@ -1,7 +1,5 @@
 from unittest import mock
 
-from lxml.etree import QName
-
 from tests.factories import AttrFactory
 from tests.factories import AttrTypeFactory
 from tests.factories import ClassFactory
@@ -9,6 +7,7 @@ from tests.factories import FactoryTestCase
 from xsdata.codegen.container import ClassContainer
 from xsdata.codegen.handlers import AttributeSubstitutionHandler
 from xsdata.codegen.models import AttrType
+from xsdata.utils import text
 
 
 class AttributeSubstitutionHandlerTests(FactoryTestCase):
@@ -73,9 +72,10 @@ class AttributeSubstitutionHandlerTests(FactoryTestCase):
         ns = "xsdata"
         classes = [
             ClassFactory.create(
-                substitutions=[QName(ns, "foo"), QName(ns, "bar")], abstract=True
+                substitutions=[text.qname(ns, "foo"), text.qname(ns, "bar")],
+                abstract=True,
             ),
-            ClassFactory.create(substitutions=[QName(ns, "foo")], abstract=True),
+            ClassFactory.create(substitutions=[text.qname(ns, "foo")], abstract=True),
         ]
 
         reference_attrs = AttrFactory.list(3)
@@ -85,8 +85,8 @@ class AttributeSubstitutionHandlerTests(FactoryTestCase):
         self.processor.create_substitutions()
 
         expected = {
-            QName(ns, "foo"): [reference_attrs[0], reference_attrs[2]],
-            QName(ns, "bar"): [reference_attrs[1]],
+            text.qname(ns, "foo"): [reference_attrs[0], reference_attrs[2]],
+            text.qname(ns, "bar"): [reference_attrs[1]],
         }
         self.assertEqual(expected, self.processor.substitutions)
 
@@ -95,13 +95,13 @@ class AttributeSubstitutionHandlerTests(FactoryTestCase):
         )
 
     def test_create_substitution(self):
-        item = ClassFactory.elements(1, qname=QName("foo", "bar"))
+        item = ClassFactory.elements(1, qname=text.qname("foo", "bar"))
         actual = self.processor.create_substitution(item)
 
         expected = AttrFactory.create(
             name=item.name,
             default=None,
-            types=[AttrType(qname=QName("foo", "bar"))],
+            types=[AttrType(qname=text.qname("foo", "bar"))],
             tag=item.type.__name__,
         )
 

--- a/tests/codegen/handlers/test_attribute_type.py
+++ b/tests/codegen/handlers/test_attribute_type.py
@@ -1,7 +1,5 @@
 from unittest import mock
 
-from lxml.etree import QName
-
 from tests.factories import AttrFactory
 from tests.factories import AttrTypeFactory
 from tests.factories import ClassFactory
@@ -229,13 +227,13 @@ class AttributeTypeHandlerTests(FactoryTestCase):
         another = ClassFactory.create()
         processing = ClassFactory.create(status=Status.PROCESSING)
 
-        find_classes = {QName("a"): another, QName("b"): target}
+        find_classes = {"a": another, "b": target}
 
         mock_container_find.side_effect = lambda x: find_classes.get(x)
         mock_dependencies.side_effect = [
-            [QName(x) for x in "ccde"],
-            [QName(x) for x in "abc"],
-            [QName(x) for x in "xy"],
+            list("ccde"),
+            list("abc"),
+            list("xy"),
         ]
 
         self.assertTrue(
@@ -253,13 +251,13 @@ class AttributeTypeHandlerTests(FactoryTestCase):
 
         mock_container_find.assert_has_calls(
             [
-                mock.call(QName("c")),
-                mock.call(QName("d")),
-                mock.call(QName("e")),
-                mock.call(QName("a")),
-                mock.call(QName("x")),
-                mock.call(QName("y")),
-                mock.call(QName("b")),
+                mock.call("c"),
+                mock.call("d"),
+                mock.call("e"),
+                mock.call("a"),
+                mock.call("x"),
+                mock.call("y"),
+                mock.call("b"),
             ]
         )
 
@@ -282,18 +280,15 @@ class AttributeTypeHandlerTests(FactoryTestCase):
 
     @mock.patch.object(Class, "dependencies")
     def test_cached_dependencies(self, mock_class_dependencies):
-        a_qname = QName("a")
-        b_qname = QName("b")
-
-        mock_class_dependencies.return_value = [a_qname, b_qname]
+        mock_class_dependencies.return_value = ["a", "b"]
 
         source = ClassFactory.create()
-        self.processor.dependencies[id(source)] = (a_qname,)
+        self.processor.dependencies[id(source)] = ("a",)
 
         actual = self.processor.cached_dependencies(source)
-        self.assertEqual((a_qname,), actual)
+        self.assertEqual(("a",), actual)
 
         self.processor.dependencies.clear()
         actual = self.processor.cached_dependencies(source)
-        self.assertEqual((a_qname, b_qname), actual)
+        self.assertEqual(("a", "b"), actual)
         mock_class_dependencies.assert_called_once_with()

--- a/tests/codegen/mappers/test_definitions.py
+++ b/tests/codegen/mappers/test_definitions.py
@@ -1,8 +1,6 @@
 from typing import Generator
 from unittest import mock
 
-from lxml.etree import QName
-
 from tests.factories import AttrFactory
 from tests.factories import ClassFactory
 from tests.factories import FactoryTestCase
@@ -24,6 +22,7 @@ from xsdata.models.wsdl import PortTypeOperation
 from xsdata.models.wsdl import Service
 from xsdata.models.wsdl import ServicePort
 from xsdata.models.xsd import Element
+from xsdata.utils import text
 
 
 def mock_create_inner(target: Class, name: str):
@@ -169,7 +168,7 @@ class DefinitionsMapperTests(FactoryTestCase):
         second = ClassFactory.create(qname="some_name_second", meta_name="Envelope")
         other = ClassFactory.create()
         service = ClassFactory.create(
-            qname=QName("xsdata", "Calc_Add"),
+            qname=text.qname("xsdata", "Calc_Add"),
             status=Status.PROCESSED,
             type=BindingOperation,
             module="foo",
@@ -344,7 +343,7 @@ class DefinitionsMapperTests(FactoryTestCase):
         )
 
         expected = Class(
-            qname=QName("bar", name),
+            qname=text.qname("bar", name),
             meta_name="Envelope",
             type=BindingMessage,
             module="foo",
@@ -420,7 +419,7 @@ class DefinitionsMapperTests(FactoryTestCase):
         )
 
         expected = Class(
-            qname=QName("bar", name),
+            qname=text.qname("bar", name),
             meta_name="Envelope",
             type=BindingMessage,
             module="foo",
@@ -513,7 +512,7 @@ class DefinitionsMapperTests(FactoryTestCase):
 
         expected_fault_detail_attrs = [
             DefinitionsMapper.build_attr(
-                name, QName(name), namespace=target.namespace, native=False
+                name, qname=name, namespace=target.namespace, native=False
             )
             for name in ["fooEl", "barEl"]
         ]
@@ -666,13 +665,13 @@ class DefinitionsMapperTests(FactoryTestCase):
         result = DefinitionsMapper.build_parts_attributes(parts, ns_map)
         expected = [
             DefinitionsMapper.build_attr(
-                "bar", QName("great", "bar"), namespace="great", native=False
+                "bar", text.qname("great", "bar"), namespace="great", native=False
             ),
             DefinitionsMapper.build_attr(
-                "arg0", QName(Namespace.XS.uri, "string"), namespace="", native=True
+                "arg0", DataType.STRING.qname, namespace="", native=True
             ),
             DefinitionsMapper.build_attr(
-                "arg1", QName("boo", "cafe"), namespace="", native=False
+                "arg1", text.qname("boo", "cafe"), namespace="", native=False
             ),
         ]
         self.assertIsInstance(result, Generator)
@@ -691,7 +690,7 @@ class DefinitionsMapperTests(FactoryTestCase):
         mock_create_message_attributes.return_value = attrs
         actual = DefinitionsMapper.build_message_class(definitions, port_type_message)
         expected = Class(
-            qname=QName("xsdata", "bar"),
+            qname=text.qname("xsdata", "bar"),
             status=Status.PROCESSED,
             type=Element,
             module="foo",
@@ -706,7 +705,7 @@ class DefinitionsMapperTests(FactoryTestCase):
 
         actual = DefinitionsMapper.build_inner_class(target, "body")
         expected = ClassFactory.create(
-            qname=QName("body"),
+            qname="body",
             type=BindingMessage,
             module=target.module,
             package=None,
@@ -717,9 +716,7 @@ class DefinitionsMapperTests(FactoryTestCase):
 
         self.assertIsNot(actual.ns_map, target.ns_map)
 
-        expected_attr = DefinitionsMapper.build_attr(
-            "body", QName("body"), forward=True
-        )
+        expected_attr = DefinitionsMapper.build_attr("body", "body", forward=True)
         self.assertEqual(expected_attr, target.attrs[0])
 
         repeat = DefinitionsMapper.build_inner_class(target, "body")
@@ -733,7 +730,7 @@ class DefinitionsMapperTests(FactoryTestCase):
             port_type_message, target_namespace
         )
         expected = DefinitionsMapper.build_attr(
-            "bar", qname=QName("foobar", "bar"), namespace=target_namespace
+            "bar", qname=text.qname("foobar", "bar"), namespace=target_namespace
         )
 
         self.assertIsInstance(actual, Generator)

--- a/tests/codegen/mappers/test_definitions.py
+++ b/tests/codegen/mappers/test_definitions.py
@@ -333,9 +333,9 @@ class DefinitionsMapperTests(FactoryTestCase):
         binding_message = BindingMessage(
             ns_map={"foo": "bar"},
             extended=[
-                AnyElement(qname=QName("body")),
-                AnyElement(qname=QName("header")),
-                AnyElement(qname=QName("header")),
+                AnyElement(qname="body"),
+                AnyElement(qname="header"),
+                AnyElement(qname="header"),
             ],
         )
 
@@ -409,9 +409,9 @@ class DefinitionsMapperTests(FactoryTestCase):
         binding_message = BindingMessage(
             ns_map={"foo": "bar"},
             extended=[
-                AnyElement(qname=QName("body"), attributes={"namespace": "bodyns"}),
-                AnyElement(qname=QName("header")),
-                AnyElement(qname=QName("header")),
+                AnyElement(qname="body", attributes={"namespace": "bodyns"}),
+                AnyElement(qname="header"),
+                AnyElement(qname="header"),
             ],
         )
 

--- a/tests/codegen/models/test_class.py
+++ b/tests/codegen/models/test_class.py
@@ -1,7 +1,5 @@
 import sys
 
-from lxml.etree import QName
-
 from tests.factories import AttrFactory
 from tests.factories import AttrTypeFactory
 from tests.factories import ClassFactory
@@ -10,6 +8,7 @@ from tests.factories import FactoryTestCase
 from xsdata.models import wsdl
 from xsdata.models import xsd
 from xsdata.models.enums import Namespace
+from xsdata.utils import text
 
 
 class ClassTests(FactoryTestCase):
@@ -20,43 +19,48 @@ class ClassTests(FactoryTestCase):
                 AttrFactory.create(
                     types=[
                         AttrTypeFactory.create(
-                            qname=QName(Namespace.XS.uri, "annotated"), forward=True
+                            qname=text.qname(Namespace.XS.uri, "annotated"),
+                            forward=True,
                         )
                     ]
                 ),
                 AttrFactory.create(
                     types=[
                         AttrTypeFactory.create(
-                            qname=QName(Namespace.XS.uri, "openAttrs")
+                            qname=text.qname(Namespace.XS.uri, "openAttrs")
                         ),
                         AttrTypeFactory.create(
-                            qname=QName(Namespace.XS.uri, "localAttribute")
+                            qname=text.qname(Namespace.XS.uri, "localAttribute")
                         ),
                     ]
                 ),
             ],
             extensions=[
                 ExtensionFactory.create(
-                    type=AttrTypeFactory.create(qname=QName(Namespace.XS.uri, "foobar"))
+                    type=AttrTypeFactory.create(
+                        qname=text.qname(Namespace.XS.uri, "foobar")
+                    )
                 ),
                 ExtensionFactory.create(
-                    type=AttrTypeFactory.create(qname=QName(Namespace.XS.uri, "foobar"))
+                    type=AttrTypeFactory.create(
+                        qname=text.qname(Namespace.XS.uri, "foobar")
+                    )
                 ),
             ],
             inner=[
                 ClassFactory.create(
                     attrs=AttrFactory.list(
-                        2, types=AttrTypeFactory.list(1, qname="foo")
+                        2, types=AttrTypeFactory.list(1, qname="{xsdata}foo")
                     )
                 )
             ],
         )
 
         expected = [
-            QName("{http://www.w3.org/2001/XMLSchema}openAttrs"),
-            QName("{http://www.w3.org/2001/XMLSchema}localAttribute"),
-            QName("{http://www.w3.org/2001/XMLSchema}foobar"),
-            QName("{xsdata}foo"),
+            text.qname("{http://www.w3.org/2001/XMLSchema}openAttrs"),
+            text.qname("{http://www.w3.org/2001/XMLSchema}localAttribute"),
+            text.qname("{http://www.w3.org/2001/XMLSchema}foobar"),
+            text.qname("{xsdata}foo"),
         ]
         self.assertEqual(expected, list(obj.dependencies()))
 

--- a/tests/codegen/test_container.py
+++ b/tests/codegen/test_container.py
@@ -1,7 +1,6 @@
 from unittest import mock
 
 from lxml.etree import Element
-from lxml.etree import QName
 
 from tests.factories import ClassFactory
 from tests.factories import FactoryTestCase
@@ -19,9 +18,9 @@ class ClassContainerTests(FactoryTestCase):
 
     def test_from_list(self):
         classes = [
-            ClassFactory.create(qname="foo", type=Element),
-            ClassFactory.create(qname="foo", type=ComplexType),
-            ClassFactory.create(qname="foobar", type=ComplexType),
+            ClassFactory.create(qname="{xsdata}foo", type=Element),
+            ClassFactory.create(qname="{xsdata}foo", type=ComplexType),
+            ClassFactory.create(qname="{xsdata}foobar", type=ComplexType),
         ]
         container = ClassContainer.from_list(classes)
 
@@ -41,7 +40,7 @@ class ClassContainerTests(FactoryTestCase):
 
         self.container.extend([class_a, class_b, class_c])
 
-        self.assertIsNone(self.container.find(QName("nope")))
+        self.assertIsNone(self.container.find("nope"))
         self.assertEqual(class_a, self.container.find(class_a.qname))
         self.assertEqual(class_b, self.container.find(class_b.qname))
         self.assertEqual(

--- a/tests/codegen/test_sanitizer.py
+++ b/tests/codegen/test_sanitizer.py
@@ -67,6 +67,15 @@ class ClassSanitizerTest(FactoryTestCase):
             [mock.call(target.inner[0].attrs), mock.call(target.attrs)]
         )
 
+    def test_process_attribute_default_with_enumeration(self):
+        target = ClassFactory.create()
+        attr = AttrFactory.enumeration()
+        attr.restrictions.max_occurs = 2
+        attr.fixed = True
+
+        self.sanitizer.process_attribute_default(target, attr)
+        self.assertTrue(attr.fixed)
+
     def test_process_attribute_default_with_list_field(self):
         target = ClassFactory.create()
         attr = AttrFactory.create(fixed=True)

--- a/tests/codegen/test_writer.py
+++ b/tests/codegen/test_writer.py
@@ -6,8 +6,6 @@ from typing import List
 from typing import Optional
 from unittest import mock
 
-from lxml.etree import QName
-
 from tests.factories import ClassFactory
 from tests.factories import FactoryTestCase
 from xsdata.codegen.models import Class
@@ -123,7 +121,7 @@ class CodeWriterTests(FactoryTestCase):
         self.assertEqual("xsdata", classes[0].module)
         self.assertEqual("xsdata", classes[1].module)
 
-        classes = ClassFactory.list(1, qname=QName("foo"))
+        classes = ClassFactory.list(1, qname="foo")
         with self.assertRaises(CodeGenerationError) as cm:
             writer.designate(classes, "fake", "foo", True)
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -3,8 +3,6 @@ import unittest
 from abc import ABC
 from abc import abstractmethod
 
-from lxml.etree import QName
-
 from xsdata.codegen.models import Attr
 from xsdata.codegen.models import AttrType
 from xsdata.codegen.models import Class
@@ -22,6 +20,7 @@ from xsdata.models.xsd import ComplexType
 from xsdata.models.xsd import Element
 from xsdata.models.xsd import Restriction
 from xsdata.models.xsd import SimpleType
+from xsdata.utils import text
 
 DEFAULT_NS_MAP = {
     Namespace.XS.prefix: Namespace.XS.uri,
@@ -91,10 +90,7 @@ class ClassFactory(Factory):
         container=None,
     ):
         if not qname:
-            qname = QName("xsdata", f"class_{cls.next_letter()}")
-
-        if not isinstance(qname, QName):
-            qname = QName("xsdata", qname)
+            qname = text.qname("xsdata", f"class_{cls.next_letter()}")
 
         return cls.model(
             qname=qname,
@@ -167,10 +163,7 @@ class AttrTypeFactory(Factory):
         circular=False,
     ):
         if not qname:
-            qname = QName("xsdata", f"attr_{cls.next_letter()}")
-
-        if not isinstance(qname, QName):
-            qname = QName("xsdata", qname)
+            qname = text.qname("xsdata", f"attr_{cls.next_letter()}")
 
         return cls.model(
             qname=qname,

--- a/tests/formats/dataclass/filters/test_attribute_default.py
+++ b/tests/formats/dataclass/filters/test_attribute_default.py
@@ -1,7 +1,5 @@
 from unittest import TestCase
 
-from lxml.etree import QName
-
 from tests.factories import AttrFactory
 from tests.factories import AttrTypeFactory
 from xsdata.formats.dataclass.filters import attribute_default
@@ -68,7 +66,7 @@ class AttributeDefaultTests(TestCase):
         attr.types[0].alias = "foo_bar"
         self.assertEqual("FooBar.BAR", attribute_default(attr))
 
-        attr.types[0].qname = QName("nomatch")  # impossible
+        attr.types[0].qname = "nomatch"  # impossible
         with self.assertRaises(Exception):
             attribute_default(attr)
 

--- a/tests/formats/dataclass/parsers/test_json.py
+++ b/tests/formats/dataclass/parsers/test_json.py
@@ -1,11 +1,8 @@
 from unittest.case import TestCase
 
-from lxml.etree import QName
-
 from tests import fixtures_dir
 from tests.fixtures.books import BookForm
 from tests.fixtures.books import Books
-from xsdata.exceptions import ParserError
 from xsdata.formats.dataclass.models.elements import XmlElement
 from xsdata.formats.dataclass.models.elements import XmlText
 from xsdata.formats.dataclass.parsers.json import JsonParser
@@ -48,10 +45,8 @@ class JsonParserTests(TestCase):
     def test_get_value(self):
         data = dict(foo="bar", bar="foo")
 
-        foo_field = XmlText(name="foo", qname=QName("foo"), types=[str])
-        bar_field = XmlElement(
-            name="bar", qname=QName("bar"), types=[str], list_element=True
-        )
+        foo_field = XmlText(name="foo", qname="foo", types=[str])
+        bar_field = XmlElement(name="bar", qname="bar", types=[str], list_element=True)
 
         self.assertEqual("bar", JsonParser.get_value(data, foo_field))
         self.assertEqual(["foo"], JsonParser.get_value(data, bar_field))

--- a/tests/formats/dataclass/parsers/test_xml.py
+++ b/tests/formats/dataclass/parsers/test_xml.py
@@ -6,7 +6,6 @@ from unittest import mock
 from unittest.case import TestCase
 
 from lxml.etree import Element
-from lxml.etree import QName
 
 from tests import fixtures_dir
 from tests.fixtures.books import BookForm
@@ -26,7 +25,7 @@ class XmlParserTests(TestCase):
         super().setUp()
         self.parser = XmlParser()
         self.parser.index = 10
-        self.parser.objects = [(QName(x), x) for x in "abcde"]
+        self.parser.objects = [(x, x) for x in "abcde"]
 
     def test_parse_context_raises_exception(self):
         with self.assertRaises(ParserError) as cm:
@@ -41,7 +40,7 @@ class XmlParserTests(TestCase):
     @mock.patch.object(RootNode, "next_node")
     @mock.patch.object(XmlParser, "emit_event")
     def test_queue(self, mock_emit_event, mock_next_node):
-        var = XmlText(name="foo", qname=QName("foo"))
+        var = XmlText(name="foo", qname="foo")
         primitive_node = PrimitiveNode(position=1, var=var)
         mock_next_node.return_value = primitive_node
         element = Element("{urn:books}books")
@@ -70,7 +69,7 @@ class XmlParserTests(TestCase):
 
         objects = []
         queue = []
-        var = XmlText(name="foo", qname=QName("foo"))
+        var = XmlText(name="foo", qname="foo")
         queue.append(PrimitiveNode(position=0, var=var))
 
         result = self.parser.dequeue(element, queue, objects)

--- a/tests/formats/dataclass/serializers/test_utils.py
+++ b/tests/formats/dataclass/serializers/test_utils.py
@@ -69,7 +69,7 @@ class SerializeUtilsTests(TestCase):
 
     def test_set_attribute_xsi_nil(self):
         SerializeUtils.set_attribute(
-            self.element, QNames.XSI_NIL.text, True, self.namespaces
+            self.element, QNames.XSI_NIL, True, self.namespaces
         )
         self.assertEqual("true", self.element.attrib[QNames.XSI_NIL])
 
@@ -77,9 +77,9 @@ class SerializeUtilsTests(TestCase):
         self.element.text = "foo"
 
         SerializeUtils.set_attribute(
-            self.element, QNames.XSI_NIL.text, True, self.namespaces
+            self.element, QNames.XSI_NIL, True, self.namespaces
         )
-        self.assertNotIn(QNames.XSI_NIL.text, self.element.attrib)
+        self.assertNotIn(QNames.XSI_NIL, self.element.attrib)
 
     def test_set_attribute_xsi_nil_and_element_has_children(self):
         SubElement(self.element, "bar")

--- a/tests/formats/dataclass/serializers/test_xml.py
+++ b/tests/formats/dataclass/serializers/test_xml.py
@@ -8,7 +8,6 @@ from unittest import mock
 from unittest.case import TestCase
 
 from lxml.etree import Element
-from lxml.etree import QName
 
 from tests.fixtures.books import BookForm
 from tests.fixtures.books import Books
@@ -146,7 +145,7 @@ class XmlSerializerTests(TestCase):
 
         attribute = prod_meta.find_var("effDate")
         attributes = prod_meta.find_var("{!}other_attributes")
-        text = replace(size_meta.find_var("value"), qname=QName("foo", "bar"))
+        text = replace(size_meta.find_var("value"), qname="{foo}bar")
         sub_node = prod_meta.find_var("name")
 
         mock_next_value.return_value = [
@@ -282,7 +281,7 @@ class XmlSerializerTests(TestCase):
     ):
         root = Element("root")
         value = SizeType()
-        value.qname = QName("foo")
+        value.qname = "foo"
         meta = self.serializer.context.build(DescriptionType)
         var = meta.find_var(mode=FindMode.WILDCARD)
 

--- a/tests/formats/dataclass/test_elements.py
+++ b/tests/formats/dataclass/test_elements.py
@@ -2,8 +2,6 @@ from dataclasses import dataclass
 from dataclasses import replace
 from unittest.case import TestCase
 
-from lxml.etree import QName
-
 from tests.fixtures.books.books import BookForm
 from xsdata.formats.dataclass.context import XmlContext
 from xsdata.formats.dataclass.models.elements import FindMode
@@ -15,7 +13,6 @@ from xsdata.formats.dataclass.models.elements import XmlText
 from xsdata.formats.dataclass.models.elements import XmlVar
 from xsdata.formats.dataclass.models.elements import XmlWildcard
 from xsdata.models.enums import FormType
-from xsdata.models.enums import QNames
 
 
 @dataclass
@@ -25,28 +22,28 @@ class Fixture:
 
 class XmlValTests(TestCase):
     def test_property_clazz(self):
-        var = XmlVar(name="foo", qname=QName("foo"))
+        var = XmlVar(name="foo", qname="foo")
         self.assertIsNone(var.clazz)
 
-        var = XmlVar(name="foo", qname=QName("foo"), dataclass=True, types=[Fixture])
+        var = XmlVar(name="foo", qname="foo", dataclass=True, types=[Fixture])
         self.assertEqual(Fixture, var.clazz)
 
     def test_property_is_clazz_union(self):
-        var = XmlVar(name="foo", qname=QName("foo"), dataclass=True, types=[Fixture])
+        var = XmlVar(name="foo", qname="foo", dataclass=True, types=[Fixture])
         self.assertFalse(var.is_clazz_union)
 
         var.types.append(Fixture)
         self.assertTrue(var.is_clazz_union)
 
     def test_property_is_list(self):
-        var = XmlVar(name="foo", qname=QName("foo"))
+        var = XmlVar(name="foo", qname="foo")
         self.assertFalse(var.is_list)
 
-        var = XmlVar(name="foo", qname=QName("foo"), types=[int], list_element=True)
+        var = XmlVar(name="foo", qname="foo", types=[int], list_element=True)
         self.assertTrue(var.is_list)
 
     def test_default_properties(self):
-        var = XmlVar(name="foo", qname=QName("foo"))
+        var = XmlVar(name="foo", qname="foo")
         self.assertFalse(var.is_any_type)
         self.assertFalse(var.is_attribute)
         self.assertFalse(var.is_attributes)
@@ -56,33 +53,33 @@ class XmlValTests(TestCase):
         self.assertFalse(var.is_mixed_content)
 
     def test_matches(self):
-        var = XmlVar(name="foo", qname=QName("foo"))
-        self.assertTrue(var.matches(QNames.ALL))
+        var = XmlVar(name="foo", qname="foo")
+        self.assertTrue(var.matches("*"))
         self.assertTrue(var.matches(var.qname))
-        self.assertFalse(var.matches(QName("bar")))
+        self.assertFalse(var.matches("bar"))
 
 
 class XmlElementTests(TestCase):
     def test_property_is_element(self):
-        var = XmlElement(name="foo", qname=QName("foo"))
+        var = XmlElement(name="foo", qname="foo")
 
         self.assertIsInstance(var, XmlVar)
         self.assertTrue(var.is_element)
 
     def test_property_is_any_type(self):
-        var = XmlElement(name="foo", qname=QName("foo"))
+        var = XmlElement(name="foo", qname="foo")
         self.assertFalse(var.is_any_type)
 
-        var = XmlElement(name="foo", qname=QName("foo"), types=[int, object])
+        var = XmlElement(name="foo", qname="foo", types=[int, object])
         self.assertFalse(var.is_any_type)
 
-        var = XmlElement(name="foo", qname=QName("foo"), types=[object])
+        var = XmlElement(name="foo", qname="foo", types=[object])
         self.assertTrue(var.is_any_type)
 
 
 class XmlWildcardTests(TestCase):
     def test_property_is_mixed_content(self):
-        var = XmlWildcard(name="foo", qname=QName("foo"))
+        var = XmlWildcard(name="foo", qname="foo")
 
         self.assertIsInstance(var, XmlVar)
         self.assertFalse(var.is_mixed_content)
@@ -91,40 +88,40 @@ class XmlWildcardTests(TestCase):
         self.assertTrue(var.is_mixed_content)
 
     def test_property_is_wildcard(self):
-        var = XmlWildcard(name="foo", qname=QName("foo"))
+        var = XmlWildcard(name="foo", qname="foo")
 
         self.assertIsInstance(var, XmlVar)
         self.assertTrue(var.is_wildcard)
 
     def test_property_is_any_type(self):
-        var = XmlWildcard(name="foo", qname=QName("foo"))
+        var = XmlWildcard(name="foo", qname="foo")
         self.assertTrue(var.is_any_type)
 
     def test_matches(self):
-        var = XmlWildcard(name="foo", qname=QName("foo"))
-        self.assertTrue(var.matches(QNames.ALL))
-        self.assertTrue(var.matches(QName("a")))
+        var = XmlWildcard(name="foo", qname="foo")
+        self.assertTrue(var.matches("*"))
+        self.assertTrue(var.matches("a"))
 
-        var = XmlWildcard(name="foo", qname=QName("foo"), namespaces=["tns"])
-        self.assertFalse(var.matches(QName("a")))
-        self.assertTrue(var.matches(QName("tns", "a")))
+        var = XmlWildcard(name="foo", qname="foo", namespaces=["tns"])
+        self.assertFalse(var.matches("a"))
+        self.assertTrue(var.matches("{tns}a"))
 
-        var = XmlWildcard(name="foo", qname=QName("foo"), namespaces=["##any"])
-        self.assertTrue(var.matches(QName("a")))
-        self.assertTrue(var.matches(QName("tns", "a")))
+        var = XmlWildcard(name="foo", qname="foo", namespaces=["##any"])
+        self.assertTrue(var.matches("a"))
+        self.assertTrue(var.matches("{tns}a"))
 
-        var = XmlWildcard(name="foo", qname=QName("foo"), namespaces=[""])
-        self.assertTrue(var.matches(QName("a")))
-        self.assertFalse(var.matches(QName("tns", "a")))
+        var = XmlWildcard(name="foo", qname="foo", namespaces=[""])
+        self.assertTrue(var.matches("a"))
+        self.assertFalse(var.matches("{tns}a"))
 
-        var = XmlWildcard(name="foo", qname=QName("foo"), namespaces=["!tns"])
-        self.assertTrue(var.matches(QName("foo", "a")))
-        self.assertFalse(var.matches(QName("tns", "a")))
+        var = XmlWildcard(name="foo", qname="foo", namespaces=["!tns"])
+        self.assertTrue(var.matches("{foo}a"))
+        self.assertFalse(var.matches("{tns}a"))
 
 
 class XmlAttributeTests(TestCase):
     def test_property_is_attribute(self):
-        var = XmlAttribute(name="foo", qname=QName("foo"))
+        var = XmlAttribute(name="foo", qname="foo")
 
         self.assertIsInstance(var, XmlVar)
         self.assertTrue(var.is_attribute)
@@ -132,7 +129,7 @@ class XmlAttributeTests(TestCase):
 
 class XmlAttributesTests(TestCase):
     def test_property_is_attributes(self):
-        var = XmlAttributes(name="foo", qname=QName("foo"))
+        var = XmlAttributes(name="foo", qname="foo")
 
         self.assertIsInstance(var, XmlVar)
         self.assertTrue(var.is_attributes)
@@ -140,7 +137,7 @@ class XmlAttributesTests(TestCase):
 
 class XmlTextTests(TestCase):
     def test_property_is_text(self):
-        var = XmlText(name="foo", qname=QName("foo"))
+        var = XmlText(name="foo", qname="foo")
 
         self.assertIsInstance(var, XmlVar)
         self.assertTrue(var.is_text)
@@ -149,21 +146,17 @@ class XmlTextTests(TestCase):
 class XmlMetaTests(TestCase):
     def test_property_element_form(self):
         meta = XmlMeta(
-            name="foo",
-            clazz=BookForm,
-            qname=QName("foo"),
-            source_qname=QName("foo"),
-            nillable=False,
+            name="foo", clazz=BookForm, qname="foo", source_qname="foo", nillable=False,
         )
         self.assertEqual(FormType.UNQUALIFIED, meta.element_form)
 
-        meta = replace(meta, qname=QName("bar", "foo"))
+        meta = replace(meta, qname="{bar}foo")
         self.assertEqual(FormType.QUALIFIED, meta.element_form)
 
-        meta.vars.append(XmlElement(name="a", qname=QName("a")))
+        meta.vars.append(XmlElement(name="a", qname="a"))
         self.assertEqual(FormType.UNQUALIFIED, meta.element_form)
 
-        meta.vars.append(XmlElement(name="b", qname=QName("b"), namespaces=["bar"]))
+        meta.vars.append(XmlElement(name="b", qname="b", namespaces=["bar"]))
         self.assertEqual(FormType.UNQUALIFIED, meta.element_form)
 
         meta.vars.pop(0)
@@ -172,22 +165,18 @@ class XmlMetaTests(TestCase):
     def test_find_var(self):
         ctx = XmlContext()
         meta = ctx.build(BookForm)
-        author = QName("author")
-        excluded = set()
-        excluded.add("author")
 
-        self.assertIsInstance(meta.find_var(author), XmlElement)
-        self.assertIsNone(meta.find_var(author, FindMode.ATTRIBUTE))
-        self.assertIsNone(meta.find_var(QName("nope")))
+        self.assertIsInstance(meta.find_var("author"), XmlElement)
+        self.assertIsNone(meta.find_var("author", FindMode.ATTRIBUTE))
+        self.assertIsNone(meta.find_var("nope"))
 
     def test_find_var_uses_cache(self):
         ctx = XmlContext()
         meta = ctx.build(BookForm)
-        author = QName("author")
 
-        self.assertEqual("author", meta.find_var(author).name)
+        self.assertEqual("author", meta.find_var("author").name)
         self.assertEqual(1, len(meta.cache))
         key = tuple(meta.cache.keys())[0]
 
         meta.cache[key] = 1
-        self.assertEqual("title", meta.find_var(author).name)
+        self.assertEqual("title", meta.find_var("author").name)

--- a/tests/formats/dataclass/test_elements.py
+++ b/tests/formats/dataclass/test_elements.py
@@ -184,11 +184,10 @@ class XmlMetaTests(TestCase):
         ctx = XmlContext()
         meta = ctx.build(BookForm)
         author = QName("author")
-        title = QName("title")
 
         self.assertEqual("author", meta.find_var(author).name)
         self.assertEqual(1, len(meta.cache))
         key = tuple(meta.cache.keys())[0]
 
-        meta.cache[key] = meta._find_var(title)
+        meta.cache[key] = 1
         self.assertEqual("title", meta.find_var(author).name)

--- a/tests/utils/test_text.py
+++ b/tests/utils/test_text.py
@@ -3,7 +3,9 @@ from unittest import TestCase
 from xsdata.utils.text import capitalize
 from xsdata.utils.text import clean_uri
 from xsdata.utils.text import pascal_case
+from xsdata.utils.text import qname
 from xsdata.utils.text import snake_case
+from xsdata.utils.text import split_qname
 
 
 class TextTests(TestCase):
@@ -40,3 +42,22 @@ class TextTests(TestCase):
         self.assertEqual("a_com/b", clean_uri("http://www.a.com/b.xsd"))
         self.assertEqual("a_com/b", clean_uri("https://a.com/b.wsdl"))
         self.assertEqual("a_com/b", clean_uri("https://www.a.com/b.xsd"))
+
+    def test_qname(self):
+        self.assertEqual("{a}b", qname("a", "b"))
+        self.assertEqual("b", qname("", "b"))
+        self.assertEqual("b", qname(None, "b"))
+
+        self.assertEqual("b", qname("b", ""))
+        self.assertEqual("b", qname("b"))
+        self.assertEqual("b", qname("b", None))
+
+        with self.assertRaises(ValueError):
+            qname(None, None)
+
+    def test_split_qname(self):
+        self.assertEqual(("a", "b"), split_qname("{a}b"))
+        self.assertEqual((None, "b"), split_qname("b"))
+
+        with self.assertRaises(IndexError):
+            split_qname("")

--- a/xsdata/codegen/container.py
+++ b/xsdata/codegen/container.py
@@ -7,8 +7,6 @@ from typing import Iterator
 from typing import List
 from typing import Optional
 
-from lxml.etree import QName
-
 from xsdata.codegen.handlers import AttributeEnumUnionHandler
 from xsdata.codegen.handlers import AttributeGroupHandler
 from xsdata.codegen.handlers import AttributeMergeHandler
@@ -29,7 +27,7 @@ Condition = Optional[Callable]
 
 
 class ClassContainer(UserDict, ContainerInterface):
-    def __init__(self, data: Dict[QName, List[Class]] = None) -> None:
+    def __init__(self, data: Dict[str, List[Class]] = None) -> None:
         """
         Initialize container structure and the list of process handlers.
 
@@ -58,7 +56,7 @@ class ClassContainer(UserDict, ContainerInterface):
         for items in list(self.data.values()):
             yield from items
 
-    def find(self, qname: QName, condition: Condition = None) -> Optional[Class]:
+    def find(self, qname: str, condition: Condition = None) -> Optional[Class]:
         """Search by qualified name for a specific class with an optional
         condition callable."""
         for row in self.data.get(qname, []):

--- a/xsdata/codegen/handlers/attribute_substitution.py
+++ b/xsdata/codegen/handlers/attribute_substitution.py
@@ -5,8 +5,6 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
-from lxml.etree import QName
-
 from xsdata.codegen.mixins import ContainerInterface
 from xsdata.codegen.mixins import HandlerInterface
 from xsdata.codegen.models import Attr
@@ -15,7 +13,7 @@ from xsdata.codegen.models import Class
 from xsdata.codegen.utils import ClassUtils
 from xsdata.utils import collections
 
-Substitutions = Optional[Dict[QName, List[Attr]]]
+Substitutions = Optional[Dict[str, List[Attr]]]
 
 
 @dataclass
@@ -79,7 +77,7 @@ class AttributeSubstitutionHandler(HandlerInterface):
         return Attr(
             name=source.name,
             local_name=source.name,
-            types=[AttrType(qname=QName(source.qname.namespace, source.name))],
+            types=[AttrType(qname=source.qname)],
             tag=source.type.__name__,
             namespace=source.namespace,
         )

--- a/xsdata/codegen/handlers/attribute_type.py
+++ b/xsdata/codegen/handlers/attribute_type.py
@@ -5,8 +5,6 @@ from typing import Optional
 from typing import Set
 from typing import Tuple
 
-from lxml.etree import QName
-
 from xsdata.codegen.mixins import ContainerInterface
 from xsdata.codegen.mixins import HandlerInterface
 from xsdata.codegen.models import Attr
@@ -158,7 +156,7 @@ class AttributeTypeHandler(HandlerInterface):
 
         return False
 
-    def cached_dependencies(self, source: Class) -> Tuple[QName]:
+    def cached_dependencies(self, source: Class) -> Tuple[str]:
         """Returns from cache the source class dependencies as a collection of
         qualified names."""
         cache_key = id(source)

--- a/xsdata/codegen/mixins.py
+++ b/xsdata/codegen/mixins.py
@@ -4,8 +4,6 @@ from typing import Iterator
 from typing import List
 from typing import Optional
 
-from lxml.etree import QName
-
 from xsdata.codegen.models import Class
 
 Condition = Optional[Callable]
@@ -20,7 +18,7 @@ class ContainerInterface(metaclass=abc.ABCMeta):
         """Create an iterator for the class map values."""
 
     @abc.abstractmethod
-    def find(self, qname: QName, condition: Condition = None) -> Optional[Class]:
+    def find(self, qname: str, condition: Condition = None) -> Optional[Class]:
         """Search by qualified name for a specific class with an optional
         condition callable."""
 

--- a/xsdata/codegen/parsers/schema.py
+++ b/xsdata/codegen/parsers/schema.py
@@ -2,13 +2,14 @@ import sys
 from dataclasses import dataclass
 from dataclasses import field
 from typing import Any
+from typing import List
 from typing import Optional
 from urllib.parse import urljoin
 
 from lxml.etree import Element
 
 from xsdata.formats.bindings import T
-from xsdata.formats.dataclass.parsers.nodes import ParsedObjects
+from xsdata.formats.dataclass.parsers.nodes import Parsed
 from xsdata.formats.dataclass.parsers.nodes import XmlNodes
 from xsdata.formats.dataclass.parsers.xml import XmlParser
 from xsdata.models import xsd
@@ -41,7 +42,7 @@ class SchemaParser(XmlParser):
     default_attributes: Optional[str] = field(default=None)
     default_open_content: Optional[xsd.DefaultOpenContent] = field(default=None)
 
-    def dequeue(self, element: Element, queue: XmlNodes, objects: ParsedObjects) -> Any:
+    def dequeue(self, element: Element, queue: XmlNodes, objects: List[Parsed]) -> Any:
         """Override parent method to set element index and namespaces map."""
         obj: Any = super().dequeue(element, queue, objects)
 

--- a/xsdata/codegen/writer.py
+++ b/xsdata/codegen/writer.py
@@ -71,14 +71,14 @@ class CodeWriter:
         for obj in classes:
 
             if ns_struct:
-                if not obj.qname.namespace:
+                if not obj.target_namespace:
                     raise CodeGenerationError(
                         f"Class `{obj.name}` target namespace "
                         f"is empty, avoid option `--ns-struct`"
                     )
 
                 obj.package = package
-                obj.module = obj.qname.namespace
+                obj.module = obj.target_namespace
 
             if obj.package is None:
                 raise CodeGenerationError(

--- a/xsdata/formats/dataclass/context.py
+++ b/xsdata/formats/dataclass/context.py
@@ -14,14 +14,13 @@ from typing import List
 from typing import Optional
 from typing import Type
 
-from lxml.etree import QName
-
 from xsdata.exceptions import XmlContextError
 from xsdata.formats.converter import converter
 from xsdata.formats.dataclass.models.constants import XmlType
 from xsdata.formats.dataclass.models.elements import XmlMeta
 from xsdata.formats.dataclass.models.elements import XmlVar
 from xsdata.models.enums import NamespaceType
+from xsdata.utils import text
 
 
 @dataclass
@@ -42,7 +41,7 @@ class XmlContext:
         self,
         clazz: Type,
         parent_ns: Optional[str] = None,
-        xsi_type: Optional[QName] = None,
+        xsi_type: Optional[str] = None,
     ) -> XmlMeta:
         """
         Fetch the model metadata of the given dataclass type, namespace and xsi
@@ -62,7 +61,7 @@ class XmlContext:
 
         return meta
 
-    def find_subclass(self, clazz: Type, xsi_type: QName) -> Optional[Type]:
+    def find_subclass(self, clazz: Type, xsi_type: str) -> Optional[Type]:
         """
         Find a derived class of the given clazz that matches the given
         qualified xsi type.
@@ -87,7 +86,7 @@ class XmlContext:
 
         return None
 
-    def match_class_source_qname(self, clazz: Type, xsi_type: QName) -> bool:
+    def match_class_source_qname(self, clazz: Type, xsi_type: str) -> bool:
         """Match a given source qualified name with the given xsi type."""
         if is_dataclass(clazz):
             meta = self.build(clazz)
@@ -120,8 +119,8 @@ class XmlContext:
             self.cache[clazz] = XmlMeta(
                 name=name,
                 clazz=clazz,
-                qname=QName(namespace, name),
-                source_qname=QName(source_namespace, name),
+                qname=text.qname(namespace, name),
+                source_qname=text.qname(source_namespace, name),
                 nillable=nillable,
                 vars=list(self.get_type_hints(clazz, namespace)),
             )
@@ -150,7 +149,7 @@ class XmlContext:
 
             yield xml_clazz(
                 name=var.name,
-                qname=QName(first_namespace, local_name),
+                qname=text.qname(first_namespace, local_name),
                 namespaces=namespaces,
                 init=var.init,
                 mixed=var.metadata.get("mixed", False),

--- a/xsdata/formats/dataclass/generator.py
+++ b/xsdata/formats/dataclass/generator.py
@@ -82,7 +82,7 @@ class DataclassGenerator(AbstractGenerator):
         resolver.process(classes)
         imports = resolver.sorted_imports()
         output = self.render_classes(resolver.sorted_classes())
-        namespace = classes[0].qname.namespace
+        namespace = classes[0].target_namespace
 
         return self.template("module").render(
             output=output, imports=imports, namespace=namespace

--- a/xsdata/formats/dataclass/models/elements.py
+++ b/xsdata/formats/dataclass/models/elements.py
@@ -258,14 +258,17 @@ class XmlMeta:
         if key not in self.cache:
             self.cache[key] = self._find_var(qname, mode)
 
-        return self.cache[key]
+        index = self.cache[key]
+        return None if index < 0 else self.vars[index]
 
-    def _find_var(
-        self, qname: QName = QNames.ALL, mode: FindMode = FindMode.ALL,
-    ) -> Optional[XmlVar]:
-
+    def _find_var(self, qname: QName, mode: FindMode) -> int:
         find_func = find_lambdas[mode]
 
         return next(
-            (var for var in self.vars if find_func(var) and var.matches(qname)), None,
+            (
+                index
+                for index, var in enumerate(self.vars)
+                if find_func(var) and var.matches(qname)
+            ),
+            -1,
         )

--- a/xsdata/formats/dataclass/models/generics.py
+++ b/xsdata/formats/dataclass/models/generics.py
@@ -5,7 +5,6 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
-from lxml.etree import QName
 from lxml.etree import register_namespace
 
 from xsdata.formats.dataclass.models.constants import XmlType
@@ -26,7 +25,7 @@ class AnyElement:
     :param attributes: element attributes.
     """
 
-    qname: Optional[QName] = field(default=None)
+    qname: Optional[str] = field(default=None)
     text: Optional[str] = field(default=None)
     tail: Optional[str] = field(default=None)
     ns_map: Dict = field(default_factory=dict)

--- a/xsdata/formats/dataclass/parsers/json.py
+++ b/xsdata/formats/dataclass/parsers/json.py
@@ -84,8 +84,10 @@ class JsonParser(AbstractParser):
     def get_value(data: Dict, var: XmlVar) -> Any:
         """Find the var value in the given dictionary or return the default var
         value."""
-        if var.qname.localname in data:
-            value = data[var.qname.localname]
+
+        local_name = var.local_name
+        if local_name in data:
+            value = data[local_name]
         elif var.name in data:
             value = data[var.name]
         else:

--- a/xsdata/formats/dataclass/parsers/xml.py
+++ b/xsdata/formats/dataclass/parsers/xml.py
@@ -8,7 +8,6 @@ from lxml.etree import Element
 from lxml.etree import iterparse
 from lxml.etree import iterwalk
 from lxml.etree import parse
-from lxml.etree import QName
 
 from xsdata.formats.bindings import AbstractParser
 from xsdata.formats.bindings import T
@@ -63,7 +62,7 @@ class XmlParser(NodeParser, AbstractParser):
         """Call if exist the parser's hook for the given element and event."""
 
         if name not in self.event_names:
-            self.event_names[name] = text.snake_case(QName(name).localname)
+            self.event_names[name] = text.snake_case(text.split_qname(name)[1])
 
         method_name = f"{event}_{self.event_names[name]}"
         if hasattr(self, method_name):

--- a/xsdata/formats/dataclass/parsers/xml.py
+++ b/xsdata/formats/dataclass/parsers/xml.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from dataclasses import field
 from typing import Any
 from typing import Dict
+from typing import List
 from typing import Type
 
 from lxml.etree import Element
@@ -12,7 +13,7 @@ from lxml.etree import parse
 from xsdata.formats.bindings import AbstractParser
 from xsdata.formats.bindings import T
 from xsdata.formats.dataclass.parsers.nodes import NodeParser
-from xsdata.formats.dataclass.parsers.nodes import ParsedObjects
+from xsdata.formats.dataclass.parsers.nodes import Parsed
 from xsdata.formats.dataclass.parsers.nodes import XmlNodes
 from xsdata.models.enums import EventType
 from xsdata.utils import text
@@ -37,13 +38,13 @@ class XmlParser(NodeParser, AbstractParser):
 
         return self.parse_context(ctx, clazz)
 
-    def queue(self, element: Element, queue: XmlNodes, objects: ParsedObjects):
+    def queue(self, element: Element, queue: XmlNodes, objects: List[Parsed]):
         """Queue the next xml node for parsing based on the given element
         qualified name."""
         super().queue(element, queue, objects)
         self.emit_event(EventType.START, element.tag, element=element)
 
-    def dequeue(self, element: Element, queue: XmlNodes, objects: ParsedObjects) -> Any:
+    def dequeue(self, element: Element, queue: XmlNodes, objects: List[Parsed]) -> Any:
         """
         Use the last xml node to parse the given element and bind any child
         objects.

--- a/xsdata/models/enums.py
+++ b/xsdata/models/enums.py
@@ -5,6 +5,8 @@ from typing import Optional
 
 from lxml.etree import QName
 
+from xsdata.utils import text
+
 COMMON_SCHEMA_DIR = Path(__file__).absolute().parent.parent.joinpath("schemas/")
 
 
@@ -40,8 +42,8 @@ __STANDARD_NAMESPACES__ = {ns.uri: ns for ns in Namespace}
 class QNames:
     """Common qualified names."""
 
-    XSI_NIL = QName(Namespace.XSI.uri, "nil")
-    XSI_TYPE = QName(Namespace.XSI.uri, "type")
+    XSI_NIL = text.qname(Namespace.XSI.uri, "nil")
+    XSI_TYPE = text.qname(Namespace.XSI.uri, "type")
 
 
 class NamespaceType:
@@ -138,8 +140,8 @@ class DataType(Enum):
         self.local = local
 
     @property
-    def qname(self) -> QName:
-        return QName(Namespace.XS.uri, self.code)
+    def qname(self) -> str:
+        return text.qname(Namespace.XS.uri, self.code)
 
     @property
     def local_name(self) -> str:

--- a/xsdata/models/enums.py
+++ b/xsdata/models/enums.py
@@ -40,7 +40,6 @@ __STANDARD_NAMESPACES__ = {ns.uri: ns for ns in Namespace}
 class QNames:
     """Common qualified names."""
 
-    ALL = QName("__all__")
     XSI_NIL = QName(Namespace.XSI.uri, "nil")
     XSI_TYPE = QName(Namespace.XSI.uri, "type")
 

--- a/xsdata/models/wsdl.py
+++ b/xsdata/models/wsdl.py
@@ -37,7 +37,7 @@ class WsdlElement:
 
     name: str = attribute()
     documentation: Optional[Documentation] = element()
-    ns_map: Dict = field(default_factory=dict)
+    ns_map: Dict = field(default_factory=dict, init=False)
 
 
 @dataclass

--- a/xsdata/utils/text.py
+++ b/xsdata/utils/text.py
@@ -1,4 +1,5 @@
 from typing import List
+from typing import Optional
 from typing import Tuple
 
 
@@ -69,3 +70,23 @@ def clean_uri(namespace: str) -> str:
     return "_".join(
         [part for part in namespace.split(".") if part not in ("www", "xsd", "wsdl")]
     )
+
+
+def qname(tag_or_uri: Optional[str], tag: Optional[str] = None) -> str:
+    """Create namespace qualified strings."""
+
+    if not tag_or_uri:
+        if not tag:
+            raise ValueError("Invalid input both uri and tag are empty.")
+
+        return tag
+
+    return f"{{{tag_or_uri}}}{tag}" if tag else tag_or_uri
+
+
+def split_qname(tag: str) -> Tuple:
+    """Split namespace qualified strings."""
+    if tag[0] == "{":
+        return tuple(tag[1:].split("}", 1))
+    else:
+        return None, tag


### PR DESCRIPTION
The codegen and the data binding modules are tight coupled with lxml and mostly with its Element and QName classes.

I want to try more parsing techniques, steam (sax), pull, etc etc but currently it's impossible because lxml is everywhere sometimes with no good reason. Ideally I want to minimize the usage to just the XmlParser class, everything else should be able to function without it and its classes.

This will also give a small memory/performance boost.