### PR TITLE
Resolve #340 Add docstring style accessible

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install libxml2
-        if: matrix.python ==  '3.9-dev' || matrix.python == 'pypy3'
+        if: matrix.python == 'pypy3'
         run: |
           sudo apt-get install libxml2-dev libxslt-dev
       - name: Install dependencies

--- a/docs/codegen.rst
+++ b/docs/codegen.rst
@@ -73,11 +73,34 @@ See :ref:`Type: Elements`
 docstring-style
 ---------------
 
-Choose between the available docstring styles.
+Choose the style of the generated docstrings.
 
-* ``reStructuredText`` **default**
-* ``NumPy``
-* ``Google``
+The accessible style is xsdata's attempt to offer easy access to dataclasses fields and
+enum members docs.
+
+.. tab:: reStructuredText
+
+    .. literalinclude:: /../tests/fixtures/docstrings/rst/schema.py
+       :language: python
+       :lines: 37-
+
+.. tab:: NumPy
+
+    .. literalinclude:: /../tests/fixtures/docstrings/numpy/schema.py
+       :language: python
+       :lines: 38-
+
+.. tab:: Google
+
+    .. literalinclude:: /../tests/fixtures/docstrings/google/schema.py
+       :language: python
+       :lines: 38-
+
+.. tab:: Accessible
+
+    .. literalinclude:: /../tests/fixtures/docstrings/accessible/schema.py
+       :language: python
+       :lines: 37-
 
 
 verbosity

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.githubpages",
     "sphinx_autodoc_typehints",
+    "sphinx_inline_tabs",
     "sphinxcontrib.apidoc",
     "sphinxcontrib.programoutput",
 ]

--- a/docs/scripts/generate_data_types.py
+++ b/docs/scripts/generate_data_types.py
@@ -25,7 +25,7 @@ custom_classes = {
 }
 
 
-for tp, data_types in group_by(list(DataType), key=lambda x: x.local_name).items():
+for tp, data_types in group_by(list(DataType), key=lambda x: x.type.__name__).items():
     output.append(f"    * - :class:`{custom_classes.get(tp, tp)}`")
 
     count = 0

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,7 @@ docs =
     sphinx
     sphinx-autobuild
     sphinx-autodoc-typehints
+    sphinx-inline-tabs
     sphinx-material
     sphinxcontrib-apidoc
     sphinxcontrib-programoutput

--- a/tests/codegen/mappers/test_definitions.py
+++ b/tests/codegen/mappers/test_definitions.py
@@ -177,13 +177,13 @@ class DefinitionsMapperTests(FactoryTestCase):
             ns_map={"foo": "bar"},
             attrs=[
                 DefinitionsMapper.build_attr(
-                    "a", DataType.STRING.qname, native=True, default="one"
+                    "a", str(DataType.STRING), native=True, default="one"
                 ),
                 DefinitionsMapper.build_attr(
-                    "b", DataType.STRING.qname, native=True, default="two"
+                    "b", str(DataType.STRING), native=True, default="two"
                 ),
                 DefinitionsMapper.build_attr(
-                    "style", DataType.STRING.qname, native=True, default="rpc"
+                    "style", str(DataType.STRING), native=True, default="rpc"
                 ),
                 DefinitionsMapper.build_attr("first", first.qname),
                 DefinitionsMapper.build_attr("second", second.qname),
@@ -472,7 +472,7 @@ class DefinitionsMapperTests(FactoryTestCase):
         expected_fault_attr = DefinitionsMapper.build_attr(
             "Fault", body.inner[0].qname, forward=True, namespace=target.namespace
         )
-        str_qname = DataType.STRING.qname
+        str_qname = str(DataType.STRING)
         expected_fault_attrs = [
             DefinitionsMapper.build_attr(name, str_qname, native=True, namespace="")
             for name in ["faultcode", "faultstring", "faultactor", "detail"]
@@ -499,7 +499,7 @@ class DefinitionsMapperTests(FactoryTestCase):
         expected_fault_attr = DefinitionsMapper.build_attr(
             "Fault", body.inner[0].qname, forward=True, namespace=target.namespace
         )
-        str_qname = DataType.STRING.qname
+        str_qname = str(DataType.STRING)
         expected_fault_attrs = [
             DefinitionsMapper.build_attr(name, str_qname, native=True, namespace="")
             for name in ["faultcode", "faultstring", "faultactor"]
@@ -672,7 +672,7 @@ class DefinitionsMapperTests(FactoryTestCase):
                 "bar", build_qname("great", "bar"), namespace="great", native=False
             ),
             DefinitionsMapper.build_attr(
-                "arg0", DataType.STRING.qname, namespace="", native=True
+                "arg0", str(DataType.STRING), namespace="", native=True
             ),
             DefinitionsMapper.build_attr(
                 "arg1", build_qname("boo", "cafe"), namespace="", native=False

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -176,7 +176,7 @@ class AttrTypeFactory(Factory):
             qname = build_qname("xsdata", f"attr_{cls.next_letter()}")
 
         return cls.model(
-            qname=qname,
+            qname=str(qname),
             alias=alias,
             native=native,
             circular=circular,
@@ -185,43 +185,43 @@ class AttrTypeFactory(Factory):
 
     @classmethod
     def xs_string(cls):
-        return cls.create(qname=DataType.STRING.qname, native=True)
+        return cls.create(qname=DataType.STRING, native=True)
 
     @classmethod
     def xs_int(cls):
-        return cls.create(qname=DataType.INTEGER.qname, native=True)
+        return cls.create(qname=DataType.INTEGER, native=True)
 
     @classmethod
     def xs_positive_int(cls):
-        return cls.create(qname=DataType.POSITIVE_INTEGER.qname, native=True)
+        return cls.create(qname=DataType.POSITIVE_INTEGER, native=True)
 
     @classmethod
     def xs_float(cls):
-        return cls.create(qname=DataType.FLOAT.qname, native=True)
+        return cls.create(qname=DataType.FLOAT, native=True)
 
     @classmethod
     def xs_decimal(cls):
-        return cls.create(qname=DataType.DECIMAL.qname, native=True)
+        return cls.create(qname=DataType.DECIMAL, native=True)
 
     @classmethod
     def xs_bool(cls):
-        return cls.create(qname=DataType.BOOLEAN.qname, native=True)
+        return cls.create(qname=DataType.BOOLEAN, native=True)
 
     @classmethod
     def xs_any(cls):
-        return cls.create(qname=DataType.ANY_TYPE.qname, native=True)
+        return cls.create(qname=DataType.ANY_TYPE, native=True)
 
     @classmethod
     def xs_qname(cls):
-        return cls.create(qname=DataType.QNAME.qname, native=True)
+        return cls.create(qname=DataType.QNAME, native=True)
 
     @classmethod
     def xs_tokens(cls):
-        return cls.create(qname=DataType.NMTOKENS.qname, native=True)
+        return cls.create(qname=DataType.NMTOKENS, native=True)
 
     @classmethod
     def xs_error(cls):
-        return cls.create(qname=DataType.ERROR.qname, native=True)
+        return cls.create(qname=DataType.ERROR, native=True)
 
 
 class AttrFactory(Factory):

--- a/tests/fixtures/books/books.py
+++ b/tests/fixtures/books/books.py
@@ -6,7 +6,8 @@ __NAMESPACE__ = "urn:books"
 
 @dataclass
 class BookForm:
-    """Book Definition.
+    """
+    Book Definition.
 
     Attributes
         author: Writer's name
@@ -94,7 +95,9 @@ class BooksForm:
 
 @dataclass
 class Books(BooksForm):
-    """Το βιβλίο."""
+    """
+    Το βιβλίο.
+    """
     class Meta:
         name = "books"
         namespace = "urn:books"

--- a/tests/fixtures/docstrings/accessible/__init__.py
+++ b/tests/fixtures/docstrings/accessible/__init__.py
@@ -1,0 +1,6 @@
+from tests.fixtures.docstrings.accessible.schema import (
+    DoubleQuotesDescription,
+    DoubleQuotesSummary,
+    Root,
+    RootEnum,
+)

--- a/tests/fixtures/docstrings/accessible/schema.py
+++ b/tests/fixtures/docstrings/accessible/schema.py
@@ -1,0 +1,118 @@
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+__NAMESPACE__ = "urn:docs"
+
+
+@dataclass
+class DoubleQuotesDescription:
+    """Let's trip.
+
+    Dont trip on quotes: "A", "B", "C", "D"
+    """
+    class Meta:
+        namespace = "urn:docs"
+
+
+@dataclass
+class DoubleQuotesSummary:
+    """
+    Dont trip on quotes: "A", "B", "C", "D".
+    """
+    class Meta:
+        namespace = "urn:docs"
+
+
+class RootEnum(Enum):
+    A = "A"
+    B = "B"
+
+
+RootEnum.A.__doc__ = "Lorem ipsum dolor"
+RootEnum.B.__doc__ = (
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi dapibus."
+)
+
+
+@dataclass
+class Root:
+    """This is the root type documentation. Lorem ipsum dolor sit amet,
+    consectetur adipiscing elit. Morbi dapibus.
+
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec
+    imperdiet lacus sed sagittis scelerisque. Ut sodales metus: "sit",
+    "amet", "lectus"
+    """
+    class Meta:
+        namespace = "urn:docs"
+
+    a: Optional["Root.A"] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "namespace": "",
+            "required": True,
+            "doc": (
+                "This is an inner type field documentation.\nLorem ipsum dolor"
+                " sit amet, consectetur adipiscing elit. Aliquam nec."
+            ),
+        }
+    )
+    b: Optional["Root.B"] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "namespace": "",
+            "required": True,
+            "doc": "This is a second root type field documentation.",
+        }
+    )
+    c: Optional[RootEnum] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "namespace": "",
+            "required": True,
+        }
+    )
+    d: Optional["Root.D"] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "namespace": "",
+            "required": True,
+        }
+    )
+
+    @dataclass
+    class A:
+        """
+        This is an inner type documentation.
+        """
+        sub_a: Optional[str] = field(
+            default=None,
+            metadata={
+                "type": "Element",
+                "namespace": "",
+                "required": True,
+                "doc": (
+                    "This is an inner type field documentation.\nLorem ipsum dolor"
+                    " sit amet, consectetur adipiscing elit. Vivamus efficitur."
+                ),
+            }
+        )
+
+    class B(Enum):
+        YES = "Yes"
+        NO = "No"
+
+    B.YES.__doc__ = (
+        "This is an inner enum member documentation. Lorem ipsum dolor sit amet, "
+        "consectetur adipiscing elit. Etiam mollis."
+    )
+    B.NO.__doc__ = "Lorem ipsum dolor"
+
+    class D(Enum):
+        TRUE_VALUE = "true"
+        FALSE_VALUE = "false"

--- a/tests/fixtures/docstrings/google/__init__.py
+++ b/tests/fixtures/docstrings/google/__init__.py
@@ -1,0 +1,6 @@
+from tests.fixtures.docstrings.google.schema import (
+    DoubleQuotesDescription,
+    DoubleQuotesSummary,
+    Root,
+    RootEnum,
+)

--- a/tests/fixtures/docstrings/google/schema.py
+++ b/tests/fixtures/docstrings/google/schema.py
@@ -1,0 +1,120 @@
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+__NAMESPACE__ = "urn:docs"
+
+
+@dataclass
+class DoubleQuotesDescription:
+    """Let's trip.
+
+    Dont trip on quotes: "A", "B", "C", "D"
+    """
+    class Meta:
+        namespace = "urn:docs"
+
+
+@dataclass
+class DoubleQuotesSummary:
+    """
+    Dont trip on quotes: "A", "B", "C", "D".
+    """
+    class Meta:
+        namespace = "urn:docs"
+
+
+class RootEnum(Enum):
+    """
+    Attributes
+        A: Lorem ipsum dolor
+        B: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi
+            dapibus.
+    """
+    A = "A"
+    B = "B"
+
+
+@dataclass
+class Root:
+    """This is the root type documentation. Lorem ipsum dolor sit amet,
+    consectetur adipiscing elit. Morbi dapibus.
+
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec
+    imperdiet lacus sed sagittis scelerisque. Ut sodales metus: "sit",
+    "amet", "lectus"
+
+    Attributes
+        a: This is an inner type field documentation. Lorem ipsum dolor sit
+            amet, consectetur adipiscing elit. Aliquam nec.
+        b: This is a second root type field documentation.
+        c:
+        d:
+    """
+    class Meta:
+        namespace = "urn:docs"
+
+    a: Optional["Root.A"] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "namespace": "",
+            "required": True,
+        }
+    )
+    b: Optional["Root.B"] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "namespace": "",
+            "required": True,
+        }
+    )
+    c: Optional[RootEnum] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "namespace": "",
+            "required": True,
+        }
+    )
+    d: Optional["Root.D"] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "namespace": "",
+            "required": True,
+        }
+    )
+
+    @dataclass
+    class A:
+        """
+        This is an inner type documentation.
+
+        Attributes
+            sub_a: This is an inner type field documentation. Lorem ipsum dolor
+                sit amet, consectetur adipiscing elit. Vivamus efficitur.
+        """
+        sub_a: Optional[str] = field(
+            default=None,
+            metadata={
+                "type": "Element",
+                "namespace": "",
+                "required": True,
+            }
+        )
+
+    class B(Enum):
+        """
+        Attributes
+            YES: This is an inner enum member documentation. Lorem ipsum dolor
+                sit amet, consectetur adipiscing elit. Etiam mollis.
+            NO: Lorem ipsum dolor
+        """
+        YES = "Yes"
+        NO = "No"
+
+    class D(Enum):
+        TRUE_VALUE = "true"
+        FALSE_VALUE = "false"

--- a/tests/fixtures/docstrings/numpy/__init__.py
+++ b/tests/fixtures/docstrings/numpy/__init__.py
@@ -1,0 +1,6 @@
+from tests.fixtures.docstrings.numpy.schema import (
+    DoubleQuotesDescription,
+    DoubleQuotesSummary,
+    Root,
+    RootEnum,
+)

--- a/tests/fixtures/docstrings/numpy/schema.py
+++ b/tests/fixtures/docstrings/numpy/schema.py
@@ -1,0 +1,123 @@
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+__NAMESPACE__ = "urn:docs"
+
+
+@dataclass
+class DoubleQuotesDescription:
+    """Let's trip.
+
+    Dont trip on quotes: "A", "B", "C", "D"
+    """
+    class Meta:
+        namespace = "urn:docs"
+
+
+@dataclass
+class DoubleQuotesSummary:
+    """
+    Dont trip on quotes: "A", "B", "C", "D".
+    """
+    class Meta:
+        namespace = "urn:docs"
+
+
+class RootEnum(Enum):
+    """
+    Properties
+    ----------
+    A: Lorem ipsum dolor
+    B: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi dapibus.
+    """
+    A = "A"
+    B = "B"
+
+
+@dataclass
+class Root:
+    """This is the root type documentation. Lorem ipsum dolor sit amet,
+    consectetur adipiscing elit. Morbi dapibus.
+
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec
+    imperdiet lacus sed sagittis scelerisque. Ut sodales metus: "sit",
+    "amet", "lectus"
+
+    Parameters
+    ----------
+    a: This is an inner type field documentation. Lorem ipsum dolor sit amet,
+        consectetur adipiscing elit. Aliquam nec.
+    b: This is a second root type field documentation.
+    c:
+    d:
+    """
+    class Meta:
+        namespace = "urn:docs"
+
+    a: Optional["Root.A"] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "namespace": "",
+            "required": True,
+        }
+    )
+    b: Optional["Root.B"] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "namespace": "",
+            "required": True,
+        }
+    )
+    c: Optional[RootEnum] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "namespace": "",
+            "required": True,
+        }
+    )
+    d: Optional["Root.D"] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "namespace": "",
+            "required": True,
+        }
+    )
+
+    @dataclass
+    class A:
+        """
+        This is an inner type documentation.
+
+        Parameters
+        ----------
+        sub_a: This is an inner type field documentation. Lorem ipsum dolor sit
+            amet, consectetur adipiscing elit. Vivamus efficitur.
+        """
+        sub_a: Optional[str] = field(
+            default=None,
+            metadata={
+                "type": "Element",
+                "namespace": "",
+                "required": True,
+            }
+        )
+
+    class B(Enum):
+        """
+        Properties
+        ----------
+        YES: This is an inner enum member documentation. Lorem ipsum dolor sit
+            amet, consectetur adipiscing elit. Etiam mollis.
+        NO: Lorem ipsum dolor
+        """
+        YES = "Yes"
+        NO = "No"
+
+    class D(Enum):
+        TRUE_VALUE = "true"
+        FALSE_VALUE = "false"

--- a/tests/fixtures/docstrings/rst/__init__.py
+++ b/tests/fixtures/docstrings/rst/__init__.py
@@ -1,0 +1,6 @@
+from tests.fixtures.docstrings.rst.schema import (
+    DoubleQuotesDescription,
+    DoubleQuotesSummary,
+    Root,
+    RootEnum,
+)

--- a/tests/fixtures/docstrings/rst/schema.py
+++ b/tests/fixtures/docstrings/rst/schema.py
@@ -1,0 +1,116 @@
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+__NAMESPACE__ = "urn:docs"
+
+
+@dataclass
+class DoubleQuotesDescription:
+    """Let's trip.
+
+    Dont trip on quotes: "A", "B", "C", "D"
+    """
+    class Meta:
+        namespace = "urn:docs"
+
+
+@dataclass
+class DoubleQuotesSummary:
+    """
+    Dont trip on quotes: "A", "B", "C", "D".
+    """
+    class Meta:
+        namespace = "urn:docs"
+
+
+class RootEnum(Enum):
+    """
+    :cvar A: Lorem ipsum dolor
+    :cvar B: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi
+        dapibus.
+    """
+    A = "A"
+    B = "B"
+
+
+@dataclass
+class Root:
+    """This is the root type documentation. Lorem ipsum dolor sit amet,
+    consectetur adipiscing elit. Morbi dapibus.
+
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec
+    imperdiet lacus sed sagittis scelerisque. Ut sodales metus: "sit",
+    "amet", "lectus"
+
+    :ivar a: This is an inner type field documentation. Lorem ipsum dolor sit
+        amet, consectetur adipiscing elit. Aliquam nec.
+    :ivar b: This is a second root type field documentation.
+    :ivar c:
+    :ivar d:
+    """
+    class Meta:
+        namespace = "urn:docs"
+
+    a: Optional["Root.A"] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "namespace": "",
+            "required": True,
+        }
+    )
+    b: Optional["Root.B"] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "namespace": "",
+            "required": True,
+        }
+    )
+    c: Optional[RootEnum] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "namespace": "",
+            "required": True,
+        }
+    )
+    d: Optional["Root.D"] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "namespace": "",
+            "required": True,
+        }
+    )
+
+    @dataclass
+    class A:
+        """
+        This is an inner type documentation.
+
+        :ivar sub_a: This is an inner type field documentation. Lorem ipsum
+            dolor sit amet, consectetur adipiscing elit. Vivamus efficitur.
+        """
+        sub_a: Optional[str] = field(
+            default=None,
+            metadata={
+                "type": "Element",
+                "namespace": "",
+                "required": True,
+            }
+        )
+
+    class B(Enum):
+        """
+        :cvar YES: This is an inner enum member documentation. Lorem ipsum
+            dolor sit amet, consectetur adipiscing elit. Etiam mollis.
+        :cvar NO: Lorem ipsum dolor
+        """
+        YES = "Yes"
+        NO = "No"
+
+    class D(Enum):
+        TRUE_VALUE = "true"
+        FALSE_VALUE = "false"

--- a/tests/fixtures/docstrings/schema.xsd
+++ b/tests/fixtures/docstrings/schema.xsd
@@ -1,0 +1,104 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:docs" xmlns:docs="urn:docs">
+  <xsd:element name="Root">
+    <xsd:annotation>
+      <xsd:documentation>
+        This is the root type documentation. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi dapibus.
+
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec imperdiet lacus sed sagittis scelerisque. Ut sodales metus: "sit", "amet", "lectus"
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="a">
+          <xsd:annotation>
+            <xsd:documentation>
+              This is an inner type field documentation.
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam nec.
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:complexType>
+            <xsd:annotation>
+              <xsd:documentation>
+                This is an inner type documentation.
+              </xsd:documentation>
+            </xsd:annotation>
+            <xsd:sequence>
+              <xsd:element name="sub_a" type="xsd:string">
+                <xsd:annotation>
+                  <xsd:documentation>
+                    This is an inner type field documentation.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus efficitur.
+                  </xsd:documentation>
+                </xsd:annotation>
+              </xsd:element>
+            </xsd:sequence>
+          </xsd:complexType>
+        </xsd:element>
+        <xsd:element name="b">
+          <xsd:annotation>
+            <xsd:documentation>
+              This is a second root type field documentation.
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:simpleType>
+            <xsd:restriction>
+              <xsd:enumeration value="Yes">
+                <xsd:annotation>
+                  <xsd:documentation>
+                    This is an inner enum member documentation. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam mollis.
+                  </xsd:documentation>
+                </xsd:annotation>
+              </xsd:enumeration>
+              <xsd:enumeration value="No">
+                <xsd:annotation>
+                  <xsd:documentation>
+                    Lorem ipsum dolor
+                  </xsd:documentation>
+                </xsd:annotation>
+              </xsd:enumeration>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element name="c" type="RootEnum" />
+        <xsd:element name="d">
+          <xsd:simpleType>
+            <xsd:restriction>
+              <xsd:enumeration value="true" />
+              <xsd:enumeration value="false" />
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="DoubleQuotesSummary">
+    <xsd:annotation>
+      <xsd:documentation>Dont trip on quotes: "A", "B", "C", "D"</xsd:documentation>
+    </xsd:annotation>
+  </xsd:element>
+    <xsd:element name="DoubleQuotesDescription">
+    <xsd:annotation>
+      <xsd:documentation>Let's trip.
+
+        Dont trip on quotes: "A", "B", "C", "D"</xsd:documentation>
+    </xsd:annotation>
+  </xsd:element>
+  <xsd:simpleType name="RootEnum">
+    <xsd:restriction>
+      <xsd:enumeration value="A">
+        <xsd:annotation>
+          <xsd:documentation>
+            Lorem ipsum dolor
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value="B">
+        <xsd:annotation>
+          <xsd:documentation>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi dapibus.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:enumeration>
+    </xsd:restriction>
+  </xsd:simpleType>
+</xsd:schema>

--- a/tests/fixtures/primer/order.py
+++ b/tests/fixtures/primer/order.py
@@ -146,8 +146,9 @@ class Comment:
 
 @dataclass
 class PurchaseOrderType:
-    """Purchase order schema for Example.com. Copyright 2000 Example.com. All
-    rights reserved.
+    """Purchase order schema for Example.com.
+
+    Copyright 2000 Example.com. All rights reserved.
 
     Parameters
     ----------

--- a/tests/formats/dataclass/parsers/test_nodes.py
+++ b/tests/formats/dataclass/parsers/test_nodes.py
@@ -466,7 +466,7 @@ class AnyTypeNodeTests(TestCase):
         objects = []
 
         self.node.var = XmlElement(name="a", qname="a", types=[object], derived=True)
-        self.node.attrs[QNames.XSI_TYPE] = DataType.FLOAT.qname
+        self.node.attrs[QNames.XSI_TYPE] = str(DataType.FLOAT)
 
         self.assertTrue(self.node.bind("a", "10", None, objects))
         self.assertEqual(self.var.qname, objects[-1][0])
@@ -476,7 +476,7 @@ class AnyTypeNodeTests(TestCase):
         objects = []
 
         self.node.mixed = True
-        self.node.attrs[QNames.XSI_TYPE] = DataType.FLOAT.qname
+        self.node.attrs[QNames.XSI_TYPE] = str(DataType.FLOAT)
 
         self.assertTrue(self.node.bind("a", "10", "pieces", objects))
         self.assertEqual(self.var.qname, objects[-2][0])

--- a/tests/formats/dataclass/serializers/test_mixins.py
+++ b/tests/formats/dataclass/serializers/test_mixins.py
@@ -166,7 +166,7 @@ class XmlWriterTests(TestCase):
         self.writer.add_attribute("b", True)
         self.writer.add_attribute("c", "{")
         self.writer.add_attribute("d", "{a}b")
-        self.writer.add_attribute(QNames.XSI_TYPE, DataType.STRING.qname)
+        self.writer.add_attribute(QNames.XSI_TYPE, str(DataType.STRING))
 
         expected = {
             (None, "a"): "bar",

--- a/tests/formats/dataclass/serializers/test_xml.py
+++ b/tests/formats/dataclass/serializers/test_xml.py
@@ -282,7 +282,7 @@ class XmlSerializerTests(TestCase):
         var = XmlElement(qname="a", name="a", types=[object])
         expected = [
             (XmlWriterEvent.START, "a"),
-            (XmlWriterEvent.ATTR, QNames.XSI_TYPE, DataType.INT.qname),
+            (XmlWriterEvent.ATTR, QNames.XSI_TYPE, str(DataType.INT)),
             (XmlWriterEvent.DATA, 123),
             (XmlWriterEvent.END, "a"),
         ]

--- a/tests/formats/dataclass/test_context.py
+++ b/tests/formats/dataclass/test_context.py
@@ -91,7 +91,7 @@ class XmlContextTests(TestCase):
         mock_find_subclass.assert_called_once_with(ItemsType, "foo")
 
     def test_find(self):
-        self.assertIsNone(self.ctx.find_type(DataType.FLOAT.qname))
+        self.assertIsNone(self.ctx.find_type(str(DataType.FLOAT)))
         self.assertEqual(BookForm, self.ctx.find_type("{urn:books}BookForm"))
 
         self.ctx.xsi_cache["{urn:books}BookForm"].append(BooksForm)

--- a/tests/formats/dataclass/test_elements.py
+++ b/tests/formats/dataclass/test_elements.py
@@ -116,6 +116,7 @@ class XmlElementsTests(TestCase):
                 XmlElement(qname="a", name="a", types=[int]),
                 XmlElement(qname="b", name="b", types=[int], tokens=True),
                 XmlElement(qname="c", name="c", types=[c], dataclass=True),
+                XmlElement(qname="d", name="d", types=[float], nillable=True),
             ],
         )
 
@@ -124,6 +125,7 @@ class XmlElementsTests(TestCase):
         self.assertEqual(var.choices[1], var.find_value_choice([1, 2]))
         self.assertEqual(var.choices[2], var.find_value_choice(d()))
         self.assertEqual(var.choices[2], var.find_value_choice(c()))
+        self.assertEqual(var.choices[3], var.find_value_choice(None))
 
 
 class XmlWildcardTests(TestCase):

--- a/tests/formats/dataclass/test_filters.py
+++ b/tests/formats/dataclass/test_filters.py
@@ -1,7 +1,6 @@
 from tests.factories import AttrChoiceFactory
 from tests.factories import AttrFactory
 from tests.factories import AttrTypeFactory
-from tests.factories import ClassFactory
 from tests.factories import FactoryTestCase
 from xsdata.codegen.models import Restrictions
 from xsdata.formats.dataclass.filters import CLASS
@@ -500,7 +499,7 @@ class FiltersTests(FactoryTestCase):
             '    "num": 1,\n'
             '    "text": "foo",\n'
             '    "text_two": "fo\'o",\n'
-            '    "text_three": "fo\'o",\n'
+            '    "text_three": "fo\\"o",\n'
             '    "pattern": r"foo",\n'
             '    "level_two": {\n'
             '        "a": 1,\n'
@@ -516,32 +515,20 @@ class FiltersTests(FactoryTestCase):
             "}"
         )
         self.assertEqual(expected, self.filters.format_metadata(data))
+        self.assertEqual('""', self.filters.format_metadata(""))
 
-    def test_format_docstring(self):
+    def test_format_string(self):
+        self.assertEqual("None", self.filters.format_string(None))
+        self.assertEqual('""', self.filters.format_string(""))
 
-        actual = self.filters.format_docstring("'''    '''")
-        self.assertEqual("", actual)
+        value = ' foo"bar \n'
+        self.assertEqual('" foo\\"bar \\n"', self.filters.format_string(value))
 
-        actual = self.filters.format_docstring('"""    """')
-        self.assertEqual("", actual)
-
-        actual = self.filters.format_docstring("   ")
-        self.assertEqual("", actual)
-
-        docstring = (
-            "\n\nfafafa\n\n"
-            "                fwfw\n"
-            "        \n   \n  "
-            "            :param foobar: dfff  \n"
-            "        "
-        )
-
-        expected = (
-            '"""fafafa.\n' "\n" "  fwfw\n" "\n" "\n" ":param foobar: dfff\n" '"""'
-        )
-
-        actual = self.filters.format_docstring(docstring)
-        self.assertEqual(expected, actual)
+        expected = """(
+            " foo\\"bar \\n foo\\"bar \\n foo\\"bar \\n foo\\"bar \\n foo\\"bar \\n "
+            "foo\\"bar \\n foo\\"bar \\n foo\\"bar \\n foo\\"bar \\n foo\\"bar \\n"
+        )"""
+        self.assertEqual(expected, self.filters.format_string(value * 10, 50, 2))
 
     def test_from_config(self):
         config = GeneratorConfig()

--- a/tests/formats/dataclass/test_generator.py
+++ b/tests/formats/dataclass/test_generator.py
@@ -91,7 +91,8 @@ class DataclassGeneratorTests(FactoryTestCase):
             "\n"
             "\n"
             "class ClassB(Enum):\n"
-            '    """I am enum.\n'
+            '    """\n'
+            "    I am enum.\n"
             "\n"
             "    :cvar ATTR_B: I am a member\n"
             "    :cvar ATTR_C:\n"

--- a/tests/integration/test_docstrings.py
+++ b/tests/integration/test_docstrings.py
@@ -1,0 +1,83 @@
+import os
+
+from click.testing import CliRunner
+
+from tests import fixtures_dir
+from tests import root
+from xsdata.cli import cli
+from xsdata.utils.testing import load_class
+
+os.chdir(root)
+
+
+def test_generate_restructured_docstrings():
+    schema = fixtures_dir.joinpath("docstrings/schema.xsd")
+    package = "tests.fixtures.docstrings.rst"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            str(schema),
+            "--package",
+            package,
+            "--docstring-style",
+            "reStructuredText",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exception is None
+
+
+def test_generate_numpy_docstrings():
+    schema = fixtures_dir.joinpath("docstrings/schema.xsd")
+    package = "tests.fixtures.docstrings.numpy"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            str(schema),
+            "--package",
+            package,
+            "--docstring-style",
+            "NumPy",
+        ],
+    )
+
+    assert result.exception is None
+
+
+def test_generate_google_docstrings():
+    schema = fixtures_dir.joinpath("docstrings/schema.xsd")
+    package = "tests.fixtures.docstrings.google"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            str(schema),
+            "--package",
+            package,
+            "--docstring-style",
+            "Google",
+        ],
+    )
+
+    assert result.exception is None
+
+
+def test_generate_accessible_docstrings():
+    schema = fixtures_dir.joinpath("docstrings/schema.xsd")
+    package = "tests.fixtures.docstrings.accessible"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            str(schema),
+            "--package",
+            package,
+            "--docstring-style",
+            "Accessible",
+        ],
+    )
+
+    assert result.exception is None

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -18,7 +18,7 @@ class GeneratorConfigTests(TestCase):
         expected = (
             '<?xml version="1.0" encoding="UTF-8"?>\n'
             f'<Config xmlns="http://pypi.org/project/xsdata" version="{version}">\n'
-            '  <Output wsdl="false">\n'
+            '  <Output wsdl="false" maxLineLength="79">\n'
             "    <Package>generated</Package>\n"
             "    <Format>pydata</Format>\n"
             "    <Structure>filenames</Structure>\n"
@@ -47,7 +47,7 @@ class GeneratorConfigTests(TestCase):
         existing = (
             '<?xml version="1.0" encoding="UTF-8"?>\n'
             '<Config xmlns="http://pypi.org/project/xsdata" version="20.8">\n'
-            '  <Output wsdl="false">\n'
+            '  <Output wsdl="false" maxLineLength="79">\n'
             "    <Package>foo.bar</Package>\n"
             "  </Output>\n"
             "  <Conventions>\n"
@@ -66,7 +66,7 @@ class GeneratorConfigTests(TestCase):
         expected = (
             '<?xml version="1.0" encoding="UTF-8"?>\n'
             f'<Config xmlns="http://pypi.org/project/xsdata" version="{version}">\n'
-            '  <Output wsdl="false">\n'
+            '  <Output wsdl="false" maxLineLength="79">\n'
             "    <Package>foo.bar</Package>\n"
             "    <Format>pydata</Format>\n"
             "    <Structure>filenames</Structure>\n"

--- a/tests/models/xsd/test_documentation.py
+++ b/tests/models/xsd/test_documentation.py
@@ -8,7 +8,7 @@ class DocumentationTests(TestCase):
     def test_tostring(self):
         documentation = Documentation(
             elements=[
-                "I am a ",
+                "    I am a ",
                 AnyElement(
                     qname="p",
                     text="test",

--- a/xsdata/cli.py
+++ b/xsdata/cli.py
@@ -32,7 +32,7 @@ def cli():
 @cli.command("init-config")
 @click.argument("output", type=click.Path(), default=".xsdata.xml")
 @click.option("--print", is_flag=True, default=False, help="Print output")
-def init_config(*args: Any, **kwargs: Any):
+def init_config(**kwargs: Any):
     """Create or update a configuration file."""
 
     if kwargs["print"]:
@@ -98,7 +98,7 @@ def download(source: str, output: str):
         "Useful against circular import errors."
     ),
 )
-def generate(*args: Any, **kwargs: Any):
+def generate(**kwargs: Any):
     """
     Convert schema definitions to code.
 

--- a/xsdata/codegen/handlers/attribute_mixed_content.py
+++ b/xsdata/codegen/handlers/attribute_mixed_content.py
@@ -34,7 +34,7 @@ class AttributeMixedContentHandler(HandlerInterface):
                 name="content",
                 local_name="content",
                 index=0,
-                types=[AttrType(qname=DataType.ANY_TYPE.qname, native=True)],
+                types=[AttrType(qname=str(DataType.ANY_TYPE), native=True)],
                 tag=Tag.ANY,
                 mixed=True,
                 namespace=NamespaceType.ANY_NS,

--- a/xsdata/codegen/handlers/attribute_type.py
+++ b/xsdata/codegen/handlers/attribute_type.py
@@ -177,7 +177,7 @@ class AttributeTypeHandler(HandlerInterface):
     @classmethod
     def reset_attribute_type(cls, attr_type: AttrType):
         """Reset the attribute type to native string."""
-        attr_type.qname = DataType.STRING.qname
+        attr_type.qname = str(DataType.STRING)
         attr_type.native = True
         attr_type.circular = False
         attr_type.forward = False
@@ -199,6 +199,6 @@ class AttributeTypeHandler(HandlerInterface):
             types = collections.remove(types, lambda x: x.native_type is object)
 
         if not types:
-            types.append(AttrType(qname=DataType.STRING.qname, native=True))
+            types.append(AttrType(qname=str(DataType.STRING), native=True))
 
         return types

--- a/xsdata/codegen/mappers/definitions.py
+++ b/xsdata/codegen/mappers/definitions.py
@@ -93,7 +93,7 @@ class DefinitionsMapper:
         the process of all the message classes to the next entry point."""
 
         attrs = [
-            cls.build_attr(key, DataType.STRING.qname, native=True, default=config[key])
+            cls.build_attr(key, str(DataType.STRING), native=True, default=config[key])
             for key in sorted(config.keys(), key=len)
             if config[key]
         ]
@@ -186,7 +186,7 @@ class DefinitionsMapper:
         collections.prepend(
             fault_class.attrs,
             *[
-                cls.build_attr(f, DataType.STRING.qname, native=True, namespace="")
+                cls.build_attr(f, str(DataType.STRING), native=True, namespace="")
                 for f in default_fields
             ],
         )

--- a/xsdata/codegen/models.py
+++ b/xsdata/codegen/models.py
@@ -207,7 +207,7 @@ class AttrType:
         """Return the python build-in type name: `'str'`, `'int'` if it's
         native type."""
         data_type = DataType.get_enum(self.name) if self.native else None
-        return data_type.local_name if data_type else None
+        return data_type.type.__name__ if data_type else None
 
     @property
     def native_code(self) -> Optional[str]:
@@ -219,7 +219,7 @@ class AttrType:
     def native_type(self) -> Any:
         """Return the python build-in type if it's a native type."""
         data_type = DataType.get_enum(self.name) if self.native else None
-        return data_type.local if data_type else None
+        return data_type.type if data_type else None
 
     def clone(self) -> "AttrType":
         """Return a deep cloned instance."""

--- a/xsdata/codegen/sanitizer.py
+++ b/xsdata/codegen/sanitizer.py
@@ -95,7 +95,7 @@ class ClassSanitizer:
                 name=name,
                 local_name=name,
                 index=0,
-                types=[AttrType(qname=DataType.ANY_TYPE.qname, native=True)],
+                types=[AttrType(qname=str(DataType.ANY_TYPE), native=True)],
                 tag=Tag.CHOICE,
                 restrictions=Restrictions(
                     min_occurs=min((x for x in min_occurs if x is not None), default=0),

--- a/xsdata/formats/dataclass/filters.py
+++ b/xsdata/formats/dataclass/filters.py
@@ -256,7 +256,7 @@ class Filters:
         return str(data)
 
     def format_string(
-        self, value: Optional[str], start: int = 0, level: int = 0, ident: int = 0
+        self, value: Optional[str], start: int = 0, level: int = 0
     ) -> str:
         if value is None:
             return str(None)

--- a/xsdata/formats/dataclass/parsers/nodes.py
+++ b/xsdata/formats/dataclass/parsers/nodes.py
@@ -233,7 +233,7 @@ class AnyTypeNode(XmlNode):
             var = self.var
             ns_map = self.ns_map
             datatype = ParserUtils.data_type(self.attrs, self.ns_map)
-            obj = ParserUtils.parse_value(text, [datatype.local], var.default, ns_map)
+            obj = ParserUtils.parse_value(text, [datatype.type], var.default, ns_map)
 
             if var.derived:
                 obj = DerivedElement(qname=qname, value=obj)

--- a/xsdata/formats/dataclass/serializers/xml.py
+++ b/xsdata/formats/dataclass/serializers/xml.py
@@ -272,7 +272,7 @@ class XmlSerializer(AbstractSerializer):
         if value is not None and var.is_any_type:
             datatype = DataType.from_value(value)
             if datatype != DataType.STRING:
-                yield XmlWriterEvent.ATTR, QNames.XSI_TYPE, datatype.qname
+                yield XmlWriterEvent.ATTR, QNames.XSI_TYPE, str(datatype)
 
         yield XmlWriterEvent.DATA, value
         yield XmlWriterEvent.END, var.qname

--- a/xsdata/formats/dataclass/templates/class.jinja2
+++ b/xsdata/formats/dataclass/templates/class.jinja2
@@ -1,7 +1,7 @@
-{% set help | format_docstring %}
+{% set level = level|default(0) -%}
+{% set help | format_docstring(level + 1) %}
     {%- include "docstrings." + docstring_style + ".jinja2" -%}
 {% endset -%}
-{% set level = level|default(0) -%}
 {% set parent_namespace = obj.namespace or parent_namespace|default(None) -%}
 {% set class_name =  obj.name|class_name -%}
 {% set parents = parents|default([obj.name]) %}
@@ -33,14 +33,14 @@ class {{ class_name }}{{"({})".format(obj.extensions|map(attribute='type')|map('
         {% endif -%}
         {{ "default_factory" if attr.is_factory else "default" }}={{ attr|field_default(obj.ns_map) }},
         {%- if metadata %}
-        metadata={{ metadata|format_metadata|indent(8) }}
+        metadata={{ metadata|format_metadata(2) }}
         {%- endif %}
     )
 {%- endfor -%}
 {%- for inner in obj.inner %}
     {%- set tpl = "enum.jinja2" if inner.is_enumeration else "class.jinja2" -%}
     {%- filter indent(4) -%}
-        {%- with obj=inner, namespace=obj.namespace or parent_namespace, parents=parents + [inner.name] -%}
+        {%- with obj=inner, namespace=obj.namespace or parent_namespace, parents=parents + [inner.name], level=(level + 1) -%}
             {% include tpl %}
         {%- endwith -%}
     {%- endfilter -%}

--- a/xsdata/formats/dataclass/templates/docstrings.accessible.jinja2
+++ b/xsdata/formats/dataclass/templates/docstrings.accessible.jinja2
@@ -1,0 +1,1 @@
+{{ '"""{}"""'.format(obj.help | text_strip) }}

--- a/xsdata/formats/dataclass/templates/docstrings.google.jinja2
+++ b/xsdata/formats/dataclass/templates/docstrings.google.jinja2
@@ -1,10 +1,7 @@
-{% set is_enum = obj.is_enumeration -%}
-"""
-{{ obj.help or "" }}
+{{ '"""{}"""'.format(obj.help | text_strip) }}
 {% if obj.has_help_attr %}
 Attributes
-{%- for attr in obj.attrs %}
-    {{ attr.name|constant_name if is_enum else attr.name|field_name }}:{{- " " + attr.help|trim if attr.help else "" -}}
+{%- for var_name, var_doc in obj|class_params %}
+{{ "{}: {}".format(var_name, var_doc)|text_wrap(level + 2)|indent(first=True) }}
 {%- endfor -%}
 {%- endif %}
-"""

--- a/xsdata/formats/dataclass/templates/docstrings.numpy.jinja2
+++ b/xsdata/formats/dataclass/templates/docstrings.numpy.jinja2
@@ -1,12 +1,8 @@
-{% set is_enum = obj.is_enumeration -%}
-{% set attr_title = "Properties" if is_enum else "Parameters" -%}
-"""
-{{ obj.help or "" }}
+{{ '"""{}"""'.format(obj.help | text_strip) }}
 {% if obj.has_help_attr %}
-{{ attr_title }}
+{{ "Properties" if obj.is_enumeration else "Parameters" }}
 ----------
-{%- for attr in obj.attrs %}
-{{ attr.name|constant_name if is_enum else attr.name|field_name }}:{{- " " + attr.help|trim if attr.help else "" -}}
+{%- for var_name, var_doc in obj|class_params %}
+{{ "{}: {}".format(var_name, var_doc)|text_wrap(level + 1) }}
 {%- endfor -%}
 {%- endif %}
-"""

--- a/xsdata/formats/dataclass/templates/docstrings.rst.jinja2
+++ b/xsdata/formats/dataclass/templates/docstrings.rst.jinja2
@@ -1,10 +1,8 @@
 {% set is_enum = obj.is_enumeration -%}
 {% set prefix = "cvar" if is_enum else "ivar" -%}
-"""
-{{ obj.help or "" }}
+{{ '"""{}"""'.format(obj.help | text_strip) }}
 {% if obj.has_help_attr %}
-{%- for attr in obj.attrs %}
-:{{ prefix }} {{ attr.name|constant_name if is_enum else attr.name|field_name }}:{{- " " + attr.help|trim if attr.help else "" -}}
-{%- endfor -%}
+{%- for var_name, var_doc in obj|class_params %}
+{{ ":{} {}: {}".format(prefix, var_name, var_doc) | text_wrap(level + 1) }}
+{%- endfor %}
 {%- endif %}
-"""

--- a/xsdata/formats/dataclass/templates/enum.jinja2
+++ b/xsdata/formats/dataclass/templates/enum.jinja2
@@ -1,11 +1,20 @@
-{% set help | format_docstring %}
+{% set level = level|default(0) -%}
+{% set help | format_docstring(level + 1) %}
     {%- include "docstrings." + docstring_style + ".jinja2" -%}
-{% endset %}
+{% endset -%}
+{% set class_name = obj.name|class_name %}
 
-class {{ obj.name|class_name }}(Enum):
+class {{ class_name }}(Enum):
 {%- if help %}
 {{ help|indent(4, first=True) }}
 {%- endif -%}
 {%- for attr in obj.attrs %}
     {{ attr.name|constant_name }} = {{ attr|field_default(obj.ns_map) }}
 {%- endfor -%}
+{% if docstring_style == "accessible" -%}
+{{ "\n\n" if level == 0 else "\n" }}
+{%- for attr in obj.attrs if attr.help %}
+{% set member_name = "{}.{}.__doc__ = ".format(class_name, attr.name|constant_name) -%}
+{{ member_name }}{{ attr.help | format_string(member_name|length) }}
+{%- endfor -%}
+{%- endif -%}

--- a/xsdata/models/config.py
+++ b/xsdata/models/config.py
@@ -63,6 +63,7 @@ class DocstringStyle(Enum):
     RST = "reStructuredText"
     NUMPY = "NumPy"
     GOOGLE = "Google"
+    ACCESSIBLE = "Accessible"
 
 
 @dataclass
@@ -71,6 +72,7 @@ class GeneratorOutput:
     Main generator output options.
 
     :param wsdl: Enable wsdl mode
+    :param max_line_length: Maximum line length
     :param package: Package name eg foo.bar.models
     :param format: Select an output format
     :param structure: Select an output structure
@@ -80,6 +82,7 @@ class GeneratorOutput:
     """
 
     wsdl: bool = attribute(default=False)
+    max_line_length: int = attribute(default=79)
     package: str = element(default="generated")
     format: OutputFormat = element(default=OutputFormat.DATACLASS)
     structure: OutputStructure = element(default=OutputStructure.FILENAMES)

--- a/xsdata/models/enums.py
+++ b/xsdata/models/enums.py
@@ -139,17 +139,12 @@ class DataType(Enum):
     UNSIGNED_LONG = ("unsignedLong", int)
     UNSIGNED_SHORT = ("unsignedShort", int)
 
-    def __init__(self, code: str, local: type):
+    def __init__(self, code: str, python_type: type):
         self.code = code
-        self.local = local
+        self.type = python_type
 
-    @property
-    def qname(self) -> str:
+    def __str__(self) -> str:
         return f"{{{Namespace.XS.uri}}}{self.code}"
-
-    @property
-    def local_name(self) -> str:
-        return self.local.__name__
 
     @classmethod
     def get_enum(cls, code: str) -> Optional["DataType"]:
@@ -175,8 +170,8 @@ class DataType(Enum):
         return __DataTypeQNameIndex__.get(qname)
 
 
-__DataTypeCodeIndex__ = {xsd.code: xsd for xsd in DataType}
-__DataTypeQNameIndex__ = {xsd.qname: xsd for xsd in DataType}
+__DataTypeCodeIndex__ = {dt.code: dt for dt in DataType}
+__DataTypeQNameIndex__ = {str(dt): dt for dt in DataType}
 
 
 class EventType:

--- a/xsdata/models/xsd.py
+++ b/xsdata/models/xsd.py
@@ -1,4 +1,5 @@
 import sys
+import textwrap
 from dataclasses import dataclass
 from dataclasses import field
 from typing import Any as Anything
@@ -54,7 +55,7 @@ class Documentation(ElementBase):
 
     def tostring(self) -> Optional[str]:
         xml = docstring_serializer.render(Docstring(self.elements)).split("\n", 1)
-        return clean_html(xml[1])[5:-7].strip()
+        return textwrap.dedent(clean_html(xml[1])[5:-7]).strip()
 
 
 @dataclass

--- a/xsdata/utils/collections.py
+++ b/xsdata/utils/collections.py
@@ -36,7 +36,7 @@ def remove(items: Iterable, predicate: Callable) -> List:
     return [x for x in items if not predicate(x)]
 
 
-def group_by(items: Sequence, key: Callable) -> Dict[Any, List]:
+def group_by(items: Iterable, key: Callable) -> Dict[Any, List]:
     """Group the items of a sequence by the result of the callable."""
     result = defaultdict(list)
     for item in items:

--- a/xsdata/utils/constants.py
+++ b/xsdata/utils/constants.py
@@ -6,6 +6,6 @@ EMPTY_MAP: Dict = {}
 EMPTY_SEQUENCE: Sequence = []
 
 
-def return_true(*args: Any) -> bool:
+def return_true(*_: Any) -> bool:
     """A dummy function that always returns true."""
     return True

--- a/xsdata/utils/text.py
+++ b/xsdata/utils/text.py
@@ -1,4 +1,6 @@
+import re
 from typing import List
+from typing import Match
 from typing import Tuple
 
 
@@ -101,3 +103,30 @@ def classify(character: str) -> int:
         return StringType.NUMERIC
 
     return StringType.OTHER
+
+
+ESCAPE = re.compile(r'[\x00-\x1f\\"\b\f\n\r\t]')
+ESCAPE_DCT = {
+    "\\": "\\\\",
+    '"': '\\"',
+    "\b": "\\b",
+    "\f": "\\f",
+    "\n": "\\n",
+    "\r": "\\r",
+    "\t": "\\t",
+}
+for i in range(0x20):
+    ESCAPE_DCT.setdefault(chr(i), f"\\u{i:04x}")
+
+
+def escape_string(string: str) -> str:
+    """
+    Escape a string for code generation.
+
+    Source: json.encoder.py_encode_basestring
+    """
+
+    def replace(match: Match) -> str:
+        return ESCAPE_DCT[match.group(0)]
+
+    return ESCAPE.sub(replace, string)


### PR DESCRIPTION
### Access fields docstrings on runtime

```python
# dataclass field  example
root_field: Optional["Root.RootField"] = field(
    default=None,
    metadata={
        "type": "Element",
        "namespace": "",
        "required": True,
        "doc": (
            "This is a root type field documentation.\nLorem ipsum dolor "
            "sit amet, consectetur adipiscing elit. Aliquam nec."
        ),
    }
)

# Enum member example
RootBField.NO.__doc__ = "Lorem ipsum dolor"

```

This is an opportunity to also introduce a max line length for the generator, that I was avoiding for a long time. ~~Unfortunately this means that I have to drop `docformatter ` as it can not handle docstrings with summary + description + params, see tests~~


- [x] New docstring style `Accessible`
- [x] New max line length config
- [x] Wrap Docstring description