### PR TITLE
Prevent duplicate class names

### DIFF
--- a/tests/formats/dataclass/test_filters.py
+++ b/tests/formats/dataclass/test_filters.py
@@ -152,7 +152,7 @@ class FiltersTests(FactoryTestCase):
 
     def test_field_default_value_with_type_enum(self):
         attr = AttrFactory.create(
-            types=AttrTypeFactory.list(1, qname="foo"), default="@enum@foo::bar"
+            types=AttrTypeFactory.list(1, qname="{a}foo"), default="@enum@{a}foo::bar"
         )
         self.assertEqual("Foo.BAR", self.filters.field_default_value(attr))
 

--- a/tests/utils/test_text.py
+++ b/tests/utils/test_text.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 from xsdata.utils.text import camel_case
 from xsdata.utils.text import capitalize
 from xsdata.utils.text import mixed_case
+from xsdata.utils.text import mixed_pascal_case
 from xsdata.utils.text import mixed_snake_case
 from xsdata.utils.text import pascal_case
 from xsdata.utils.text import snake_case
@@ -49,6 +50,16 @@ class TextTests(TestCase):
         self.assertEqual("UserName", mixed_case("User_Name"))
         self.assertEqual("username", mixed_case("user_name"))
         self.assertEqual("SUserNAME", mixed_case("SUserNAME"))
+
+    def test_mixed_pascal_case(self):
+        self.assertEqual("P00p", mixed_pascal_case("p00p"))
+        self.assertEqual("USERName", mixed_pascal_case("USERName"))
+        self.assertEqual("UserNAME", mixed_pascal_case("UserNAME"))
+        self.assertEqual("USERname", mixed_pascal_case("USER_name"))
+        self.assertEqual("USERNAME", mixed_pascal_case("USER-NAME"))
+        self.assertEqual("UserName", mixed_pascal_case("User_Name"))
+        self.assertEqual("Username", mixed_pascal_case("user_name"))
+        self.assertEqual("SUserNAME", mixed_pascal_case("SUserNAME"))
 
     def test_mixed_snake_case(self):
         self.assertEqual("p00p", mixed_snake_case("p00p"))

--- a/xsdata/formats/dataclass/filters.py
+++ b/xsdata/formats/dataclass/filters.py
@@ -27,6 +27,7 @@ from xsdata.models.config import GeneratorConfig
 from xsdata.utils import text
 from xsdata.utils.collections import unique_sequence
 from xsdata.utils.namespaces import clean_uri
+from xsdata.utils.namespaces import split_qname
 
 
 @dataclass
@@ -375,9 +376,10 @@ class Filters:
         )
 
     def field_default_enum(self, attr: Attr) -> str:
-        source, enumeration = attr.default[6:].split("::", 1)
-        source = next(x.alias or source for x in attr.types if x.name == source)
-        return f"{self.class_name(source)}.{self.constant_name(enumeration, source)}"
+        qname, enumeration = attr.default[6:].split("::", 1)
+        qname = next(x.alias or qname for x in attr.types if x.qname == qname)
+        _, name = split_qname(qname)
+        return f"{self.class_name(name)}.{self.constant_name(enumeration, name)}"
 
     def field_default_tokens(
         self, attr: Attr, types: List[Type], ns_map: Optional[Dict]

--- a/xsdata/models/config.py
+++ b/xsdata/models/config.py
@@ -51,24 +51,25 @@ class NameCase(Enum):
     when it encounters non alphanumerical characters or when an upper
     case letter follows a lower case letter.
 
-    =========  =========  =========  ==========  =========  ===========
-    Original   Pascal     Camel      Snake       Mixed      Mixed Snake
-    =========  =========  =========  ==========  =========  ===========
-    p00p       P00P       p00P       p00p        p00p       p00p
-    USERName   Username   username   username    USERName   USERName
-    UserNAME   UserName   userName   user_name   UserNAME   User_NAME
-    USER_name  UserName   userName   user_name   USERname   USER_name
-    USER-NAME  UserName   userName   user_name   USERNAME   USER_NAME
-    User_Name  UserName   userName   user_name   UserName   User_Name
-    user_name  UserName   userName   user_name   username   user_name
-    SUserNAME  SuserName  suserName  suser_name  SUserNAME  SUser_NAME
-    =========  =========  =========  ==========  =========  ===========
+    =========  =========  =========  ==========  =========  ===========  ============
+    Original   Pascal     Camel      Snake       Mixed      Mixed Snake  Mixed Pascal
+    =========  =========  =========  ==========  =========  ===========  ============
+    p00p       P00P       p00P       p00p        p00p       p00p         P00p
+    USERName   Username   username   username    USERName   USERName     USERName
+    UserNAME   UserName   userName   user_name   UserNAME   User_NAME    UserNAME
+    USER_name  UserName   userName   user_name   USERname   USER_name    USERname
+    USER-NAME  UserName   userName   user_name   USERNAME   USER_NAME    USERNAME
+    User_Name  UserName   userName   user_name   UserName   User_Name    UserName
+    user_name  UserName   userName   user_name   username   user_name    Username
+    SUserNAME  SuserName  suserName  suser_name  SUserNAME  SUser_NAME   SUserNAME
+    =========  =========  =========  ==========  =========  ===========  ============
 
     :cvar PASCAL: pascalCase
     :cvar CAMEL: camelCase
     :cvar SNAKE: snakeCase
     :cvar MIXED: mixedCase
     :cvar MIXED_SNAKE: mixedSnakeCase
+    :cvar MIXED_PASCAL: mixedPascalCase
     """
 
     PASCAL = "pascalCase"
@@ -76,6 +77,7 @@ class NameCase(Enum):
     SNAKE = "snakeCase"
     MIXED = "mixedCase"
     MIXED_SNAKE = "mixedSnakeCase"
+    MIXED_PASCAL = "mixedPascalCase"
 
     def __call__(self, string: str, **kwargs: Any) -> str:
         return self.callback(string, **kwargs)
@@ -92,6 +94,7 @@ __name_case_func__ = {
     "snakeCase": text.snake_case,
     "mixedCase": text.mixed_case,
     "mixedSnakeCase": text.mixed_snake_case,
+    "mixedPascalCase": text.mixed_pascal_case,
 }
 
 

--- a/xsdata/utils/text.py
+++ b/xsdata/utils/text.py
@@ -47,6 +47,11 @@ def mixed_case(string: str, **kwargs: Any) -> str:
     return "".join(split_words(string))
 
 
+def mixed_pascal_case(string: str, **kwargs: Any) -> str:
+    """Convert the given string to mixed pascal case."""
+    return capitalize(mixed_case(string))
+
+
 def mixed_snake_case(string: str, **kwargs: Any) -> str:
     """Convert the given string to mixed snake case."""
     return "_".join(split_words(string))


### PR DESCRIPTION
In v20.12 the text processor for class/field names started striping underscores before applying any naming scheme in an effort to create better names.

I forgot to address the ClassSanitizer that takes care of duplicate class names.