### PR TITLE
Resolve #306 Lookup xsi type for xs:anyType derived elements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: pyupgrade
         args: [--py37-plus]
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v2.3.5
+    rev: v2.3.6
     hooks:
       - id: reorder-python-imports
   - repo: https://github.com/ambv/black

--- a/tests/formats/dataclass/parsers/test_utils.py
+++ b/tests/formats/dataclass/parsers/test_utils.py
@@ -18,6 +18,7 @@ from xsdata.formats.dataclass.models.elements import XmlWildcard
 from xsdata.formats.dataclass.models.generics import AnyElement
 from xsdata.formats.dataclass.models.generics import DerivedElement
 from xsdata.formats.dataclass.parsers.utils import ParserUtils
+from xsdata.models.enums import DataType
 from xsdata.models.enums import Namespace
 from xsdata.models.enums import QNames
 
@@ -36,6 +37,18 @@ class ParserUtilsTests(TestCase):
 
         attrs = {QNames.XSI_TYPE: "bar:foo"}
         self.assertEqual("{xsdata}foo", ParserUtils.xsi_type(attrs, ns_map))
+
+    def test_data_type(self):
+        ns_map = {"bar": "xsdata"}
+        attrs = {}
+        self.assertEqual(DataType.STRING, ParserUtils.data_type(attrs, ns_map))
+
+        ns_map = {"xs": Namespace.XS.uri}
+        attrs = {QNames.XSI_TYPE: "xs:foo"}
+        self.assertEqual(DataType.STRING, ParserUtils.data_type(attrs, ns_map))
+
+        attrs = {QNames.XSI_TYPE: "xs:float"}
+        self.assertEqual(DataType.FLOAT, ParserUtils.data_type(attrs, ns_map))
 
     @mock.patch.object(ConverterAdapter, "from_string", return_value=2)
     def test_parse_value(self, mock_from_string):
@@ -122,13 +135,14 @@ class ParserUtilsTests(TestCase):
             ("b", None),
             ("d", data_class),
             ("foo", generic),
+            (None, "foo"),
         ]
 
         var = XmlWildcard(name="foo", qname="{any}foo")
         params = {}
         ParserUtils.bind_mixed_objects(params, var, 1, objects)
 
-        expected = {var.name: [AnyElement(qname="b", text=""), derived, generic]}
+        expected = {var.name: [AnyElement(qname="b", text=""), derived, generic, "foo"]}
         self.assertEqual(expected, params)
 
     def test_fetch_any_children(self):

--- a/tests/formats/dataclass/test_elements.py
+++ b/tests/formats/dataclass/test_elements.py
@@ -142,10 +142,6 @@ class XmlWildcardTests(TestCase):
         self.assertIsInstance(var, XmlVar)
         self.assertTrue(var.is_wildcard)
 
-    def test_property_is_any_type(self):
-        var = XmlWildcard(name="foo", qname="foo")
-        self.assertTrue(var.is_any_type)
-
     def test_matches(self):
         var = XmlWildcard(name="foo", qname="foo")
         self.assertTrue(var.matches("*"))

--- a/tests/models/enums/test_datatype.py
+++ b/tests/models/enums/test_datatype.py
@@ -1,0 +1,15 @@
+from decimal import Decimal
+from unittest import TestCase
+from xml.etree.ElementTree import QName
+
+from xsdata.models.enums import DataType
+
+
+class DataTypeTests(TestCase):
+    def test_from_value(self):
+        self.assertEqual(DataType.BOOLEAN, DataType.from_value(True))
+        self.assertEqual(DataType.INT, DataType.from_value(1))
+        self.assertEqual(DataType.FLOAT, DataType.from_value(1.1))
+        self.assertEqual(DataType.DECIMAL, DataType.from_value(Decimal(1.1)))
+        self.assertEqual(DataType.QNAME, DataType.from_value(QName("a")))
+        self.assertEqual(DataType.STRING, DataType.from_value("a"))

--- a/xsdata/formats/dataclass/models/elements.py
+++ b/xsdata/formats/dataclass/models/elements.py
@@ -201,10 +201,6 @@ class XmlWildcard(XmlVar):
     def is_wildcard(self) -> bool:
         return True
 
-    @property
-    def is_any_type(self) -> bool:
-        return True
-
     def matches(self, qname: str) -> bool:
         """Match the given qname to the wildcard allowed namespaces."""
 
@@ -303,6 +299,9 @@ class XmlMeta:
     @property
     def namespace(self) -> Optional[str]:
         return split_qname(self.qname)[0]
+
+    def has_var(self, qname: str = "*", mode: FindMode = FindMode.ALL) -> bool:
+        return self.find_var(qname, mode) is not None
 
     def find_var(
         self, qname: str = "*", mode: FindMode = FindMode.ALL

--- a/xsdata/models/enums.py
+++ b/xsdata/models/enums.py
@@ -1,6 +1,7 @@
 from decimal import Decimal
 from enum import Enum
 from pathlib import Path
+from typing import Any
 from typing import Iterator
 from typing import Optional
 from xml.etree.ElementTree import QName
@@ -148,10 +149,30 @@ class DataType(Enum):
 
     @classmethod
     def get_enum(cls, code: str) -> Optional["DataType"]:
-        return __XSDType__.get(code) if code else None
+        return __DataTypeCodeIndex__.get(code) if code else None
+
+    @classmethod
+    def from_value(cls, value: Any) -> "DataType":
+        if isinstance(value, bool):
+            return DataType.BOOLEAN
+        if isinstance(value, int):
+            return DataType.INT
+        if isinstance(value, float):
+            return DataType.FLOAT
+        if isinstance(value, Decimal):
+            return DataType.DECIMAL
+        if isinstance(value, QName):
+            return DataType.QNAME
+
+        return DataType.STRING
+
+    @classmethod
+    def from_qname(cls, qname: str) -> Optional["DataType"]:
+        return __DataTypeQNameIndex__.get(qname)
 
 
-__XSDType__ = {xsd.code: xsd for xsd in DataType}
+__DataTypeCodeIndex__ = {xsd.code: xsd for xsd in DataType}
+__DataTypeQNameIndex__ = {xsd.qname: xsd for xsd in DataType}
 
 
 class EventType:


### PR DESCRIPTION
### Description

Currently fields derived from elements with type `xs:anyType` and fields derived from `xs:any` wildcards are using the same flow for parsing/serializing. This prevents any xsi:type lookups. 


###  What I did
- Introduced `AnyTypeNode` to split the flow from wildcards during parsing.
- The new node attempts to lookup for a dataclass that matches the xsi:type attribute
  - Exception one: simple types xs:int, xs:float, xs:int etc etc
  - Exception two no xsi:type or no match defaults back to the generic `AnyElement` like it used to
  - Exception three: the dataclass has to be already imported

The lookup process is cached but still quite aggressive, all imported dataclasses are indexed by their xsi:type qname
