### PR TITLE
Allow ns structure with empty target namespaces

### DIFF
--- a/tests/formats/test_mixins.py
+++ b/tests/formats/test_mixins.py
@@ -53,22 +53,19 @@ class AbstractGeneratorTests(FactoryTestCase):
         )
 
     def test_designate_with_namespaces_structure(self):
-        classes = ClassFactory.list(2, package=None)
+        classes = [
+            ClassFactory.create(qname="{a}a", package=None),
+            ClassFactory.create(qname="{a}b", package=None),
+            ClassFactory.create(qname="b", package=None),
+        ]
         self.generator.config.output.structure = OutputStructure.NAMESPACES
         self.generator.config.output.package = "bar"
 
         self.generator.designate(classes)
         self.assertEqual("bar", classes[0].package)
         self.assertEqual("bar", classes[1].package)
+        self.assertEqual("bar", classes[2].package)
 
-        self.assertEqual("xsdata", classes[0].module)
-        self.assertEqual("xsdata", classes[1].module)
-
-        classes = ClassFactory.list(1, qname="foo")
-        with self.assertRaises(CodeGenerationError) as cm:
-            self.generator.designate(classes)
-
-        self.assertEqual(
-            ("Class `foo` target namespace is empty, " "avoid option `--ns-struct`"),
-            str(cm.exception),
-        )
+        self.assertEqual("a", classes[0].module)
+        self.assertEqual("a", classes[1].module)
+        self.assertEqual("", classes[2].module)

--- a/xsdata/formats/mixins.py
+++ b/xsdata/formats/mixins.py
@@ -89,14 +89,8 @@ class AbstractGenerator(metaclass=abc.ABCMeta):
         for obj in classes:
 
             if ns_struct:
-                if not obj.target_namespace:
-                    raise CodeGenerationError(
-                        f"Class `{obj.name}` target namespace "
-                        f"is empty, avoid option `--ns-struct`"
-                    )
-
                 obj.package = self.config.output.package
-                obj.module = obj.target_namespace
+                obj.module = obj.target_namespace or ""
 
             if obj.package is None:
                 raise CodeGenerationError(


### PR DESCRIPTION
Notes:
The module name will be equal to the configuration
safe module suffix, eg `mod.py`


Pass the saxon meta group **over015** tests