### PR TITLE
Improve mixed content handling with non-generics

### DIFF
--- a/tests/codegen/mappers/test_schema.py
+++ b/tests/codegen/mappers/test_schema.py
@@ -194,7 +194,7 @@ class SchemaMapperTests(FactoryTestCase):
             attributes=[Attribute(), Attribute()],
             sequence=sequence_one,
             simple_content=SimpleContent(restriction=Restriction()),
-            complex_content=ComplexContent(restriction=restriction,),
+            complex_content=ComplexContent(restriction=restriction),
         )
         restrictions = Restrictions.from_element(complex_type)
         children = SchemaMapper.element_children(complex_type, restrictions)

--- a/tests/formats/dataclass/parsers/test_nodes.py
+++ b/tests/formats/dataclass/parsers/test_nodes.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 from dataclasses import field
-from dataclasses import replace
 from typing import List
 from typing import Union
 from unittest import mock
@@ -56,24 +55,35 @@ class FooMixed:
 
 
 class XmlNodeTests(TestCase):
-    def test_next_node(self):
+    def test_child(self):
         with self.assertRaises(NotImplementedError):
-            XmlNode().next_node("foo", {}, {}, 0)
+            XmlNode().child("foo", {}, {}, 0)
 
-    def test_assemble(self):
+    def test_bind(self):
         with self.assertRaises(NotImplementedError):
-            XmlNode().assemble("foo", None, None, [])
+            XmlNode().bind("foo", None, None, [])
 
 
 class ElementNodeTests(TestCase):
     def setUp(self) -> None:
         super().setUp()
         self.context = XmlContext()
+        self.meta = XmlMeta(
+            name="foo", clazz=Foo, qname="foo", source_qname="foo", nillable=False,
+        )
+        self.node = ElementNode(
+            position=0,
+            meta=self.meta,
+            context=self.context,
+            config=ParserConfig(),
+            attrs={},
+            ns_map={},
+        )
 
     @mock.patch.object(ParserUtils, "bind_element_children")
     @mock.patch.object(ParserUtils, "bind_element")
     @mock.patch.object(ParserUtils, "bind_element_attrs")
-    def test_assemble(
+    def test_bind(
         self, mock_bind_element_attrs, mock_bind_element, mock_bind_element_children,
     ):
         def add_attr(x, *args):
@@ -98,11 +108,11 @@ class ElementNodeTests(TestCase):
             ns_map={"ns0": "xsdata"},
         )
 
-        pool = [1, 2, 3]
-        qname, obj = node.assemble("foo", "text", "tail", pool)
+        objects = [1, 2, 3]
 
-        self.assertEqual("foo", qname)
-        self.assertEqual(Foo(1, 2, 3), obj)
+        self.assertTrue(node.bind("foo", "text", "tail", objects))
+        self.assertEqual("foo", objects[-1][0])
+        self.assertEqual(Foo(1, 2, 3), objects[-1][1])
 
         mock_bind_element_attrs.assert_called_once_with(
             mock.ANY, node.meta, node.attrs, node.ns_map
@@ -110,12 +120,62 @@ class ElementNodeTests(TestCase):
         mock_bind_element.assert_called_once_with(
             mock.ANY, node.meta, "text", "tail", node.attrs, node.ns_map
         )
-        mock_bind_element_children.assert_called_once_with(mock.ANY, node.meta, 0, pool)
+        mock_bind_element_children.assert_called_once_with(
+            mock.ANY, node.meta, 0, objects
+        )
+
+    @mock.patch.object(ParserUtils, "bind_element_children")
+    @mock.patch.object(ParserUtils, "bind_element")
+    @mock.patch.object(ParserUtils, "bind_element_attrs")
+    def test_bind_with_mixed_flag_true(
+        self, mock_bind_element_attrs, mock_bind_element, mock_bind_element_children,
+    ):
+        def add_attr(x, *args):
+            x["a"] = 1
+
+        def add_text(x, *args):
+            x["b"] = 2
+
+        def add_child(x, *args):
+            x["c"] = 3
+
+        mock_bind_element_attrs.side_effect = add_attr
+        mock_bind_element.side_effect = add_text
+        mock_bind_element_children.side_effect = add_child
+
+        node = ElementNode(
+            position=0,
+            meta=self.context.build(Foo),
+            context=self.context,
+            config=ParserConfig(),
+            attrs={"a": "b"},
+            ns_map={"ns0": "xsdata"},
+        )
+
+        node = ElementNode(
+            position=0,
+            meta=self.context.build(Foo),
+            context=self.context,
+            config=ParserConfig(),
+            attrs={"a": "b"},
+            ns_map={"ns0": "xsdata"},
+            mixed=True,
+        )
+
+        objects = []
+        self.assertTrue(node.bind("foo", "text", "   ", objects))
+        self.assertEqual(1, len(objects))
+
+        objects = []
+        self.assertTrue(node.bind("foo", "text", " tail ", objects))
+        self.assertEqual(2, len(objects))
+        self.assertEqual(None, objects[-1][0])
+        self.assertEqual("tail", objects[-1][1])
 
     @mock.patch.object(ParserUtils, "bind_mixed_content")
     @mock.patch.object(ParserUtils, "bind_wildcard_element")
     @mock.patch.object(ParserUtils, "bind_element_attrs")
-    def test_assemble_with_mixed_content(
+    def test_bind_with_mixed_content_var(
         self,
         mock_bind_element_attrs,
         mock_bind_wildcard_element,
@@ -142,12 +202,12 @@ class ElementNodeTests(TestCase):
             attrs={"a": "b"},
             ns_map={"ns0": "xsdata"},
         )
-        pool = [1, 2, 3]
+        objects = [1, 2, 3]
 
-        qname, obj = node.assemble("foo", "text", "tail", pool)
+        self.assertTrue(node.bind("foo", "text", "tail", objects))
 
-        self.assertEqual("foo", qname)
-        self.assertEqual(FooMixed(1, 2, 3), obj)
+        self.assertEqual("foo", objects[-1][0])
+        self.assertEqual(FooMixed(1, 2, 3), objects[-1][1])
 
         mock_bind_element_attrs.assert_called_once_with(
             mock.ANY, node.meta, node.attrs, node.ns_map
@@ -156,171 +216,86 @@ class ElementNodeTests(TestCase):
             mock.ANY, node.meta.vars[2], "text", "tail", node.attrs, node.ns_map
         )
         mock_bind_mixed_content.assert_called_once_with(
-            mock.ANY, node.meta.vars[2], 0, pool
+            mock.ANY, node.meta.vars[2], 0, objects
         )
 
     @mock.patch.object(ParserUtils, "parse_xsi_type", return_value="foo")
     @mock.patch.object(XmlContext, "fetch")
-    def test_next_node_when_given_qname_matches_dataclass_var(
+    def test_child_when_given_qname_matches_dataclass_var(
         self, mock_ctx_fetch, mock_parse_xsi_type
     ):
         var = XmlElement(name="a", qname="a", types=[Foo], dataclass=True)
-        meta = XmlMeta(
-            name="foo",
-            clazz=None,
-            qname="foo",
-            source_qname="foo",
-            nillable=False,
-            vars=[var],
-        )
+        self.meta.vars.append(var)
         xsi_type = "foo"
-        namespace = meta.namespace
-        mock_ctx_fetch.return_value = replace(meta)
+        namespace = self.meta.namespace
+        mock_ctx_fetch.return_value = self.meta
         mock_parse_xsi_type.return_value = xsi_type
-        node = ElementNode(
-            position=0,
-            meta=meta,
-            context=self.context,
-            config=ParserConfig(),
-            attrs={},
-            ns_map={},
-        )
 
         attrs = {"a": "b"}
         ns_map = {"ns0": "xsdata"}
-        actual = node.next_node("a", attrs, ns_map, 10)
+        actual = self.node.child("a", attrs, ns_map, 10)
+
         self.assertIsInstance(actual, ElementNode)
         self.assertEqual(10, actual.position)
         self.assertIs(mock_ctx_fetch.return_value, actual.meta)
+
         mock_parse_xsi_type.assert_called_once_with(attrs, ns_map)
         mock_ctx_fetch.assert_called_once_with(var.clazz, namespace, xsi_type)
 
-    def test_next_node_when_given_qname_matches_var_clazz_union(self):
+    def test_child_when_given_qname_matches_var_clazz_union(self):
         var = XmlElement(name="a", qname="a", types=[Foo, FooMixed], dataclass=True)
-        meta = XmlMeta(
-            name="foo",
-            clazz=None,
-            qname="foo",
-            source_qname="foo",
-            nillable=False,
-            vars=[var],
-        )
-        node = ElementNode(
-            position=0,
-            meta=meta,
-            context=self.context,
-            config=ParserConfig(),
-            attrs={},
-            ns_map={},
-        )
+        self.meta.vars.append(var)
 
         attrs = {"a": "b"}
         ns_map = {"ns0": "xsdata"}
-        actual = node.next_node("a", attrs, ns_map, 10)
+        actual = self.node.child("a", attrs, ns_map, 10)
 
         self.assertIsInstance(actual, UnionNode)
         self.assertEqual(10, actual.position)
         self.assertIs(var, actual.var)
+        self.assertEqual(attrs, actual.attrs)
+        self.assertEqual(ns_map, actual.ns_map)
+        self.assertEqual(0, actual.level)
+        self.assertEqual(0, len(actual.events))
 
-    def test_next_node_when_given_qname_matches_any_element_var(self):
+    def test_child_when_given_qname_matches_any_element_var(self):
         var = XmlWildcard(name="a", qname="a", types=[], dataclass=False)
-        meta = XmlMeta(
-            name="foo",
-            clazz=None,
-            qname="foo",
-            source_qname="foo",
-            nillable=False,
-            vars=[var],
-        )
-        node = ElementNode(
-            position=0,
-            meta=meta,
-            context=self.context,
-            config=ParserConfig(),
-            attrs={},
-            ns_map={},
-        )
+        self.meta.vars.append(var)
 
-        attrs = {"a": "b"}
-        ns_map = {"ns0": "xsdata"}
-        actual = node.next_node("a", attrs, ns_map, 10)
+        actual = self.node.child("a", {}, {}, 10)
 
         self.assertIsInstance(actual, WildcardNode)
         self.assertEqual(10, actual.position)
         self.assertEqual(var, actual.var)
 
-    def test_next_node_when_given_qname_matches_primitive_var(self):
+    def test_child_when_given_qname_matches_primitive_var(self):
         var = XmlText(name="a", qname="a", types=[int], default=100)
-        meta = XmlMeta(
-            name="foo",
-            clazz=None,
-            qname="foo",
-            source_qname="foo",
-            nillable=False,
-            vars=[var],
-        )
-        node = ElementNode(
-            position=0,
-            meta=meta,
-            context=self.context,
-            config=ParserConfig(),
-            attrs={},
-            ns_map={},
-        )
-
+        self.meta.vars.append(var)
         attrs = {"a": "b"}
         ns_map = {"ns0": "xsdata"}
-        actual = node.next_node("a", attrs, ns_map, 10)
+        actual = self.node.child("a", attrs, ns_map, 10)
 
         self.assertIsInstance(actual, PrimitiveNode)
         self.assertEqual(var, actual.var)
         self.assertEqual(ns_map, actual.ns_map)
 
-    def test_next_node_when_given_qname_does_not_match_any_var(self):
-        meta = XmlMeta(
-            name="foo", clazz=None, qname="foo", source_qname="foo", nillable=False,
-        )
-        node = ElementNode(
-            position=0,
-            meta=meta,
-            context=self.context,
-            config=ParserConfig(),
-            attrs={},
-            ns_map={},
-        )
-
-        attrs = {"a": "b"}
-        ns_map = {"ns0": "xsdata"}
-
+    def test_child_when_given_qname_does_not_match_any_var(self):
         with self.assertRaises(ParserError) as cm:
-            node.next_node("unknown", attrs, ns_map, 10)
+            self.node.child("unknown", {}, {}, 10)
 
         self.assertEqual("Unknown property foo:unknown", str(cm.exception))
 
-    def test_next_node_when_config_fail_on_unknown_properties_is_false(self):
-        meta = XmlMeta(
-            name="foo", clazz=None, qname="foo", source_qname="foo", nillable=False,
-        )
-        node = ElementNode(
-            position=0,
-            meta=meta,
-            context=self.context,
-            config=ParserConfig(fail_on_unknown_properties=False),
-            attrs={},
-            ns_map={},
-        )
-
-        self.assertEqual(SkipNode(), node.next_node("unknown", {}, {}, 10))
+    def test_child_when_config_fail_on_unknown_properties_is_false(self):
+        self.node.config.fail_on_unknown_properties = False
+        self.assertEqual(SkipNode(), self.node.child("unknown", {}, {}, 10))
 
 
 class WildcardNodeTests(TestCase):
-    @mock.patch.object(ParserUtils, "fetch_any_children")
-    def test_assemble(self, mock_fetch_any_children):
+    def test_bind(self):
         text = "\n "
         tail = "bar"
         attrs = {"id": "1"}
         ns_map = {"ns0": "xsdata"}
-        mock_fetch_any_children.return_value = ["a", "b"]
 
         generic = AnyElement(
             qname="foo",
@@ -328,22 +303,23 @@ class WildcardNodeTests(TestCase):
             tail="bar",
             ns_map=ns_map,
             attributes=attrs,
-            children=["a", "b"],
+            children=[1, 2, 3],
         )
 
         var = XmlText(name="foo", qname="a")
         node = WildcardNode(position=0, var=var, attrs=attrs, ns_map=ns_map)
-        actual = node.assemble("foo", text, tail, [1, 2, 3])
+        objects = [("a", 1), ("b", 2), ("c", 3)]
 
-        self.assertEqual((var.qname, generic), actual)
-        mock_fetch_any_children.assert_called_once_with(0, [1, 2, 3])
+        self.assertTrue(node.bind("foo", text, tail, objects))
+        self.assertEqual(var.qname, objects[-1][0])
+        self.assertEqual(generic, objects[-1][1])
 
-    def test_next_node(self):
+    def test_child(self):
         attrs = {"id": "1"}
         ns_map = {"ns0": "xsdata"}
         var = XmlText(name="foo", qname="foo")
         node = WildcardNode(position=0, var=var, attrs={}, ns_map={})
-        actual = node.next_node("foo", attrs, ns_map, 10)
+        actual = node.child("foo", attrs, ns_map, 10)
 
         self.assertIsInstance(actual, WildcardNode)
         self.assertEqual(10, actual.position)
@@ -364,31 +340,31 @@ class UnionNodeTests(TestCase):
         self.assertEqual(attrs, node.attrs)
         self.assertIsNot(attrs, node.attrs)
 
-    def test_next_node(self):
+    def test_child(self):
         attrs = {"id": "1"}
         ns_map = {"ns0": "xsdata"}
         ctx = XmlContext()
         var = XmlText(name="foo", qname="foo")
         node = UnionNode(position=0, var=var, context=ctx, attrs={}, ns_map={})
-        self.assertEqual(node, node.next_node("foo", attrs, ns_map, 10))
+        self.assertEqual(node, node.child("foo", attrs, ns_map, 10))
 
         self.assertEqual(1, node.level)
         self.assertEqual([("start", "foo", attrs, ns_map)], node.events)
         self.assertIsNot(attrs, node.events[0][2])
 
-    def test_assemble_appends_end_event_when_level_not_zero(self):
+    def test_bind_appends_end_event_when_level_not_zero(self):
         ctx = XmlContext()
         var = XmlText(name="foo", qname="foo")
         node = UnionNode(position=0, var=var, context=ctx, attrs={}, ns_map={})
         node.level = 1
+        objects = []
 
-        qname, obj = node.assemble("bar", "text", "tail", [])
-        self.assertIsNone(qname)
-        self.assertIsNone(obj)
+        self.assertFalse(node.bind("bar", "text", "tail", objects))
+        self.assertEqual(0, len(objects))
         self.assertEqual(0, node.level)
         self.assertEqual([("end", "bar", "text", "tail")], node.events)
 
-    def test_assemble_returns_best_matching_dataclass(self):
+    def test_bind_returns_best_matching_dataclass(self):
         @dataclass
         class Item:
             value: str = field()
@@ -409,14 +385,16 @@ class UnionNodeTests(TestCase):
         attrs = {"a": "1", "b": 2}
         ns_map = {}
         node = UnionNode(position=0, var=var, context=ctx, attrs=attrs, ns_map=ns_map)
+        objects = []
 
-        qname, obj = node.assemble("item", "foo", None, [])
-        self.assertIsInstance(obj, Item)
-        self.assertEqual(1, obj.a)
-        self.assertEqual(2, obj.b)
-        self.assertEqual("foo", obj.value)
+        self.assertTrue(node.bind("item", "foo", None, objects))
+        self.assertIsInstance(objects[-1][1], Item)
+        self.assertEqual(1, objects[-1][1].a)
+        self.assertEqual(2, objects[-1][1].b)
+        self.assertEqual("foo", objects[-1][1].value)
+        self.assertEqual("item", objects[-1][0])
 
-    def test_assemble_raises_parser_error_on_failure(self):
+    def test_bind_raises_parser_error_on_failure(self):
         @dataclass
         class Item:
             value: str = field()
@@ -432,41 +410,44 @@ class UnionNodeTests(TestCase):
         node = UnionNode(position=0, var=meta.vars[0], context=ctx, attrs={}, ns_map={})
 
         with self.assertRaises(ParserError) as cm:
-            node.assemble("item", None, None, [])
+            node.bind("item", None, None, [])
 
         self.assertEqual("Failed to parse union node: item", str(cm.exception))
 
 
 class PrimitiveNodeTests(TestCase):
     @mock.patch.object(ParserUtils, "parse_value")
-    def test_assemble(self, mock_parse_value):
+    def test_bind(self, mock_parse_value):
         mock_parse_value.return_value = 13
         var = XmlText(name="foo", qname="foo", default=100)
         ns_map = {"foo": "bar"}
         node = PrimitiveNode(var=var, ns_map=ns_map)
+        objects = []
 
-        self.assertEqual(("foo", 13), node.assemble("foo", "13", "Impossible", []))
+        self.assertTrue(node.bind("foo", "13", "Impossible", objects))
+        self.assertEqual(("foo", 13), objects[-1])
+
         mock_parse_value.assert_called_once_with(
             "13", var.types, var.default, ns_map, var.tokens
         )
 
-    def test_next_node(self):
+    def test_child(self):
         node = PrimitiveNode(var=XmlText(name="foo", qname="foo"), ns_map={})
 
         with self.assertRaises(XmlContextError):
-            node.next_node("foo", {}, {}, 0)
+            node.child("foo", {}, {}, 0)
 
 
 class SKipNodeTests(TestCase):
-    def test_next_node(self):
+    def test_child(self):
         node = SkipNode()
-        actual = node.next_node("foo", {}, {}, 1)
+        actual = node.child("foo", {}, {}, 1)
 
         self.assertIs(node, actual)
 
-    def test_assemble(self):
+    def test_bind(self):
         node = SkipNode()
-        self.assertEqual((None, None), node.assemble("foo", None, None, []))
+        self.assertEqual(False, node.bind("foo", None, None, []))
 
 
 class ElementParserTests(TestCase):

--- a/tests/formats/dataclass/parsers/test_utils.py
+++ b/tests/formats/dataclass/parsers/test_utils.py
@@ -334,3 +334,18 @@ class ParserUtilsTests(TestCase):
 
         ParserUtils.bind_wildcard_element(params, var, "first", None, attrs, ns_map)
         self.assertEqual(dict(a=["first", "txt", "tail", "tail"]), params)
+
+    def test_prepare_generic_value(self):
+        @dataclass
+        class Fixture:
+            content: str
+
+        actual = ParserUtils.prepare_generic_value(None, "foo")
+        self.assertEqual("foo", actual)
+
+        actual = ParserUtils.prepare_generic_value("a", "foo")
+        self.assertEqual(AnyElement(qname="a", text="foo"), actual)
+
+        fixture = Fixture("foo")
+        ParserUtils.prepare_generic_value("a", fixture)
+        self.assertEqual("a", fixture.qname)

--- a/tests/formats/dataclass/parsers/test_xml.py
+++ b/tests/formats/dataclass/parsers/test_xml.py
@@ -35,7 +35,7 @@ class XmlParserTests(TestCase):
         self.parser.add_namespace(("foo", "bar"))
         self.assertEqual({"foo": "bar"}, self.parser.namespaces.ns_map)
 
-    @mock.patch.object(ElementNode, "next_node")
+    @mock.patch.object(ElementNode, "child")
     @mock.patch.object(XmlParser, "emit_event")
     def test_start(self, mock_emit_event, mock_next_node):
         var = XmlText(name="foo", qname="foo")
@@ -72,9 +72,9 @@ class XmlParserTests(TestCase):
         )
 
     @mock.patch.object(XmlParser, "emit_event")
-    @mock.patch.object(PrimitiveNode, "assemble", return_value=("q", "result"))
+    @mock.patch.object(PrimitiveNode, "bind", return_value=True)
     def test_end(self, mock_assemble, mock_emit_event):
-        objects = []
+        objects = [("q", "result")]
         queue = []
         var = XmlText(name="foo", qname="foo")
         queue.append(PrimitiveNode(var=var, ns_map={}))
@@ -88,13 +88,12 @@ class XmlParserTests(TestCase):
 
     @mock.patch.object(XmlParser, "emit_event")
     def test_end_with_no_result(self, mock_emit_event):
-        objects = []
+        objects = [("q", "result")]
         queue = [SkipNode()]
 
         result = self.parser.end(queue, "author", "foobar", None, objects)
         self.assertIsNone(result)
         self.assertEqual(0, len(queue))
-        self.assertEqual(0, len(objects))
         self.assertEqual(0, mock_emit_event.call_count)
 
     def test_emit_event(self):

--- a/tests/formats/dataclass/test_context.py
+++ b/tests/formats/dataclass/test_context.py
@@ -175,12 +175,12 @@ class XmlContextTests(TestCase):
         self.assertIsInstance(result, Iterator)
 
         expected = [
-            XmlElement(name="author", qname="author", types=[str],),
+            XmlElement(name="author", qname="author", types=[str]),
             XmlElement(name="title", qname="title", types=[str]),
             XmlElement(name="genre", qname="genre", types=[str]),
-            XmlElement(name="price", qname="price", types=[float],),
-            XmlElement(name="pub_date", qname="pub_date", types=[str],),
-            XmlElement(name="review", qname="review", types=[str],),
+            XmlElement(name="price", qname="price", types=[float]),
+            XmlElement(name="pub_date", qname="pub_date", types=[str]),
+            XmlElement(name="review", qname="review", types=[str]),
             XmlAttribute(name="id", qname="id", types=[str]),
             XmlAttribute(
                 name="lang", qname="lang", types=[str], init=False, default="en",

--- a/xsdata/formats/dataclass/parsers/utils.py
+++ b/xsdata/formats/dataclass/parsers/utils.py
@@ -124,12 +124,16 @@ class ParserUtils:
         return True
 
     @classmethod
-    def prepare_generic_value(cls, qname: str, value: Any) -> Any:
+    def prepare_generic_value(cls, qname: Optional[str], value: Any) -> Any:
         """Prepare parsed value before binding to a wildcard field."""
+
+        if not qname:
+            return value
+
         if not is_dataclass(value):
             value = AnyElement(qname=qname, text=value)
         elif not isinstance(value, AnyElement):
-            value.qname = qname
+            value.qname = qname  # Deprecate this hack!
 
         return value
 


### PR DESCRIPTION
The first option was to turn any mixed content nodes to simple wildcards, but this defeats the purpose of having attributes with the `content: List[object]` if it only can manage the generic `AnyElement`

The second option is to introduce in the xml serializer the ability to serialize a sequence of any object. This is experimental, even in the w3c test suite I only have a few tests that cover this scenario.

Obviously because the XmlContext class is still not able to match  any qname against any declared dataclass and not just derived typed.

The whole wildcard/mixed content needs a revisit at some point in the future, I 've noticed a couple of old hacks lurking around...

```python
        
obj = Example()
obj.content.append("Hi")
obj.content.append(AnyElement(qname="b", text="Mr."))
obj.content.append(Span("chris"))
obj.content.append("!")

print(serializer.render(obj))
>>> "<Example>Hi<b>Mr.</b><Span>chris</Span>!</Example>"

```