### PR TITLE
ElementNode: validate xs:nill for child node

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,12 +37,12 @@ repos:
       - id: docformatter
         args: ["--in-place", "--pre-summary-newline"]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.782
+    rev: v0.790
     hooks:
       - id: mypy
         additional_dependencies: [tokenize-rt]
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.11.0
+    rev: v1.14.0
     hooks:
       - id: setup-cfg-fmt
         args: ["--max-py-version=3.9"]

--- a/tests/formats/dataclass/serializers/test_mixins.py
+++ b/tests/formats/dataclass/serializers/test_mixins.py
@@ -16,7 +16,7 @@ class XmlEventWriterTests(TestCase):
         output = StringIO()
         self.writer = XmlWriter(output=output)
         self.writer.handler = XMLGenerator(
-            output,  # type: ignore
+            output,
             encoding="UTF-8",
             short_empty_elements=True,
         )

--- a/xsdata/formats/dataclass/context.py
+++ b/xsdata/formats/dataclass/context.py
@@ -225,9 +225,7 @@ class XmlContext:
             ):
                 type_hint = type_hint.__args__[0]
 
-            types = [
-                x for x in type_hint.__args__ if x is not None.__class__  # type: ignore
-            ]
+            types = [x for x in type_hint.__args__ if x is not None.__class__]
         else:
             types.append(type_hint)
 

--- a/xsdata/formats/dataclass/parsers/utils.py
+++ b/xsdata/formats/dataclass/parsers/utils.py
@@ -29,6 +29,11 @@ class ParserUtils:
         return None
 
     @classmethod
+    def is_nillable(cls, attrs: Dict) -> bool:
+        """Return whether the element attrs has xsi:nil="false"."""
+        return attrs.get(QNames.XSI_NIL) != "false"
+
+    @classmethod
     def parse_value(
         cls,
         value: Any,


### PR DESCRIPTION
w3c test case: `test_qfe1700c2_qfe1700c2_v`