### PR TITLE
Set effective choice groups

### DIFF
--- a/docs/demos.rst
+++ b/docs/demos.rst
@@ -49,7 +49,7 @@ XML and JSON Binding.
 
 XSD Results: **10** failed, **14576** passed, **89** skipped, **16** warnings
 
-XML Results: **13** failed, **14573** passed, **90** skipped, **15** warnings
+XML Results: **3** failed, **14582** passed, **90** skipped, **15** warnings
 
 JSON Results: **113** failed, **14562** passed, **1** warnings
 


### PR DESCRIPTION
Use sum for field restrictions in effective choice groups from xs:sequence instead of min/max from proper xs:choice groups.


- [x] Set the restrictions correctly
- [x] Testing