### PR TITLE
Explicit jinja version requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ cli =
     click-default-group
     click_log
     docformatter
-    jinja2
+    jinja2 >= 2.11
     toposort
     importlib-metadata;python_version<"3.8"
 docs =


### PR DESCRIPTION
Jinja < 2.11 does not support pathlib paths, so the cli component of xsdata does not work. 
This pull request makes the dependency explicit.