### PR TITLE
Use embedded schemas only instead of w3.org versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {name: PyPy 3, python: pypy3, os: ubuntu}
+          - {name: PyPy 3.6, python: pypy-3.6, os: ubuntu}
+          - {name: PyPy 3.7, python: pypy-3.7, os: ubuntu}
           - {name: Python 3.6, python: 3.6, os: ubuntu}
           - {name: Python 3.7, python: 3.7, os: ubuntu}
           - {name: Python 3.8, python: 3.8, os: ubuntu}
@@ -28,7 +29,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install libxml2
-        if: matrix.python == 'pypy3'
+        if: matrix.python == 'pypy-3.6' || matrix.python == 'pypy-3.7'
         run: |
           sudo apt-get install libxml2-dev libxslt-dev
       - name: Install dependencies

--- a/tests/codegen/parsers/test_schema.py
+++ b/tests/codegen/parsers/test_schema.py
@@ -239,13 +239,17 @@ class SchemaParserTests(TestCase):
             self.parser.resolve_local_path(None, Namespace.XSI.uri),
         )
 
-        self.assertEqual(
-            Namespace.XSI.location,
-            self.parser.resolve_local_path("http://something", Namespace.XSI.uri),
-        )
         iam = Path(__file__)
         self.parser.location = iam.as_uri()
         self.assertEqual(iam.as_uri(), self.parser.resolve_local_path(iam.name, None))
+        self.assertEqual(
+            "http://something",
+            self.parser.resolve_local_path("http://something", Namespace.XSI.uri),
+        )
+        self.assertEqual(
+            iam.parent.parent.joinpath("xsi.xsd").as_uri(),
+            self.parser.resolve_local_path("../xsi.xsd", Namespace.XSI.uri),
+        )
 
     def test_end_attribute(self):
         attribute = Attribute()

--- a/xsdata/codegen/parsers/schema.py
+++ b/xsdata/codegen/parsers/schema.py
@@ -167,7 +167,11 @@ class SchemaParser(XmlParser):
 
         common_ns = Namespace.get_enum(namespace)
         local_path = common_ns.location if common_ns else None
-        return local_path if local_path else self.resolve_path(location)
+
+        if local_path and (not location or location.find("w3.org/") > 0):
+            return local_path
+
+        return self.resolve_path(location)
 
     def end_attribute(self, obj: T):
         """Assign the schema's default form for attributes if the given


### PR DESCRIPTION
Notes:
Closes #353, use xsdata's version only if the
generator is about to fetch the schema directly
from w3.org