### PR TITLE
Add SerializerConfig::xml_declaration option

### DIFF
--- a/docs/xml.rst
+++ b/docs/xml.rst
@@ -167,6 +167,9 @@ context instance between them to save on memory and processing.
        * - xml_version
          - str
          - XML Version number, default: ``1.0``
+       * - xml_declaration
+         - bool
+         - Generate XML declaration, default ``True``
        * - pretty_print
          - bool
          - Enable pretty output, default ``False``

--- a/tests/formats/dataclass/serializers/writers/test_lxml.py
+++ b/tests/formats/dataclass/serializers/writers/test_lxml.py
@@ -41,6 +41,14 @@ class LxmlEventWriterTests(TestCase):
 
         self.assertEqual('<?xml version="1.1" encoding="US-ASCII"?>', xml_declaration)
 
+    def test_declaration_disabled(self):
+        self.serializer.config.xml_declaration = False
+        actual = self.serializer.render(books, {None: "urn:books"})
+        expected = fixtures_dir.joinpath("books/books_default_ns.xml").read_text()
+        xml_declaration, expected = expected.split("\n", 1)
+
+        self.assertEqual(expected, actual)
+
     def test_pretty_print_false(self):
         self.serializer.config.pretty_print = False
         actual = self.serializer.render(books)

--- a/tests/formats/dataclass/serializers/writers/test_native.py
+++ b/tests/formats/dataclass/serializers/writers/test_native.py
@@ -35,6 +35,14 @@ class XmlEventWriterTests(TestCase):
 
         self.assertEqual('<?xml version="1.1" encoding="US-ASCII"?>', xml_declaration)
 
+    def test_declaration_disabled(self):
+        self.serializer.config.xml_declaration = False
+        actual = self.serializer.render(books, {None: "urn:books"})
+        expected = fixtures_dir.joinpath("books/books_default_ns.xml").read_text()
+        xml_declaration, expected = expected.split("\n", 1)
+
+        self.assertEqual(expected, actual)
+
     def test_pretty_print_false(self):
         self.serializer.config.pretty_print = False
         actual = self.serializer.render(books)

--- a/xsdata/formats/dataclass/serializers/config.py
+++ b/xsdata/formats/dataclass/serializers/config.py
@@ -8,6 +8,7 @@ class SerializerConfig:
     """
     :param encoding: Text encoding
     :param xml_version: XML Version number (1.0|1.1)
+    :param xml_declaration: Generate XML declaration
     :param pretty_print: Enable pretty output
     :param schema_location: Specify the xsi:schemaLocation attribute value
     :param no_namespace_schema_location: Specify the xsi:noNamespaceSchemaLocation
@@ -16,6 +17,7 @@ class SerializerConfig:
 
     encoding: str = field(default="UTF-8")
     xml_version: str = field(default="1.0")
+    xml_declaration: bool = field(default=True)
     pretty_print: bool = field(default=False)
     schema_location: Optional[str] = field(default=None)
     no_namespace_schema_location: Optional[str] = field(default=None)

--- a/xsdata/formats/dataclass/serializers/mixins.py
+++ b/xsdata/formats/dataclass/serializers/mixins.py
@@ -91,8 +91,9 @@ class XmlWriter:
         self.handler.endDocument()
 
     def start_document(self):
-        self.output.write(f'<?xml version="{self.config.xml_version}"')
-        self.output.write(f' encoding="{self.config.encoding}"?>\n')
+        if self.config.xml_declaration:
+            self.output.write(f'<?xml version="{self.config.xml_version}"')
+            self.output.write(f' encoding="{self.config.encoding}"?>\n')
 
     def start_tag(self, qname: str):
         """


### PR DESCRIPTION
Resolves #357, the introduction of the SerializerConfig
broke the side effect of not being able to omitt xml
declaration only with the lxml writer.

This brings it back for all writers :)