### PR TITLE
Add option ""

### DIFF
--- a/xsdata/formats/dataclass/generator.py
+++ b/xsdata/formats/dataclass/generator.py
@@ -91,7 +91,7 @@ class DataclassGenerator(AbstractGenerator):
         namespace = classes[0].target_namespace
 
         return self.env.get_template("module.jinja2").render(
-            output=output, imports=imports, namespace=namespace
+            output=output, imports=imports, namespace=namespace, future_annotations = self.config.output.import_future_annotations
         )
 
     def render_classes(self, classes: List[Class]) -> str:

--- a/xsdata/formats/dataclass/templates/module.jinja2
+++ b/xsdata/formats/dataclass/templates/module.jinja2
@@ -1,3 +1,6 @@
+{%- if future_annotations %}
+from __future__ import annotations
+{% endif %}
 {{ output|default_imports }}
 {% include "imports.jinja2" -%}
 {%- if namespace %}

--- a/xsdata/models/config.py
+++ b/xsdata/models/config.py
@@ -131,9 +131,11 @@ class GeneratorOutput:
     :param docstring_style: Select a docstring style
     :param compound_fields: Use compound fields for repeating choices.
         Enable if elements ordering matters for your case.
+    :param import_future_annotations: add import "from __future__ import annotations" to allow self-referencing typing if python version is <3.10
     """
 
     max_line_length: int = attribute(default=79)
+    import_future_annotations: bool = attribute(default=False)
     package: str = element(default="generated")
     format: str = element(default="dataclasses")
     structure: OutputStructure = element(default=OutputStructure.FILENAMES)


### PR DESCRIPTION
Problem:
When converting AUTOSAR_00049_COMPACT.xsd (https://www.autosar.org/fileadmin/user_upload/standards/foundation/20-11/AUTOSAR_TR_XMLSchemaSupplement.zip), some classes have references to self. In Python <= 3.9, this is seemingly not supported by the 'typing' module (https://stackoverflow.com/questions/33533148/how-do-i-type-hint-a-method-with-the-type-of-the-enclosing-class).

Solution:
Adds an option that add "from __future__ import annotations" at the beginning of generated files

Notes:
For python <3.6 the classname as string should instead be used, not implemented here.
