### PR TITLE
Xml Content Handlers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     hooks:
       - id: reorder-python-imports
   - repo: https://github.com/ambv/black
-    rev: 19.10b0
+    rev: 20.8b1
     hooks:
       - id: black
   - repo: https://gitlab.com/pycqa/flake8

--- a/docs/examples/__init__.py
+++ b/docs/examples/__init__.py
@@ -1,7 +1,0 @@
-from examples.primer import (
-    Items,
-    PurchaseOrderType,
-    Usaddress,
-    Comment,
-    PurchaseOrder,
-)

--- a/docs/examples/xml_parser.py
+++ b/docs/examples/xml_parser.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+from docs.examples.primer import Usaddress, PurchaseOrder
+from tests import fixtures_dir
+from tests.fixtures.books import Books
+from xsdata.formats.dataclass.parsers import XmlParser
+from xsdata.formats.dataclass.parsers.config import ParserConfig
+
+config = ParserConfig(fail_on_unknown_properties=True)
+parser = XmlParser(config=config)
+order = parser.from_path(Path("primer.xml"), PurchaseOrder)
+
+assert order.bill_to == Usaddress(
+    name='Robert Smith',
+    street='8 Oak Avenue',
+    city='Old Town',
+    state='PA',
+    zip=95819.0
+)
+
+path = fixtures_dir.joinpath("books/books-xinclude.xml")
+config = ParserConfig(process_xinclude=True, base_url=path.as_uri())
+parser = XmlParser(config=config)
+actual = parser.from_bytes(path.read_bytes(), Books)
+
+from xsdata.formats.dataclass.parsers.handlers import XmlEventHandler
+
+parser = XmlParser(handler=XmlEventHandler)
+order = parser.from_path(Path("primer.xml"), PurchaseOrder)

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ dev =
     codecov
     pre-commit
     pytest
+    pytest-benchmark
     pytest-cov
     tox
 docs =

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,7 @@
+import tempfile
 from pathlib import Path
 
 
 root = Path(__file__).parent.parent
 fixtures_dir = root.joinpath("tests/fixtures")
+xsdata_temp_dir = Path(tempfile.gettempdir()).joinpath("xsdata")

--- a/tests/codegen/handlers/test_attribute_enum_union.py
+++ b/tests/codegen/handlers/test_attribute_enum_union.py
@@ -25,7 +25,7 @@ class AttributeEnumUnionHandlerTests(FactoryTestCase):
                         ),
                     ],
                 ),
-            ],
+            ]
         )
         self.target.inner.append(self.inner_enum)
 

--- a/tests/codegen/handlers/test_attribute_substitution.py
+++ b/tests/codegen/handlers/test_attribute_substitution.py
@@ -91,7 +91,7 @@ class AttributeSubstitutionHandlerTests(FactoryTestCase):
         self.assertEqual(expected, self.processor.substitutions)
 
         mock_create_substitution.assert_has_calls(
-            [mock.call(classes[0]), mock.call(classes[0]), mock.call(classes[1]),]
+            [mock.call(classes[0]), mock.call(classes[0]), mock.call(classes[1])]
         )
 
     def test_create_substitution(self):

--- a/tests/codegen/handlers/test_attribute_type.py
+++ b/tests/codegen/handlers/test_attribute_type.py
@@ -103,7 +103,7 @@ class AttributeTypeHandlerTests(FactoryTestCase):
     @mock.patch.object(AttributeTypeHandler, "reset_attribute_type")
     @mock.patch.object(AttributeTypeHandler, "find_dependency")
     def test_process_dependency_type_with_absent_type(
-        self, mock_find_dependency, mock_reset_attribute_type,
+        self, mock_find_dependency, mock_reset_attribute_type
     ):
         mock_find_dependency.return_value = None
         target = ClassFactory.create()
@@ -116,7 +116,7 @@ class AttributeTypeHandlerTests(FactoryTestCase):
     @mock.patch.object(AttributeTypeHandler, "process_simple_dependency")
     @mock.patch.object(AttributeTypeHandler, "find_dependency")
     def test_process_dependency_type_with_simple_type(
-        self, mock_find_dependency, mock_process_simple_dependency,
+        self, mock_find_dependency, mock_process_simple_dependency
     ):
         simple = ClassFactory.create(type=SimpleType)
 
@@ -134,7 +134,7 @@ class AttributeTypeHandlerTests(FactoryTestCase):
     @mock.patch.object(AttributeTypeHandler, "process_complex_dependency")
     @mock.patch.object(AttributeTypeHandler, "find_dependency")
     def test_process_dependency_type_with_complex_type(
-        self, mock_find_dependency, mock_process_complex_dependency,
+        self, mock_find_dependency, mock_process_complex_dependency
     ):
         complex = ClassFactory.create(type=ComplexType)
         element = ClassFactory.create(type=Element)

--- a/tests/codegen/handlers/test_class_extension.py
+++ b/tests/codegen/handlers/test_class_extension.py
@@ -334,7 +334,7 @@ class ClassExtensionHandlerTests(FactoryTestCase):
 
         ClassExtensionHandler.create_default_attribute(item, extension)
         expected = AttrFactory.create(
-            name="value", default=None, types=[extension.type], tag=Tag.EXTENSION,
+            name="value", default=None, types=[extension.type], tag=Tag.EXTENSION
         )
 
         self.assertEqual(1, len(item.attrs))

--- a/tests/codegen/mappers/test_definitions.py
+++ b/tests/codegen/mappers/test_definitions.py
@@ -64,7 +64,7 @@ class DefinitionsMapperTests(FactoryTestCase):
     @mock.patch.object(Definitions, "find_port_type")
     @mock.patch.object(Definitions, "find_binding")
     def test_map_port(
-        self, mock_find_binding, mock_find_port_type, mock_attributes, mock_map_binding,
+        self, mock_find_binding, mock_find_port_type, mock_attributes, mock_map_binding
     ):
         definitions = Definitions()
         service_port = ServicePort(binding="zaa:port", extended=[AnyElement()])
@@ -102,7 +102,7 @@ class DefinitionsMapperTests(FactoryTestCase):
     @mock.patch.object(PortType, "find_operation")
     @mock.patch.object(DefinitionsMapper, "attributes")
     def test_map_binding(
-        self, mock_attributes, mock_find_operation, mock_map_binding_operation,
+        self, mock_attributes, mock_find_operation, mock_map_binding_operation
     ):
         definitions = Definitions()
         port_type = PortType(name="Calc")
@@ -335,7 +335,7 @@ class DefinitionsMapperTests(FactoryTestCase):
                 AnyElement(qname="body"),
                 AnyElement(qname="header"),
                 AnyElement(qname="header"),
-            ],
+            ]
         )
         binding_message.ns_map["foo"] = "bar"
 
@@ -411,7 +411,7 @@ class DefinitionsMapperTests(FactoryTestCase):
                 AnyElement(qname="body", attributes={"namespace": "bodyns"}),
                 AnyElement(qname="header"),
                 AnyElement(qname="header"),
-            ],
+            ]
         )
         binding_message.ns_map["foo"] = "bar"
 

--- a/tests/codegen/mappers/test_schema.py
+++ b/tests/codegen/mappers/test_schema.py
@@ -188,7 +188,7 @@ class SchemaMapperTests(FactoryTestCase):
         sequence_one = Sequence(elements=[Element(), Element()])
         sequence_two = Sequence(max_occurs=2, elements=[Element(), Element()])
         restriction = Restriction(
-            enumerations=[Enumeration(value=x) for x in "abc"], sequence=sequence_two,
+            enumerations=[Enumeration(value=x) for x in "abc"], sequence=sequence_two
         )
         complex_type = ComplexType(
             attributes=[Attribute(), Attribute()],
@@ -392,5 +392,5 @@ class SchemaMapperTests(FactoryTestCase):
         self.assertIsNone(enumeration.name)
 
         mock_build_class.assert_called_once_with(
-            enumeration, Tag.SIMPLE_TYPE, "module", "target_ns",
+            enumeration, Tag.SIMPLE_TYPE, "module", "target_ns"
         )

--- a/tests/codegen/parsers/test_schema.py
+++ b/tests/codegen/parsers/test_schema.py
@@ -3,8 +3,6 @@ from pathlib import Path
 from unittest import mock
 from unittest import TestCase
 
-from lxml import etree
-
 from xsdata.codegen.parsers.schema import SchemaParser
 from xsdata.models.enums import FormType
 from xsdata.models.enums import Mode

--- a/tests/codegen/test_container.py
+++ b/tests/codegen/test_container.py
@@ -44,7 +44,7 @@ class ClassContainerTests(FactoryTestCase):
         self.assertEqual(class_a, self.container.find(class_a.qname))
         self.assertEqual(class_b, self.container.find(class_b.qname))
         self.assertEqual(
-            class_c, self.container.find(class_b.qname, lambda x: x.is_enumeration),
+            class_c, self.container.find(class_b.qname, lambda x: x.is_enumeration)
         )
         mock_process_class.assert_called_once_with(class_a)
 
@@ -62,5 +62,5 @@ class ClassContainerTests(FactoryTestCase):
         mock_process_class.side_effect = process_class
 
         self.assertEqual(
-            second, self.container.find(first.qname, lambda x: len(x.attrs) == 2),
+            second, self.container.find(first.qname, lambda x: len(x.attrs) == 2)
         )

--- a/tests/codegen/test_transformer.py
+++ b/tests/codegen/test_transformer.py
@@ -144,7 +144,7 @@ class SchemaTransformerTests(FactoryTestCase):
     @mock.patch.object(SchemaTransformer, "analyze_classes")
     @mock.patch.object(SchemaTransformer, "assign_packages")
     def test_process_classes_with_zero_classes_after_analyze(
-        self, mock_assign_packages, mock_analyze_classes, mock_logger_warning,
+        self, mock_assign_packages, mock_analyze_classes, mock_logger_warning
     ):
         package = "test"
         self.transformer.process_classes(package)
@@ -183,9 +183,7 @@ class SchemaTransformerTests(FactoryTestCase):
 
     @mock.patch.object(SchemaTransformer, "generate_classes")
     @mock.patch.object(SchemaTransformer, "process_schema")
-    def test_convert_schema(
-        self, mock_process_schema, mock_generate_classes,
-    ):
+    def test_convert_schema(self, mock_process_schema, mock_generate_classes):
         schema = Schema(target_namespace="thug", location="main")
         schema.includes.append(Include(location="foo"))
         schema.overrides.append(Override())
@@ -219,7 +217,7 @@ class SchemaTransformerTests(FactoryTestCase):
     @mock.patch.object(SchemaTransformer, "count_classes")
     @mock.patch.object(SchemaMapper, "map")
     def test_generate_classes(
-        self, mock_mapper_map, mock_count_classes, mock_logger_info,
+        self, mock_mapper_map, mock_count_classes, mock_logger_info
     ):
         schema = Schema(location="edo.xsd")
         classes = ClassFactory.list(2)

--- a/tests/codegen/test_writer.py
+++ b/tests/codegen/test_writer.py
@@ -44,7 +44,7 @@ class EmptyGenerator(FakeGenerator):
     def render(self, classes: List[Class]) -> Iterator[GeneratorResult]:
         for obj in classes:
             yield GeneratorResult(
-                path=Path(f"{self.dir}/{obj.name}.txt"), title="Empty", source="",
+                path=Path(f"{self.dir}/{obj.name}.txt"), title="Empty", source=""
             )
 
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -261,7 +261,7 @@ class AttrFactory(Factory):
     @classmethod
     def any_attribute(cls, **kwargs) -> Attr:
         return cls.create(
-            tag=Tag.ANY_ATTRIBUTE, types=[AttrTypeFactory.xs_any()], **kwargs,
+            tag=Tag.ANY_ATTRIBUTE, types=[AttrTypeFactory.xs_any()], **kwargs
         )
 
     @classmethod

--- a/tests/formats/dataclass/filters/test_format_arguments.py
+++ b/tests/formats/dataclass/filters/test_format_arguments.py
@@ -6,7 +6,7 @@ from xsdata.formats.dataclass.filters import format_arguments
 class AttributeMetadataTests(TestCase):
     def test_format_arguments(self):
         data = dict(
-            num=1, text="foo", text_two="fo'o", text_three='fo"o', pattern="foo",
+            num=1, text="foo", text_two="fo'o", text_three='fo"o', pattern="foo"
         )
 
         expected = '''num=1,

--- a/tests/formats/dataclass/parsers/handlers/__init__.py
+++ b/tests/formats/dataclass/parsers/handlers/__init__.py
@@ -1,0 +1,58 @@
+from tests.fixtures.books import BookForm
+from tests.fixtures.books import Books
+
+books = Books(
+    book=[
+        BookForm(
+            id="bk001",
+            author="Hightower, Kim",
+            title="The First Book",
+            genre="Fiction",
+            price=44.95,
+            pub_date="2000-10-01",
+            review="An amazing story of nothing.",
+        ),
+        BookForm(
+            id="bk002",
+            author="Nagata, Suanne",
+            title="Becoming Somebody",
+            genre="Biography",
+            price=33.95,
+            pub_date="2001-01-10",
+            review="A masterpiece of the fine art of gossiping.",
+        ),
+    ]
+)
+events = [
+    ("start-ns", "brk", "urn:books"),
+    ("start", "{urn:books}books", {}, {"brk": "urn:books"}),
+    ("start", "book", {"id": "bk001"}, {"brk": "urn:books"}),
+    ("start", "author", {}, {"brk": "urn:books"}),
+    ("end", "author", "Hightower, Kim", "\n    "),
+    ("start", "title", {}, {"brk": "urn:books"}),
+    ("end", "title", "The First Book", "\n    "),
+    ("start", "genre", {}, {"brk": "urn:books"}),
+    ("end", "genre", "Fiction", "\n    "),
+    ("start", "price", {}, {"brk": "urn:books"}),
+    ("end", "price", "44.95", "\n    "),
+    ("start", "pub_date", {}, {"brk": "urn:books"}),
+    ("end", "pub_date", "2000-10-01", "\n    "),
+    ("start", "review", {}, {"brk": "urn:books"}),
+    ("end", "review", "An amazing story of nothing.", "\n  "),
+    ("end", "book", "\n    ", "\n  "),
+    ("start", "book", {"id": "bk002"}, {"brk": "urn:books"}),
+    ("start", "author", {}, {"brk": "urn:books"}),
+    ("end", "author", "Nagata, Suanne", "\n    "),
+    ("start", "title", {}, {"brk": "urn:books"}),
+    ("end", "title", "Becoming Somebody", "\n    "),
+    ("start", "genre", {}, {"brk": "urn:books"}),
+    ("end", "genre", "Biography", "\n    "),
+    ("start", "price", {}, {"brk": "urn:books"}),
+    ("end", "price", "33.95", "\n    "),
+    ("start", "pub_date", {}, {"brk": "urn:books"}),
+    ("end", "pub_date", "2001-01-10", "\n    "),
+    ("start", "review", {}, {"brk": "urn:books"}),
+    ("end", "review", "A masterpiece of the fine art of gossiping.", "\n  "),
+    ("end", "book", "\n    ", "\n"),
+    ("end", "{urn:books}books", "\n  ", None),
+]

--- a/tests/formats/dataclass/parsers/handlers/test_lxml.py
+++ b/tests/formats/dataclass/parsers/handlers/test_lxml.py
@@ -1,0 +1,101 @@
+from unittest import mock
+from unittest.case import TestCase
+
+from tests import fixtures_dir
+from tests.fixtures.books import Books
+from tests.formats.dataclass.parsers.handlers import books
+from tests.formats.dataclass.parsers.handlers import events
+from xsdata.exceptions import XmlHandlerError
+from xsdata.formats.dataclass.parsers.handlers import LxmlEventHandler
+from xsdata.formats.dataclass.parsers.handlers import LxmlSaxHandler
+from xsdata.formats.dataclass.parsers.nodes import RecordParser
+
+
+class LxmlEventHandlerTests(TestCase):
+    def setUp(self) -> None:
+        self.parser = RecordParser(handler=LxmlEventHandler)
+
+    def test_parse(self):
+        path = fixtures_dir.joinpath("books/books.xml")
+        self.assertEqual(books, self.parser.from_path(path, Books))
+        self.assertEqual({"brk": "urn:books"}, self.parser.namespaces.ns_map)
+        self.assertEqual(events, self.parser.events)
+
+    def test_parse_with_xinclude(self):
+        path = fixtures_dir.joinpath("books/books-xinclude.xml")
+        ns_map = {"brk": "urn:books", "xi": "http://www.w3.org/2001/XInclude"}
+
+        self.parser.config.process_xinclude = True
+        self.assertEqual(books, self.parser.from_path(path, Books))
+        self.assertEqual(ns_map, self.parser.namespaces.ns_map)
+
+    def test_parse_with_xinclude_from_memory(self):
+        path = fixtures_dir.joinpath("books/books-xinclude.xml")
+        ns_map = {"brk": "urn:books", "xi": "http://www.w3.org/2001/XInclude"}
+
+        self.parser.config.process_xinclude = True
+        self.parser.config.base_url = path.as_uri()
+        self.assertEqual(books, self.parser.from_bytes(path.read_bytes(), Books))
+        self.assertEqual(ns_map, self.parser.namespaces.ns_map)
+
+    def test_parse_context_with_unhandled_event(self):
+        handler = LxmlEventHandler(clazz=Books, parser=self.parser)
+
+        with self.assertRaises(XmlHandlerError) as cm:
+            handler.process_context([("reverse", "")])
+
+        self.assertEqual("Unhandled event: `reverse`.", str(cm.exception))
+
+
+class LxmlSaxHandlerTests(TestCase):
+    def setUp(self):
+        self.parser = RecordParser(handler=LxmlSaxHandler)
+
+    def test_parse(self):
+        path = fixtures_dir.joinpath("books/books.xml")
+        self.assertEqual(books, self.parser.from_path(path, Books))
+        self.assertEqual({"brk": "urn:books"}, self.parser.namespaces.ns_map)
+        self.assertEqual(events, self.parser.events)
+
+    def test_parse_from_memory(self):
+        path = fixtures_dir.joinpath("books/books.xml")
+        self.assertEqual(books, self.parser.from_bytes(path.read_bytes(), Books))
+        self.assertEqual({"brk": "urn:books"}, self.parser.namespaces.ns_map)
+        self.assertEqual(events, self.parser.events)
+
+    def test_close_with_no_objects_returns_none(self):
+        handler = LxmlSaxHandler(clazz=Books, parser=self.parser)
+        self.assertIsNone(handler.close())
+
+    @mock.patch.object(RecordParser, "end")
+    def test_flush_normalizes_data_frames(self, mock_end):
+        queue = []
+        objects = []
+        handler = LxmlSaxHandler(
+            parser=self.parser, clazz=Books, queue=queue, objects=objects
+        )
+        handler.data_frames.append(([], []))
+        handler.flush_next = "value"
+        handler.flush()
+
+        handler.data_frames.append((["a", "b"], [""]))
+        handler.flush_next = "value"
+        handler.flush()
+
+        mock_end.assert_has_calls(
+            [
+                mock.call(queue, "value", None, None, objects),
+                mock.call(queue, "value", "ab", "", objects),
+            ]
+        )
+        self.assertEqual(2, mock_end.call_count)
+
+    def test_parse_with_xinclude_raises_exception(self):
+        self.parser.config.process_xinclude = True
+
+        with self.assertRaises(XmlHandlerError) as cm:
+            self.parser.from_string("", Books)
+
+        self.assertEqual(
+            "LxmlSaxHandler doesn't support xinclude elements.", str(cm.exception)
+        )

--- a/tests/formats/dataclass/parsers/handlers/test_native.py
+++ b/tests/formats/dataclass/parsers/handlers/test_native.py
@@ -1,0 +1,68 @@
+from unittest import mock
+from unittest.case import TestCase
+
+from tests import fixtures_dir
+from tests.fixtures.books import Books
+from tests.formats.dataclass.parsers.handlers import books
+from tests.formats.dataclass.parsers.handlers import events
+from xsdata.exceptions import XmlHandlerError
+from xsdata.formats.dataclass.parsers.handlers import XmlEventHandler
+from xsdata.formats.dataclass.parsers.handlers import XmlSaxHandler
+from xsdata.formats.dataclass.parsers.nodes import RecordParser
+
+
+class XmlEventHandlerTests(TestCase):
+    def setUp(self):
+        self.parser = RecordParser(handler=XmlEventHandler)
+        self.fixture = fixtures_dir.joinpath("books/books.xml")
+
+    def test_parse(self):
+        self.assertEqual(books, self.parser.from_path(self.fixture, Books))
+        self.assertEqual({"brk": "urn:books"}, self.parser.namespaces.ns_map)
+        self.assertEqual(events, self.parser.events)
+
+    def test_parse_with_xinclude_raises_exception(self):
+        self.parser.config.process_xinclude = True
+
+        with self.assertRaises(XmlHandlerError) as cm:
+            self.parser.from_path(self.fixture, Books)
+
+        self.assertEqual(
+            "XmlEventHandler doesn't support xinclude elements.", str(cm.exception)
+        )
+
+    def test_parse_context_with_unhandled_event(self):
+        context = [("reverse", None)]
+        handler = XmlEventHandler(parser=self.parser, clazz=Books)
+
+        with self.assertRaises(XmlHandlerError) as cm:
+            handler.process_context(context)
+
+        self.assertEqual("Unhandled event: `reverse`.", str(cm.exception))
+
+
+class SaxHandlerTests(TestCase):
+    def setUp(self):
+        self.parser = RecordParser(handler=XmlSaxHandler)
+        self.fixture = fixtures_dir.joinpath("books/books.xml")
+
+    def test_parse(self):
+        self.assertEqual(books, self.parser.from_path(self.fixture, Books))
+        self.assertEqual({"brk": "urn:books"}, self.parser.namespaces.ns_map)
+        self.assertEqual(events, self.parser.events)
+
+    @mock.patch.object(RecordParser, "end")
+    @mock.patch.object(RecordParser, "start")
+    def test_parse_returns_none_if_objects_empty(self, mock_start, mock_end):
+        handler = XmlSaxHandler(parser=self.parser, clazz=Books)
+        self.assertIsNone(handler.parse(self.fixture.as_uri()))
+
+    def test_parse_with_xinclude_raises_exception(self):
+        self.parser.config.process_xinclude = True
+
+        with self.assertRaises(XmlHandlerError) as cm:
+            self.parser.from_path(self.fixture, Books)
+
+        self.assertEqual(
+            "XmlSaxHandler doesn't support xinclude elements.", str(cm.exception)
+        )

--- a/tests/formats/dataclass/parsers/test_mixins.py
+++ b/tests/formats/dataclass/parsers/test_mixins.py
@@ -1,0 +1,37 @@
+from unittest.case import TestCase
+
+from tests.fixtures.books import Books
+from tests.formats.dataclass.parsers.handlers import books
+from tests.formats.dataclass.parsers.handlers import events
+from xsdata.exceptions import XmlHandlerError
+from xsdata.formats.dataclass.parsers.mixins import EventsHandler
+from xsdata.formats.dataclass.parsers.mixins import XmlHandler
+from xsdata.formats.dataclass.parsers.nodes import RecordParser
+
+
+class XmlHandlerTests(TestCase):
+    def test_process(self):
+        parser = RecordParser()
+        handler = XmlHandler(clazz=Books, parser=parser)
+
+        self.assertEqual([], handler.queue)
+        self.assertEqual([], handler.objects)
+
+        with self.assertRaises(NotImplementedError):
+            handler.parse(None)
+
+
+class EventsHandlerTests(TestCase):
+    def setUp(self) -> None:
+        self.parser = RecordParser(handler=EventsHandler)
+
+    def test_parse(self):
+        self.assertEqual(books, self.parser.parse(events, Books))
+        self.assertEqual({"brk": "urn:books"}, self.parser.namespaces.ns_map)
+
+    def test_parse_with_unhandled_event(self):
+
+        with self.assertRaises(XmlHandlerError) as cm:
+            self.parser.parse([("reverse", "")], Books)
+
+        self.assertEqual("Unhandled event: `reverse`.", str(cm.exception))

--- a/tests/formats/dataclass/parsers/test_utils.py
+++ b/tests/formats/dataclass/parsers/test_utils.py
@@ -161,7 +161,7 @@ class ParserUtilsTests(TestCase):
         self.assertEqual(expected, params)
         mock_parse_any_attribute.assert_called_once_with("bar", ns_map)
         mock_parse_value.assert_called_once_with(
-            "2020-03-01", eff_date.types, eff_date.default, ns_map, eff_date.is_list,
+            "2020-03-01", eff_date.types, eff_date.default, ns_map, eff_date.is_list
         )
 
     def test_parse_any_attributes(self):
@@ -236,7 +236,7 @@ class ParserUtilsTests(TestCase):
         ParserUtils.bind_element(params, metadata, "foo", None, {}, ns_map)
         self.assertEqual({"value": "yes!"}, params)
         mock_parse_value.assert_called_once_with(
-            "foo", var.types, var.default, ns_map, var.is_list,
+            "foo", var.types, var.default, ns_map, var.is_list
         )
 
     def test_bind_element_with_wildcard_var(self):

--- a/tests/formats/dataclass/parsers/test_xml.py
+++ b/tests/formats/dataclass/parsers/test_xml.py
@@ -1,17 +1,8 @@
-from dataclasses import asdict
-from dataclasses import dataclass
-from dataclasses import field
-from typing import List
 from unittest import mock
 from unittest.case import TestCase
 
-from tests import fixtures_dir
-from tests.fixtures.books import BookForm
 from tests.fixtures.books import Books
-from xsdata.exceptions import ParserError
 from xsdata.formats.dataclass.models.elements import XmlText
-from xsdata.formats.dataclass.parsers.config import ParserConfig
-from xsdata.formats.dataclass.parsers.nodes import ElementNode
 from xsdata.formats.dataclass.parsers.nodes import PrimitiveNode
 from xsdata.formats.dataclass.parsers.nodes import SkipNode
 from xsdata.formats.dataclass.parsers.xml import XmlParser
@@ -22,77 +13,41 @@ class XmlParserTests(TestCase):
     def setUp(self):
         super().setUp()
         self.parser = XmlParser()
-        self.parser.index = 10
         self.parser.objects = [(x, x) for x in "abcde"]
 
-    def test_parse_context_raises_exception(self):
-        with self.assertRaises(ParserError) as cm:
-            self.parser.parse_context([], Books)
-
-        self.assertEqual("Failed to create target class `Books`", str(cm.exception))
-
-    def test_add_namespace(self):
-        self.parser.add_namespace(("foo", "bar"))
-        self.assertEqual({"foo": "bar"}, self.parser.namespaces.ns_map)
-
-    @mock.patch.object(ElementNode, "child")
     @mock.patch.object(XmlParser, "emit_event")
-    def test_start(self, mock_emit_event, mock_next_node):
-        var = XmlText(name="foo", qname="foo")
-        primitive_node = PrimitiveNode(var=var, ns_map={})
-        mock_next_node.return_value = primitive_node
-        config = ParserConfig()
-        attrs = {}
-        ns_map = {}
-
+    def test_start(self, mock_emit_event):
+        attrs = {"a": "b"}
         queue = []
-        expected_root_node = ElementNode(
-            position=0,
-            context=self.parser.context,
-            meta=self.parser.context.build(Books),
-            config=config,
-            attrs=attrs,
-            ns_map=ns_map,
-        )
 
-        self.parser.start(queue, "{urn:books}books", attrs, ns_map, 0, Books)
-
+        self.parser.start(queue, "{urn:books}books", attrs, {}, [], Books)
         self.assertEqual(1, len(queue))
-        self.assertEqual(expected_root_node, queue[0])
 
-        self.parser.start(queue, "child", attrs, ns_map, 1, Books)
-        self.assertEqual(2, len(queue))
-        self.assertEqual(primitive_node, queue[1])
-
-        mock_emit_event.assert_has_calls(
-            [
-                mock.call(EventType.START, "{urn:books}books", attrs=attrs),
-                mock.call(EventType.START, "child", attrs={}),
-            ]
+        mock_emit_event.assert_called_once_with(
+            EventType.START, "{urn:books}books", attrs=attrs
         )
 
     @mock.patch.object(XmlParser, "emit_event")
-    @mock.patch.object(PrimitiveNode, "bind", return_value=True)
-    def test_end(self, mock_assemble, mock_emit_event):
-        objects = [("q", "result")]
+    def test_end(self, mock_emit_event):
+        objects = []
         queue = []
-        var = XmlText(name="foo", qname="foo")
+        var = XmlText(name="foo", qname="foo", types=[bool])
         queue.append(PrimitiveNode(var=var, ns_map={}))
 
-        result = self.parser.end(queue, "author", "foobar", None, objects)
-        self.assertEqual("result", result)
+        result = self.parser.end(queue, "enabled", "true", None, objects)
+        self.assertTrue(result)
         self.assertEqual(0, len(queue))
-        self.assertEqual(("q", result), objects[-1])
-        mock_assemble.assert_called_once_with("author", "foobar", None, objects)
-        mock_emit_event.assert_called_once_with(EventType.END, "author", obj=result)
+        self.assertEqual(("enabled", True), objects[-1])
+        mock_emit_event.assert_called_once_with(EventType.END, "enabled", obj=result)
 
     @mock.patch.object(XmlParser, "emit_event")
     def test_end_with_no_result(self, mock_emit_event):
-        objects = [("q", "result")]
+        objects = []
         queue = [SkipNode()]
 
         result = self.parser.end(queue, "author", "foobar", None, objects)
         self.assertIsNone(result)
+        self.assertEqual(0, len(objects))
         self.assertEqual(0, len(queue))
         self.assertEqual(0, mock_emit_event.call_count)
 
@@ -104,75 +59,3 @@ class XmlParserTests(TestCase):
 
         mock_func.assert_called_once_with(a=1, b=2)
         self.assertEqual({"{tns}barElement": "bar_element"}, self.parser.event_names)
-
-
-class XmlParserIntegrationTest(TestCase):
-    def setUp(self):
-        super().setUp()
-        self.books = Books(
-            book=[
-                BookForm(
-                    id="bk001",
-                    author="Hightower, Kim",
-                    title="The First Book",
-                    genre="Fiction",
-                    price=44.95,
-                    pub_date="2000-10-01",
-                    review="An amazing story of nothing.",
-                ),
-                BookForm(
-                    id="bk002",
-                    author="Nagata, Suanne",
-                    title="Becoming Somebody",
-                    genre="Biography",
-                    price=33.95,
-                    pub_date="2001-01-10",
-                    review="A masterpiece of the fine art of gossiping.",
-                ),
-            ]
-        )
-
-    def test_parse(self):
-        path = fixtures_dir.joinpath("books/books.xml")
-        parser = XmlParser()
-        actual = parser.from_path(path, Books)
-        self.assertEqual(self.books, actual)
-        self.assertEqual({"brk": "urn:books"}, parser.namespaces.ns_map)
-
-    def test_parse_with_process_xinclude_true(self):
-        path = fixtures_dir.joinpath("books/books-xinclude.xml")
-        config = ParserConfig(process_xinclude=True)
-        parser = XmlParser(config=config)
-        actual = parser.from_path(path, Books)
-        self.assertEqual(self.books, actual)
-
-    def test_parse_from_memory_with_process_xinclude_true(self):
-        path = fixtures_dir.joinpath("books/books-xinclude.xml")
-        config = ParserConfig(process_xinclude=True, base_url=path.as_uri())
-        parser = XmlParser(config=config)
-        actual = parser.from_bytes(path.read_bytes(), Books)
-        self.assertEqual(self.books, actual)
-
-    def test_parse_with_fail_on_unknown_properties_false(self):
-        path = fixtures_dir.joinpath("books/books.xml")
-
-        @dataclass
-        class Book:
-            author: str = field(metadata=dict(type="Element"))
-
-        @dataclass
-        class MyBooks:
-            class Meta:
-                name = "books"
-
-            book: List[Book] = field(
-                default_factory=list, metadata=dict(type="Element")
-            )
-
-        config = ParserConfig(fail_on_unknown_properties=False)
-        parser = XmlParser(config=config)
-        actual = parser.from_path(path, MyBooks)
-        expected = {
-            "book": [{"author": "Hightower, Kim"}, {"author": "Nagata, Suanne"}]
-        }
-        self.assertEqual(expected, asdict(actual))

--- a/tests/formats/dataclass/serializers/test_xml.py
+++ b/tests/formats/dataclass/serializers/test_xml.py
@@ -456,10 +456,16 @@ class XmlSerializerTests(TestCase):
     def test_render_mixed_content(self):
         @dataclass
         class Span:
+            class Meta:
+                name = "span"
+
             content: str
 
         @dataclass
         class Example:
+            class Meta:
+                name = "p"
+
             content: List[object] = field(
                 default_factory=list,
                 metadata=dict(
@@ -479,7 +485,7 @@ class XmlSerializerTests(TestCase):
         self.serializer.xml_declaration = False
         self.serializer.pretty_print = False
         result = self.serializer.render(obj)
-        self.assertEqual("<Example><b>Mr.</b><Span>chris</Span>!</Example>", result)
+        self.assertEqual("<p><b>Mr.</b><span>chris</span>!</p>", result)
 
         obj = Example()
         obj.content.append("Hi ")
@@ -487,4 +493,4 @@ class XmlSerializerTests(TestCase):
         obj.content.append(Span("chris"))
         obj.content.append("!")
         result = self.serializer.render(obj)
-        self.assertEqual("<Example>Hi <b>Mr.</b><Span>chris</Span>!</Example>", result)
+        self.assertEqual("<p>Hi <b>Mr.</b><span>chris</span>!</p>", result)

--- a/tests/formats/dataclass/test_context.py
+++ b/tests/formats/dataclass/test_context.py
@@ -159,9 +159,18 @@ class XmlContextTests(TestCase):
         class Foo(Bar):
             pass
 
+        @dataclass
+        class Thug(Bar):
+            class Meta:
+                name = "thug"
+
         result = self.ctx.build(Foo)
         self.assertEqual("Foo", result.name)
         self.assertEqual("Foo", result.qname)
+
+        result = self.ctx.build(Thug)
+        self.assertEqual("thug", result.name)
+        self.assertEqual("thug", result.qname)
 
     @mock.patch.object(XmlContext, "get_type_hints", return_value={})
     def test_build_with_no_dataclass_raises_exception(self, *args):

--- a/tests/formats/dataclass/test_context.py
+++ b/tests/formats/dataclass/test_context.py
@@ -192,7 +192,7 @@ class XmlContextTests(TestCase):
             XmlElement(name="review", qname="review", types=[str]),
             XmlAttribute(name="id", qname="id", types=[str]),
             XmlAttribute(
-                name="lang", qname="lang", types=[str], init=False, default="en",
+                name="lang", qname="lang", types=[str], init=False, default="en"
             ),
         ]
 

--- a/tests/formats/dataclass/test_elements.py
+++ b/tests/formats/dataclass/test_elements.py
@@ -146,7 +146,7 @@ class XmlTextTests(TestCase):
 class XmlMetaTests(TestCase):
     def test_property_element_form(self):
         meta = XmlMeta(
-            name="foo", clazz=BookForm, qname="foo", source_qname="foo", nillable=False,
+            name="foo", clazz=BookForm, qname="foo", source_qname="foo", nillable=False
         )
         self.assertEqual(FormType.UNQUALIFIED, meta.element_form)
 

--- a/tests/formats/dataclass/test_generator.py
+++ b/tests/formats/dataclass/test_generator.py
@@ -11,9 +11,7 @@ from xsdata.formats.dataclass.generator import DataclassGenerator
 class DataclassGeneratorTests(FactoryTestCase):
     @mock.patch.object(DataclassGenerator, "render_package")
     @mock.patch.object(DataclassGenerator, "render_module")
-    def test_render(
-        self, mock_render_module, mock_render_package,
-    ):
+    def test_render(self, mock_render_module, mock_render_package):
         classes = [
             ClassFactory.create(package="foo.bar"),
             ClassFactory.create(package="bar.foo"),

--- a/tests/formats/test_converter.py
+++ b/tests/formats/test_converter.py
@@ -60,7 +60,7 @@ class ConverterAdapterTests(TestCase):
             self.assertEqual("1", converter.from_string("1", [MinusOneInt]))
 
         self.assertEqual(
-            f"No converter registered for `{MinusOneInt}`", str(w[-1].message),
+            f"No converter registered for `{MinusOneInt}`", str(w[-1].message)
         )
 
         converter.register_converter(MinusOneInt, MinusOneIntConverter())

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,56 @@
+import tempfile
+from pathlib import Path
+
+from tests import xsdata_temp_dir
+from tests.fixtures.books import BookForm
+from tests.fixtures.books import Books
+from xsdata.formats.dataclass.serializers import XmlSerializer
+
+bench_fixtures = {
+    "small": 100,
+    "medium": 1000,
+    "large": 10000,
+}
+
+
+def pytest_configure(config):
+    xsdata_temp_dir.mkdir(parents=True, exist_ok=True)
+    serializer = XmlSerializer()
+
+    for name, items in bench_fixtures.items():
+        result = serializer.render(
+            Books(
+                book=[
+                    BookForm(
+                        author="Arne Dahl",
+                        title="Misterioso: A Crime Novel",
+                        genre="Thrillers & Suspense",
+                        price=15.95,
+                        pub_date="1999-10-05",
+                        review=(
+                            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
+                            "Integer at erat sagittis, accumsan mauris eu, egestas "
+                            "quam. Nam tristique felis justo, vel iaculis ipsum cursus "
+                            "at. Praesent varius enim ac nunc interdum placerat. "
+                            "Integer porttitor, nibh at viverra vehicula, leo dui "
+                            "suscipit nisi, ornare laoreet eros neque nec mi. Proin."
+                        ),
+                        id="9788831796781",
+                    )
+                    for _ in range(items)
+                ]
+            )
+        )
+
+        fixture = xsdata_temp_dir.joinpath(f"benchmark_{name}.xml")
+        fixture.write_text(result)
+        stat = fixture.stat()
+        bench_fixtures[name] = f"{stat.st_size / 1024:.2f} KB"
+
+
+def pytest_unconfigure(config):
+    temp_xsdata = Path(tempfile.gettempdir()).joinpath("xsdata")
+    for tmp_file in temp_xsdata.glob("*"):
+        tmp_file.unlink()
+
+    temp_xsdata.rmdir()

--- a/tests/integration/test_handlers_performance.py
+++ b/tests/integration/test_handlers_performance.py
@@ -1,0 +1,42 @@
+import random
+
+import pytest
+
+from tests import xsdata_temp_dir
+from tests.fixtures.books import Books
+from tests.integration.conftest import bench_fixtures
+from xsdata.formats.dataclass.context import XmlContext
+from xsdata.formats.dataclass.parsers import handlers
+from xsdata.formats.dataclass.parsers import XmlParser
+
+context = XmlContext()
+handlers_list = list(handlers.__all__)
+ids = [f"{key}-{size}" for key, size in bench_fixtures.items()]
+
+random.shuffle(handlers_list)
+
+
+@pytest.mark.benchmark(disable_gc=True, group=f"size: {bench_fixtures['small']}")
+@pytest.mark.parametrize("handler", handlers_list)
+def test_small(benchmark, handler):
+    src = xsdata_temp_dir.joinpath("benchmark_small.xml").read_bytes()
+    benchmark(parse, src, getattr(handlers, handler))
+
+
+@pytest.mark.benchmark(disable_gc=True, group=f"size: {bench_fixtures['medium']}")
+@pytest.mark.parametrize("handler", handlers_list)
+def test_medium(benchmark, handler):
+    src = xsdata_temp_dir.joinpath("benchmark_medium.xml").read_bytes()
+    benchmark(parse, src, getattr(handlers, handler))
+
+
+@pytest.mark.benchmark(disable_gc=True, group=f"size: {bench_fixtures['large']}")
+@pytest.mark.parametrize("handler", handlers_list)
+def test_large(benchmark, handler):
+    src = xsdata_temp_dir.joinpath("benchmark_large.xml").read_bytes()
+    benchmark(parse, src, getattr(handlers, handler))
+
+
+def parse(source, handler):
+    parser = XmlParser(context=context, handler=handler)
+    parser.from_bytes(source, Books)

--- a/tests/models/xsd/test_restriction.py
+++ b/tests/models/xsd/test_restriction.py
@@ -80,7 +80,7 @@ class RestrictionTests(TestCase):
             min_length=MinLength(value=2),
             simple_type=SimpleType(
                 restriction=Restriction(
-                    max_length=MaxLength(value=10), min_length=MinLength(value=5),
+                    max_length=MaxLength(value=10), min_length=MinLength(value=5)
                 )
             ),
         )

--- a/tests/models/xsd/test_union.py
+++ b/tests/models/xsd/test_union.py
@@ -43,10 +43,10 @@ class UnionTests(TestCase):
 
     def test_get_restrictions(self):
         first = Restriction(
-            min_exclusive=MinExclusive(value=1), min_inclusive=MinInclusive(value=2),
+            min_exclusive=MinExclusive(value=1), min_inclusive=MinInclusive(value=2)
         )
         second = Restriction(
-            min_length=MinLength(value=3), max_exclusive=MaxExclusive(value=4),
+            min_length=MinLength(value=3), max_exclusive=MaxExclusive(value=4)
         )
         obj = Union(
             simple_types=[

--- a/xsdata/codegen/handlers/class_extension.py
+++ b/xsdata/codegen/handlers/class_extension.py
@@ -123,10 +123,7 @@ class ClassExtensionHandler(HandlerInterface):
         Search priority: xs:SimpleType >  xs:ComplexType
         """
 
-        conditions = (
-            lambda x: x.type is SimpleType,
-            lambda x: x.type is ComplexType,
-        )
+        conditions = (lambda x: x.type is SimpleType, lambda x: x.type is ComplexType)
 
         for condition in conditions:
             result = self.container.find(attr_type.qname, condition=condition)

--- a/xsdata/codegen/mappers/definitions.py
+++ b/xsdata/codegen/mappers/definitions.py
@@ -315,7 +315,7 @@ class DefinitionsMapper:
         Build attributes for the given list of parts.
 
         :param parts: List of parts
-        :param ns_map: Namespaces dictionary of the parent class
+        :param ns_map: A prefix-URI Namespace mapping
         """
         for part in parts:
             if part.element:

--- a/xsdata/codegen/mappers/schema.py
+++ b/xsdata/codegen/mappers/schema.py
@@ -278,5 +278,5 @@ class SchemaMapper:
     @classmethod
     def is_class(cls, item: ElementBase) -> bool:
         return isinstance(
-            item, (SimpleType, ComplexType, Group, AttributeGroup, Element, Attribute),
+            item, (SimpleType, ComplexType, Group, AttributeGroup, Element, Attribute)
         )

--- a/xsdata/codegen/parsers/schema.py
+++ b/xsdata/codegen/parsers/schema.py
@@ -50,12 +50,12 @@ class SchemaParser(XmlParser):
         qname: str,
         attrs: Dict,
         ns_map: Dict,
-        position: int,
+        objects: List[Parsed],
         clazz: Type[T],
     ):
         self.index += 1
         self.indices.append(self.index)
-        super().start(queue, qname, attrs, ns_map, position, clazz)
+        super().start(queue, qname, attrs, ns_map, objects, clazz)
 
     def end(
         self,
@@ -115,12 +115,7 @@ class SchemaParser(XmlParser):
                 )
 
             ns_list = obj.ns_map.values()
-            ns_common = (
-                Namespace.XS,
-                Namespace.XSI,
-                Namespace.XML,
-                Namespace.XLINK,
-            )
+            ns_common = (Namespace.XS, Namespace.XSI, Namespace.XML, Namespace.XLINK)
             obj.ns_map.update(
                 {ns.prefix: ns.uri for ns in ns_common if ns.uri not in ns_list}
             )

--- a/xsdata/exceptions.py
+++ b/xsdata/exceptions.py
@@ -14,6 +14,10 @@ class ParserError(ValueError):
     """Parsing related errors."""
 
 
+class XmlHandlerError(ValueError):
+    """Xml handler related errors."""
+
+
 class SerializerError(ValueError):
     """Serializing related errors."""
 

--- a/xsdata/formats/bindings.py
+++ b/xsdata/formats/bindings.py
@@ -1,22 +1,20 @@
+import abc
 import io
 import pathlib
-from abc import ABC
-from abc import abstractmethod
 from typing import Any
 from typing import Type
 from typing import TypeVar
 
+T = TypeVar("T")
 
-class AbstractSerializer(ABC):
-    @abstractmethod
+
+class AbstractSerializer(abc.ABC):
+    @abc.abstractmethod
     def render(self, obj: object) -> object:
         """Render the given object to the target output format."""
 
 
-T = TypeVar("T")
-
-
-class AbstractParser(ABC):
+class AbstractParser(abc.ABC):
     def from_path(self, path: pathlib.Path, clazz: Type[T]) -> T:
         """Parse the input file path and return the resulting object tree."""
         return self.parse(str(path.resolve()), clazz)
@@ -29,6 +27,6 @@ class AbstractParser(ABC):
         """Parse the input bytes array return the resulting object tree."""
         return self.parse(io.BytesIO(source), clazz)
 
-    @abstractmethod
+    @abc.abstractmethod
     def parse(self, source: Any, clazz: Type[T]) -> T:
         """Parse the input stream and return the resulting object tree."""

--- a/xsdata/formats/dataclass/context.py
+++ b/xsdata/formats/dataclass/context.py
@@ -106,10 +106,7 @@ class XmlContext:
 
             # Fetch the dataclass meta settings and make sure we don't inherit
             # the parent class meta.
-            meta = getattr(clazz, "Meta", None)
-            if meta and meta.__qualname__ != f"{clazz.__name__}.Meta":
-                meta = None
-
+            meta = clazz.Meta if "Meta" in clazz.__dict__ else None
             name = getattr(meta, "name", self.name_generator(clazz.__name__))
             nillable = getattr(meta, "nillable", False)
             namespace = getattr(meta, "namespace", parent_ns)

--- a/xsdata/formats/dataclass/models/generics.py
+++ b/xsdata/formats/dataclass/models/generics.py
@@ -17,12 +17,12 @@ class AnyElement:
     """
     Generic ElementNode dataclass to bind xml document data to wildcard fields.
 
-    :param qname: qualified name with namespace.
-    :param text: text content.
-    :param tail: tail content.
-    :param ns_map: prefix to namespace map.
-    :param children: children element.
-    :param attributes: element attributes.
+    :param qname: The namespace qualified name.
+    :param text: Element text content.
+    :param tail: Element tail content.
+    :param ns_map: The prefix-URI Namespace mapping
+    :param children: A list of child elements.
+    :param attributes: The element key-value attribute mapping.
     """
 
     qname: Optional[str] = field(default=None)

--- a/xsdata/formats/dataclass/parsers/handlers/__init__.py
+++ b/xsdata/formats/dataclass/parsers/handlers/__init__.py
@@ -1,0 +1,11 @@
+from xsdata.formats.dataclass.parsers.handlers.lxml import LxmlEventHandler
+from xsdata.formats.dataclass.parsers.handlers.lxml import LxmlSaxHandler
+from xsdata.formats.dataclass.parsers.handlers.native import XmlEventHandler
+from xsdata.formats.dataclass.parsers.handlers.native import XmlSaxHandler
+
+__all__ = [
+    "LxmlEventHandler",
+    "LxmlSaxHandler",
+    "XmlEventHandler",
+    "XmlSaxHandler",
+]

--- a/xsdata/formats/dataclass/parsers/handlers/lxml.py
+++ b/xsdata/formats/dataclass/parsers/handlers/lxml.py
@@ -1,0 +1,173 @@
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Optional
+
+from lxml import etree
+
+from xsdata.exceptions import XmlHandlerError
+from xsdata.formats.dataclass.parsers.mixins import XmlHandler
+from xsdata.models.enums import EventType
+
+EVENTS = (EventType.START, EventType.END, EventType.START_NS)
+
+
+@dataclass
+class LxmlEventHandler(XmlHandler):
+    """Content handler based on lxml iterparse api."""
+
+    def parse(self, source: Any) -> Any:
+        """
+        Parse an XML document from a system identifier or an InputSource.
+
+        The xml parser will ignore comments, recover from errors. The
+        parser will parse the whole document and then walk down the tree
+        if the process xinclude is enabled.
+        """
+        if self.parser.config.process_xinclude:
+            tree = etree.parse(source, base_url=self.parser.config.base_url)  # nosec
+            tree.xinclude()
+            ctx = etree.iterwalk(tree, EVENTS)
+        else:
+            ctx = etree.iterparse(source, EVENTS, recover=True, remove_comments=True)
+
+        return self.process_context(ctx)
+
+    def process_context(self, context: Iterable) -> Any:
+        """Iterate context and push the events to main parser."""
+        obj = None
+        for event, element in context:
+            if event == EventType.START:
+                self.parser.start(
+                    self.queue,
+                    element.tag,
+                    element.attrib,
+                    element.nsmap,
+                    self.objects,
+                    self.clazz,
+                )
+            elif event == EventType.END:
+                obj = self.parser.end(
+                    self.queue,
+                    element.tag,
+                    element.text,
+                    element.tail,
+                    self.objects,
+                )
+                element.clear()
+            elif event == EventType.START_NS:
+                prefix, uri = element
+                self.parser.start_prefix_mapping(prefix, uri)
+            else:
+                raise XmlHandlerError(f"Unhandled event: `{event}`.")
+
+        return obj
+
+
+@dataclass
+class LxmlSaxHandler(XmlHandler):
+    """
+    Content handler based on lxml target api.
+
+    :param data_frames: Cache for text/tail element content
+    :param flush_next: Next element name to flush
+    """
+
+    data_frames: List = field(default_factory=list)
+    flush_next: Optional[str] = field(default=None)
+
+    def parse(self, source: Any) -> Any:
+        """
+        Parse an XML document from a system identifier or an InputSource.
+
+        The xml parser will ignore comments, recover from errors and
+        clean duplicate namespace prefixes.
+        """
+
+        if self.parser.config.process_xinclude:
+            raise XmlHandlerError(
+                f"{type(self).__name__} doesn't support xinclude elements."
+            )
+
+        parser = etree.XMLParser(
+            target=self,
+            recover=True,
+            remove_comments=True,
+            ns_clean=True,
+        )
+
+        return etree.parse(source, parser=parser)  # nosec
+
+    def start(self, tag: str, attrib: Dict, ns_map: Dict):
+        """
+        Start element notification receiver.
+
+        The receiver will flush any previous active element, append a
+        new data frame  to collect data content for the next active
+        element and notify the main  parser to prepare for next binding
+        instruction.
+        """
+        self.flush()
+        self.data_frames.append(([], []))
+        self.parser.start(
+            self.queue,
+            tag,
+            attrib,
+            self.start_ns_bulk(ns_map),
+            self.objects,
+            self.clazz,
+        )
+
+    def end(self, tag: str):
+        """
+        End element notification receiver.
+
+        The receiver will flush any previous active element and set the
+        next element to be flushed.
+        """
+        self.flush()
+        self.flush_next = tag
+
+    def close(self) -> Any:
+        """
+        Close document notification receiver.
+
+        The receiver will flush any previous active element and return
+        the first item in the objects stack.
+        """
+        try:
+            self.flush()
+            return self.objects[0][1]
+        except IndexError:
+            return None
+
+    def flush(self):
+        """
+        Flush element notification receiver.
+
+        The receiver will check if there is an active element present,
+        collect and join the data frames for text/tail content and
+        notify the main parser to finish the binding process for the
+        element.
+        """
+        if self.flush_next:
+            data = self.data_frames.pop()
+            text = "".join(data[0]) if data[0] else None
+            tail = "".join(data[1]) if data[1] else None
+
+            self.parser.end(self.queue, self.flush_next, text, tail, self.objects)
+            self.flush_next = None
+
+    def data(self, data: str):
+        """
+        Data notification receiver.
+
+        The receiver will append the given data content in the current
+        data frame either in the text position 0 or in the tail position
+        1 whether the element has ended or not.
+        """
+        index = 0 if self.flush_next is None else 1
+        self.data_frames[-1][index].append(data)

--- a/xsdata/formats/dataclass/parsers/handlers/native.py
+++ b/xsdata/formats/dataclass/parsers/handlers/native.py
@@ -1,0 +1,133 @@
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import Optional
+from typing import Tuple
+from xml import sax
+from xml.etree.ElementTree import iterparse
+
+from xsdata.exceptions import XmlHandlerError
+from xsdata.formats.dataclass.parsers.handlers import LxmlSaxHandler
+from xsdata.formats.dataclass.parsers.mixins import XmlHandler
+from xsdata.models.enums import EventType
+from xsdata.utils import text
+
+EVENTS = (EventType.START, EventType.END, EventType.START_NS)
+
+
+@dataclass
+class XmlEventHandler(XmlHandler):
+    """Content handler based on xml.ElementTree iterparse api."""
+
+    ns_map: Dict = field(default_factory=dict, init=False)
+
+    def parse(self, source: Any) -> Any:
+        """
+        Parse an XML document from a system identifier or an InputSource.
+
+        :raises XmlHandlerError: If process xinclude config is enabled.
+        """
+        if self.parser.config.process_xinclude:
+            raise XmlHandlerError(
+                f"{type(self).__name__} doesn't support xinclude elements."
+            )
+
+        return self.process_context(iterparse(source, EVENTS))  # nosec
+
+    def process_context(self, context: Iterable) -> Any:
+        """Iterate context and push the events to main parser."""
+        obj = None
+        self.ns_map = {}
+        for event, element in context:
+            if event == EventType.START:
+                self.parser.start(
+                    self.queue,
+                    element.tag,
+                    element.attrib,
+                    self.start_ns_bulk(self.ns_map),
+                    self.objects,
+                    self.clazz,
+                )
+                self.ns_map = {}
+            elif event == EventType.END:
+                obj = self.parser.end(
+                    self.queue,
+                    element.tag,
+                    element.text,
+                    element.tail,
+                    self.objects,
+                )
+                element.clear()
+            elif event == EventType.START_NS:
+                prefix, uri = element
+                self.ns_map[prefix] = uri
+            else:
+                raise XmlHandlerError(f"Unhandled event: `{event}`.")
+
+        return obj
+
+
+@dataclass
+class XmlSaxHandler(LxmlSaxHandler, sax.handler.ContentHandler):
+    """
+    Xml sax content handler.
+
+    :param ns_map: Active element prefix-URI Namespace mapping
+    """
+
+    ns_map: Dict = field(default_factory=dict)
+
+    def parse(self, source: Any) -> Any:
+        """
+        Parse an XML document from a system identifier or an InputSource.
+
+        :raises XmlHandlerError: If process xinclude config is enabled.
+        """
+        if self.parser.config.process_xinclude:
+            raise XmlHandlerError(
+                f"{type(self).__name__} doesn't support xinclude elements."
+            )
+
+        parser = sax.make_parser()  # nosec
+        parser.setFeature(sax.handler.feature_namespaces, True)
+        parser.setContentHandler(self)
+        parser.parse(source)
+        return self.close()
+
+    def startElementNS(self, name: Tuple[Optional[str], str], qname: Any, attrs: Dict):
+        """
+        Start element notification receiver.
+
+        The receiver will flush any previous active element, append a new data frame
+         to collect data content for the next active element and notify the main
+         parser to prepare for next binding instruction.
+
+         Converts name and attribute keys to fully qualified tags to respect the
+         main parser api, eg (foo, bar) -> {foo}bar
+        """
+        tag = text.qname(name[0], name[1])
+        attrs = {text.qname(key[0], key[1]): value for key, value in attrs.items()}
+        self.start(tag, attrs, self.ns_map)
+        self.ns_map = {}
+
+    def endElementNS(self, name: Tuple, qname: Any):
+        """
+        End element notification receiver.
+
+        The receiver will flush any previous active element and set the next
+        element to be flushed.
+
+        Converts name and attribute keys to fully qualified tags to respect the
+         main parser api, eg (foo, bar) -> {foo}bar
+        """
+        self.end(text.qname(name[0], name[1]))
+
+    def characters(self, content: str):
+        """Proxy for the data notification receiver."""
+        self.data(content)
+
+    def startPrefixMapping(self, prefix: str, uri: str):
+        """Start element prefix-URI namespace mapping."""
+        self.ns_map[prefix or None] = uri

--- a/xsdata/formats/dataclass/parsers/json.py
+++ b/xsdata/formats/dataclass/parsers/json.py
@@ -6,15 +6,13 @@ from dataclasses import field
 from typing import Any
 from typing import Dict
 from typing import Type
-from typing import TypeVar
 
 from xsdata.formats.bindings import AbstractParser
+from xsdata.formats.bindings import T
 from xsdata.formats.dataclass.context import XmlContext
 from xsdata.formats.dataclass.models.elements import XmlVar
 from xsdata.formats.dataclass.models.generics import AnyElement
 from xsdata.formats.dataclass.parsers.utils import ParserUtils
-
-T = TypeVar("T")
 
 
 @dataclass

--- a/xsdata/formats/dataclass/parsers/mixins.py
+++ b/xsdata/formats/dataclass/parsers/mixins.py
@@ -1,0 +1,152 @@
+import abc
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Type
+
+from xsdata.exceptions import XmlHandlerError
+from xsdata.formats.bindings import AbstractParser
+from xsdata.formats.bindings import T
+from xsdata.formats.dataclass.parsers.config import ParserConfig
+from xsdata.models.enums import EventType
+
+NoneStr = Optional[str]
+
+
+class PushParser(AbstractParser):
+    """
+    A generic interface for event based content handlers like sax.
+
+    :param config: Parser configuration.
+    """
+
+    config: ParserConfig
+
+    @abc.abstractmethod
+    def start(
+        self,
+        queue: List,
+        qname: str,
+        attrs: Dict,
+        ns_map: Dict,
+        objects: List,
+        clazz: Type[T],
+    ):
+        """Queue the next xml node for parsing."""
+
+    @abc.abstractmethod
+    def end(
+        self,
+        queue: List,
+        qname: str,
+        text: NoneStr,
+        tail: NoneStr,
+        objects: List,
+    ) -> Any:
+        """
+        Parse the last xml node and bind any intermediate objects.
+
+        :return: The result of the binding process.
+        """
+
+    @abc.abstractmethod
+    def start_prefix_mapping(self, prefix: NoneStr, uri: str):
+        """Add the given namespace in the registry."""
+
+
+class XmlNode(abc.ABC):
+    """
+    A generic interface for xml nodes that need to implement the two public
+    methods to be used in an event based parser with start/end element events.
+
+    The parser needs to maintain a queue for these nodes and a list of
+    objects that these nodes return.
+    """
+
+    @abc.abstractmethod
+    def child(self, qname: str, attrs: Dict, ns_map: Dict, position: int) -> "XmlNode":
+        """
+        Initialize the next child node to be queued, when a new xml element
+        starts.
+
+        This entry point is responsible to create the next node type
+        with all the necessary information on how to bind the incoming
+        input data.
+        """
+
+    @abc.abstractmethod
+    def bind(self, qname: str, text: NoneStr, tail: NoneStr, objects: List) -> bool:
+        """
+        Parse the current element bind child objects and return the result.
+
+        This entry point is called when an xml element ends and is responsible to parse
+        the current element attributes/text, bind any children objects and initialize
+        a new object.
+
+        :return: Whether or not anything was appended in the objects list.
+        """
+
+
+@dataclass
+class XmlHandler:
+    """
+    Xml content handler interface.
+
+    :param clazz: The Dataclass model to bind the xml document data.
+    :param parser: The parser instance to feed events.
+    :param queue: The queue list of xml nodes.
+    :param objects: Temporary storage for intermediate objects, eg [(qname, object)]
+    """
+
+    clazz: Type
+    parser: PushParser
+    queue: List = field(default_factory=list)
+    objects: List = field(default_factory=list)
+
+    def parse(self, source: Any) -> Any:
+        """Parse an XML document from a system identifier or an InputSource."""
+        raise NotImplementedError("This method must be implemented!")
+
+    def start_ns_bulk(self, ns_map: Dict) -> Dict:
+        """Bulk start-ns event handler that returns a normalized copy of the
+        prefix-URI mapping that also includes the parent mapping."""
+        try:
+            result = self.queue[-1].ns_map.copy()
+        except (IndexError, AttributeError):
+            result = {}
+
+        for prefix, uri in ns_map.items():
+            self.parser.start_prefix_mapping(prefix, uri)
+            result[prefix or None] = uri
+
+        return result
+
+
+@dataclass
+class EventsHandler(XmlHandler):
+    """Content handler based on pre-recorded events."""
+
+    def parse(self, source: List[Tuple]) -> Any:
+        """Forward the pre-recorded events to the main parser."""
+
+        obj = None
+        for event in source:
+            if event[0] == EventType.START:
+                _, qname, attrs, ns_map = event
+                self.parser.start(
+                    self.queue, qname, attrs, ns_map, self.objects, self.clazz
+                )
+            elif event[0] == EventType.END:
+                _, qname, text, tail = event
+                obj = self.parser.end(self.queue, qname, text, tail, self.objects)
+            elif event[0] == EventType.START_NS:
+                _, prefix, uri = event
+                self.parser.start_prefix_mapping(prefix, uri)
+            else:
+                raise XmlHandlerError(f"Unhandled event: `{event[0]}`.")
+
+        return obj

--- a/xsdata/models/mixins.py
+++ b/xsdata/models/mixins.py
@@ -27,7 +27,7 @@ class ElementBase:
     Base xsd schema model.
 
     :param index: Occurrence position inside the definition
-    :param ns_map: Namespaces map to prefixes.
+    :param ns_map: prefix-URI Namespace mapping
     """
 
     index: int = field(default_factory=int, init=False)


### PR DESCRIPTION
The goal is to stop depending on lxml for parsing and add the ability to bolt other xml content handlers for whatever reason eg performance, custom processing, compatibility, issues etc etc

```python
from xsdata.formats.dataclass.parsers.handlers import LxmlEventHandler
from xsdata.formats.dataclass.parsers.handlers import LxmlSaxHandler
from xsdata.formats.dataclass.parsers.handlers import XmlEventHandler
from xsdata.formats.dataclass.parsers.handlers import XmlSaxHandler


parser = XmlParser(handler=LxmlEventHandler)  # Default handler based on lxml
p.parse("some/file.xml", Books)

parser = XmlParser(handler=LxmlSaxHandler)
p.parse("some/file.xml", Books)

parser = XmlParser(handler=XmlEventHandler) # native
p.parse("some/file.xml", Books)

parser = XmlParser(handler=XmlSaxHandler)  # native
p.parse("some/file.xml", Books)


```


From travis 

```console
----------------------------------------------------------------------------- benchmark 'size: 53.21 KB': 4 tests -----------------------------------------------------------------------------
Name (time in ms)                   Min                Max               Mean            StdDev             Median               IQR            Outliers      OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_small[LxmlIterHandler]     11.8074 (1.0)      12.7203 (1.0)      12.0336 (1.0)      0.1816 (1.10)     11.9881 (1.0)      0.1653 (1.17)         12;6  83.1004 (1.0)          80           1
test_small[XmlIterHandler]      12.0386 (1.02)     12.9314 (1.02)     12.2282 (1.02)     0.1650 (1.0)      12.1787 (1.02)     0.1408 (1.0)          15;6  81.7782 (0.98)         82           1
test_small[LxmlSaxHandler]      13.4678 (1.14)     14.4815 (1.14)     13.7428 (1.14)     0.1965 (1.19)     13.7141 (1.14)     0.1890 (1.34)         12;6  72.7652 (0.88)         73           1
test_small[XmlSaxHandler]       15.9125 (1.35)     17.6129 (1.38)     16.1757 (1.34)     0.2551 (1.55)     16.1069 (1.34)     0.2191 (1.56)          7;4  61.8212 (0.74)         60           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


------------------------------------------------------------------------------- benchmark 'size: 531.33 KB': 4 tests ------------------------------------------------------------------------------
Name (time in ms)                     Min                 Max                Mean            StdDev              Median               IQR            Outliers     OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_medium[LxmlIterHandler]     119.8988 (1.0)      121.8568 (1.0)      120.4409 (1.0)      0.6877 (1.0)      120.2558 (1.0)      0.7342 (1.39)          2;1  8.3028 (1.0)           9           1
test_medium[XmlIterHandler]      120.1281 (1.00)     129.9892 (1.07)     121.8156 (1.01)     3.0858 (4.49)     121.0813 (1.01)     0.5286 (1.0)           1;1  8.2091 (0.99)          9           1
test_medium[LxmlSaxHandler]      133.1965 (1.11)     135.3319 (1.11)     133.9587 (1.11)     0.7241 (1.05)     133.7970 (1.11)     1.0403 (1.97)          2;0  7.4650 (0.90)          8           1
test_medium[XmlSaxHandler]       162.4670 (1.36)   0m  171.2611 (1.41)     166.1869 (1.38)     3.0557 (4.44)     166.8058 (1.39)     3.9920 (7.55)          3;0  6.0173 (0.72)          7           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


------------------------------------------------------------------------- benchmark 'size: 5312.58 KB': 4 tests --------------------------------------------------------------------------
Name (time in s)                   Min               Max              Mean            StdDev            Median               IQR            Outliers     OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_large[LxmlIterHandler]     1.2073 (1.0)      1.2377 (1.02)     1.2163 (1.00)     0.0129 (5.43)     1.2089 (1.0)      0.0156 (4.86)          1;0  0.8222 (1.00)          5           1
test_large[XmlIterHandler]      1.2117 (1.00)     1.2180 (1.0)      1.2146 (1.0)      0.0024 (1.0)      1.2147 (1.00)     0.0032 (1.0)           2;0  0.8233 (1.0)           5           1
test_large[LxmlSaxHandler]      1.3448 (1.11)     1.3568 (1.11)     1.3526 (1.11)     0.0046 (1.94)     1.3541 (1.12)     0.0042 (1.30)          1;0  0.7393 (0.90)          5           1
test_large[XmlSaxHandler]       1.6082 (1.33)     1.6261 (1.34)     1.6171 (1.33)     0.0077 (3.24)     1.6186 (1.34)     0.0135 (4.20)          2;0  0.6184 (0.75)          5           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
