### PR TITLE
Added NameCase `mixedSnakeCase`

### DIFF
--- a/docs/codegen.rst
+++ b/docs/codegen.rst
@@ -131,8 +131,9 @@ non alphanumerical characters or when an upper case letter follows a lower case 
 
 .. hint::
 
-    The mixed case is joining the words without changing the original upper/lower case,
-    except the first letter which is capitalized.
+    The mixed case is joining the words without changing the original upper/lower case
+
+    The mixed underscore case is joining the words with an underscore.
 
     The pascal/camel cases are using python's :func:`str.title` method!
 

--- a/docs/name_cases_table.rst
+++ b/docs/name_cases_table.rst
@@ -8,43 +8,52 @@
       - Camel Case
       - Snake Case
       - Mixed Case
+      - Mixed Snake Case
     * - p00p
       - P00P
       - p00P
       - p00p
-      - P00p
+      - p00p
+      - p00p
     * - USERName
       - Username
       - username
       - username
+      - USERName
       - USERName
     * - UserNAME
       - UserName
       - userName
       - user_name
       - UserNAME
+      - User_NAME
     * - USER_name
       - UserName
       - userName
       - user_name
       - USERname
+      - USER_name
     * - USER-NAME
       - UserName
       - userName
       - user_name
       - USERNAME
+      - USER_NAME
     * - User_Name
       - UserName
       - userName
       - user_name
       - UserName
+      - User_Name
     * - user_name
       - UserName
       - userName
       - user_name
-      - Username
+      - username
+      - user_name
     * - SUserNAME
       - SuserName
       - suserName
       - suser_name
       - SUserNAME
+      - SUser_NAME

--- a/docs/scripts/generate_name_cases.py
+++ b/docs/scripts/generate_name_cases.py
@@ -18,6 +18,7 @@ output = [
     "      - Camel Case",
     "      - Snake Case",
     "      - Mixed Case",
+    "      - Mixed Snake Case",
 ]
 
 result = {}
@@ -34,6 +35,7 @@ while i < len(result[lookup]):
     output.append(f"      - {result['camel_case'][i][0]}")
     output.append(f"      - {result['snake_case'][i][0]}")
     output.append(f"      - {result['mixed_case'][i][0]}")
+    output.append(f"      - {result['mixed_snake_case'][i][0]}")
 
     i += 1
 

--- a/tests/formats/dataclass/test_filters.py
+++ b/tests/formats/dataclass/test_filters.py
@@ -472,7 +472,7 @@ class FiltersTests(FactoryTestCase):
 
         self.assertEqual("cAb", filters.class_name("cAB"))
         self.assertEqual("CAb", filters.field_name("cAB"))
-        self.assertEqual("CAB", filters.package_name("cAB"))
+        self.assertEqual("cAB", filters.package_name("cAB"))
         self.assertEqual("c_ab", filters.module_name("cAB"))
 
         self.assertEqual({"a": "b", "c": "d"}, filters.class_aliases)

--- a/tests/utils/test_text.py
+++ b/tests/utils/test_text.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 from xsdata.utils.text import camel_case
 from xsdata.utils.text import capitalize
 from xsdata.utils.text import mixed_case
+from xsdata.utils.text import mixed_snake_case
 from xsdata.utils.text import pascal_case
 from xsdata.utils.text import snake_case
 from xsdata.utils.text import split_words
@@ -40,14 +41,24 @@ class TextTests(TestCase):
         self.assertEqual("suserName", camel_case("SUserNAME"))
 
     def test_mixed_case(self):
-        self.assertEqual("P00p", mixed_case("p00p"))
+        self.assertEqual("p00p", mixed_case("p00p"))
         self.assertEqual("USERName", mixed_case("USERName"))
         self.assertEqual("UserNAME", mixed_case("UserNAME"))
         self.assertEqual("USERname", mixed_case("USER_name"))
         self.assertEqual("USERNAME", mixed_case("USER-NAME"))
         self.assertEqual("UserName", mixed_case("User_Name"))
-        self.assertEqual("Username", mixed_case("user_name"))
+        self.assertEqual("username", mixed_case("user_name"))
         self.assertEqual("SUserNAME", mixed_case("SUserNAME"))
+
+    def test_mixed_snake_case(self):
+        self.assertEqual("p00p", mixed_snake_case("p00p"))
+        self.assertEqual("USERName", mixed_snake_case("USERName"))
+        self.assertEqual("User_NAME", mixed_snake_case("UserNAME"))
+        self.assertEqual("USER_name", mixed_snake_case("USER_name"))
+        self.assertEqual("USER_NAME", mixed_snake_case("USER-NAME"))
+        self.assertEqual("User_Name", mixed_snake_case("User_Name"))
+        self.assertEqual("user_name", mixed_snake_case("user_name"))
+        self.assertEqual("SUser_NAME", mixed_snake_case("SUserNAME"))
 
     def test_capitalize(self):
         self.assertEqual("UserName", capitalize("userName"))

--- a/xsdata/models/config.py
+++ b/xsdata/models/config.py
@@ -34,12 +34,14 @@ class OutputStructure(Enum):
 
 
 class NameCase(Enum):
-    """Available naming schemes, pascal, snake, camel, mixed."""
+    """Available naming schemes, pascal, snake, camel, mixed and mixed
+    underscore."""
 
     PASCAL = "pascalCase"
     CAMEL = "camelCase"
     SNAKE = "snakeCase"
     MIXED = "mixedCase"
+    MIXED_SNAKE = "mixedSnakeCase"
 
     @property
     def func(self) -> Callable:
@@ -49,9 +51,10 @@ class NameCase(Enum):
 
 __name_case_func__ = {
     "pascalCase": text.pascal_case,
+    "camelCase": text.camel_case,
     "snakeCase": text.snake_case,
     "mixedCase": text.mixed_case,
-    "camelCase": text.camel_case,
+    "mixedSnakeCase": text.mixed_snake_case,
 }
 
 

--- a/xsdata/utils/text.py
+++ b/xsdata/utils/text.py
@@ -41,7 +41,12 @@ def camel_case(string: str) -> str:
 
 def mixed_case(string: str) -> str:
     """Convert the given string to mixed case."""
-    return capitalize("".join(split_words(string)))
+    return "".join(split_words(string))
+
+
+def mixed_snake_case(string: str) -> str:
+    """Convert the given string to mixed snake case."""
+    return "_".join(split_words(string))
 
 
 def snake_case(string: str) -> str:


### PR DESCRIPTION
We need a naming scheme that joins words with underscores and doesn't change original cases.

Updated the original `mixed` case to also avoid any case changes.