### PR TITLE
Improve duplicate attr names detection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
         args: ["--suppress-none-returning"]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v3.4.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer

--- a/xsdata/formats/dataclass/utils.py
+++ b/xsdata/formats/dataclass/utils.py
@@ -65,10 +65,12 @@ def safe_snake(string: str, default: str = "value") -> str:
     if re.match(r"^-\d*\.?\d+$", string):
         return f"{default}_minus_{string}"
 
+    string = string.strip("_")
+
     if not string[0].isalpha():
         return f"{default}_{string}"
 
     if string.lower() in stop_words:
         return f"{string}_{default}"
 
-    return string.strip("_")
+    return string


### PR DESCRIPTION
Closes #351
Avoid renaming attrs before jinja filters.
Use text.snake_case to group attributes.