### PR TITLE
Try py36 again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ cache: pip
 
 jobs:
   include:
+    - python: 3.6
+      env: TOXENV=py36
     - python: 3.7
       env: TOXENV=py37
     - python: 3.8

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,12 +4,36 @@ Getting started
 Prerequisites
 -------------
 
-Make sure you have `python >= 3.7` and `pip` up and running.
+Make sure you have `python >= 3.6` and `pip` up and running.
 
 
 .. command-output:: python --version
 
 .. command-output:: pip --version
+
+
+.. warning::
+
+    In python 3.6 the typing module is flattening subclasses in unions, this
+    may affect how values are converted.
+
+    There is no official workaround because it's not very common, if you like monkey
+    patching then take a look here :py:func:`typing._remove_dups_flatten`
+
+    .. code-block::
+
+        >>> from dataclasses import dataclass
+        >>> from typing import Union, get_type_hints
+        >>>
+        >>> @dataclass
+        ... class Example:
+        ...     value: Union[int, bool, str, float]
+        ...
+        >>> get_type_hints(Example)
+        {'value': typing.Union[int, str, float]}
+        >>> issubclass(bool, int)
+        True
+
 
 
 ----

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -37,7 +38,7 @@ install_requires =
     lxml
     requests
     toposort
-python_requires = >=3.7
+python_requires = >=3.6
 include_package_data = True
 
 [options.entry_points]
@@ -52,6 +53,7 @@ dev =
     pytest-benchmark
     pytest-cov
     tox
+    dataclasses;python_version<"3.7"
 docs =
     sphinx
     sphinx-autobuild

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39
+envlist = py36,py37,py38,py39
 skip_missing_interpreters = true
 
 [testenv]

--- a/xsdata/formats/dataclass/context.py
+++ b/xsdata/formats/dataclass/context.py
@@ -238,12 +238,12 @@ class XmlContext:
 
     @staticmethod
     def is_element_list(type_hint: Any, is_tokens: bool) -> bool:
-        if getattr(type_hint, "__origin__", None) is list:
+        if getattr(type_hint, "__origin__", None) in (list, List):
             if not is_tokens:
                 return True
 
             type_hint = type_hint.__args__[0]
-            if getattr(type_hint, "__origin__", None) is list:
+            if getattr(type_hint, "__origin__", None) in (list, List):
                 return True
 
         return False


### PR DESCRIPTION
xsdata codebase is pretty compatible with python 3.6 but it relies on the typing module for mapping/converting values properly. But there is an issue with `bool` type that I never managed to investigate to see if there is a workaround or something.


```python
In [6]: from enum import Enum
   ...: from dataclasses import dataclass, field
   ...: from typing import List, Optional, Union, get_type_hints

In [7]: @dataclass
   ...: class E1:
   ...:     """
   ...:     :ivar value:
   ...:     """
   ...:     class Meta:
   ...:         namespace = "http://xsdtesting"
   ...: 
   ...:     value: Optional[Union[bool, float, int, "E1.Value"]] = field(
   ...:         default=None,
   ...:         metadata=dict(
   ...:             required=True
   ...:         )
   ...:     )
   ...: 
   ...:     class Value(Enum):
   ...:         """
   ...:         :cvar X:
   ...:         :cvar Y:
   ...:         """
   ...:         X = "x"
   ...:         Y = "y"
   ...: 

In [8]: 

In [8]: get_type_hints(E1)
Out[8]: {'value': typing.Union[float, int, __main__.E1.Value, NoneType]}

```

For some reason bool type is not in the list, same code with python 3.7

```python
In [4]: get_type_hints(E1)
Out[4]: {'value': typing.Union[bool, float, int, __main__.E1.Value, NoneType]}
```