### PR TITLE
Resolve #267 Support derived root elements

### DIFF
--- a/tests/formats/dataclass/parsers/test_utils.py
+++ b/tests/formats/dataclass/parsers/test_utils.py
@@ -17,6 +17,7 @@ from xsdata.formats.dataclass.models.elements import XmlMeta
 from xsdata.formats.dataclass.models.elements import XmlVar
 from xsdata.formats.dataclass.models.elements import XmlWildcard
 from xsdata.formats.dataclass.models.generics import AnyElement
+from xsdata.formats.dataclass.models.generics import DerivedElement
 from xsdata.formats.dataclass.parsers.utils import ParserUtils
 from xsdata.models.enums import Namespace
 from xsdata.models.enums import QNames
@@ -122,6 +123,7 @@ class ParserUtilsTests(TestCase):
     def test_bind_mixed_content(self):
         generic = AnyElement(qname="foo")
         data_class = make_dataclass("A", fields=[])
+        derived = DerivedElement(qname="d", value=data_class)
         objects = [
             ("a", 1),
             ("b", None),
@@ -133,9 +135,8 @@ class ParserUtilsTests(TestCase):
         params = {}
         ParserUtils.bind_mixed_content(params, var, 1, objects)
 
-        expected = {var.name: [AnyElement(qname="b", text=""), data_class, generic]}
+        expected = {var.name: [AnyElement(qname="b", text=""), derived, generic]}
         self.assertEqual(expected, params)
-        self.assertEqual("d", data_class.qname)
 
     def test_fetch_any_children(self):
         objects = [(x, x) for x in "abc"]
@@ -363,5 +364,5 @@ class ParserUtilsTests(TestCase):
         self.assertEqual(AnyElement(qname="a", text="foo"), actual)
 
         fixture = Fixture("foo")
-        ParserUtils.prepare_generic_value("a", fixture)
-        self.assertEqual("a", fixture.qname)
+        actual = ParserUtils.prepare_generic_value("a", fixture)
+        self.assertEqual(DerivedElement(qname="a", value=fixture), actual)

--- a/tests/formats/dataclass/test_context.py
+++ b/tests/formats/dataclass/test_context.py
@@ -371,6 +371,7 @@ class XmlContextTests(TestCase):
         self.assertTrue(self.ctx.is_derived(a(), c))
         self.assertTrue(self.ctx.is_derived(a(), a))
         self.assertFalse(self.ctx.is_derived(a(), d))
+        self.assertFalse(self.ctx.is_derived(None, d))
 
     def test_is_element_list(self):
         @dataclass

--- a/tests/models/xsd/test_schema.py
+++ b/tests/models/xsd/test_schema.py
@@ -1,6 +1,7 @@
 from typing import Iterator
 from unittest import TestCase
 
+from xsdata.models.enums import Namespace
 from xsdata.models.xsd import Import
 from xsdata.models.xsd import Include
 from xsdata.models.xsd import Override
@@ -9,6 +10,11 @@ from xsdata.models.xsd import Schema
 
 
 class SchemaTests(TestCase):
+    def test_meta(self):
+        schema = Schema()
+        self.assertEqual("schema", schema.Meta.name)
+        self.assertEqual(Namespace.XS.uri, schema.Meta.namespace)
+
     def test_sub_schemas(self):
         imports = [
             Import(schema_location="../foo.xsd"),

--- a/xsdata/formats/dataclass/context.py
+++ b/xsdata/formats/dataclass/context.py
@@ -236,6 +236,10 @@ class XmlContext:
     def is_derived(cls, obj: Any, clazz: Type) -> bool:
         """Return whether the given obj is derived from the given dataclass
         type."""
+
+        if obj is None:
+            return False
+
         if isinstance(obj, clazz):
             return True
 

--- a/xsdata/formats/dataclass/models/elements.py
+++ b/xsdata/formats/dataclass/models/elements.py
@@ -18,7 +18,7 @@ class XmlVar:
     Dataclass field bind metadata.
 
     :param name: Field name.
-    :param qname: Namespace qualified local name.
+    :param qname: The namespace qualified local name.
     :param init:  Field is present in the constructor parameters.
     :param mixed:  Field supports mixed content.
     :param tokens: Use a list to map simple values.

--- a/xsdata/formats/dataclass/models/generics.py
+++ b/xsdata/formats/dataclass/models/generics.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from dataclasses import field
+from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -30,3 +31,16 @@ class AnyElement:
     attributes: Dict = field(
         default_factory=dict, metadata={"type": XmlType.ATTRIBUTES}
     )
+
+
+@dataclass
+class DerivedElement:
+    """
+    Derived element wrapper for base types, eg. <b xsi:type="a">...</b>
+
+    :param qname: The namespace qualified name of the base type.
+    :param value: A dataclass instance
+    """
+
+    qname: str
+    value: Any

--- a/xsdata/formats/dataclass/parsers/utils.py
+++ b/xsdata/formats/dataclass/parsers/utils.py
@@ -11,6 +11,7 @@ from xsdata.formats.dataclass.models.elements import FindMode
 from xsdata.formats.dataclass.models.elements import XmlMeta
 from xsdata.formats.dataclass.models.elements import XmlVar
 from xsdata.formats.dataclass.models.generics import AnyElement
+from xsdata.formats.dataclass.models.generics import DerivedElement
 from xsdata.logger import logger
 from xsdata.models.enums import QNames
 from xsdata.utils import text
@@ -133,7 +134,7 @@ class ParserUtils:
         if not is_dataclass(value):
             value = AnyElement(qname=qname, text=value)
         elif not isinstance(value, AnyElement):
-            value.qname = qname  # Deprecate this hack!
+            value = DerivedElement(qname=qname, value=value)
 
         return value
 

--- a/xsdata/models/xsd.py
+++ b/xsdata/models/xsd.py
@@ -1276,6 +1276,7 @@ class Schema(SchemaLocation, ModuleMixin):
     """
 
     class Meta:
+        name = "schema"
         namespace = Namespace.XS.uri
 
     target: Optional[str] = attribute()


### PR DESCRIPTION
Demo: tefra/xsdata-w3c-tests#41

I am so excited about this, I removed the last hack from the initial wildcards support :tada: 
