### PR TITLE
Enable option to have one file per class

### DIFF
--- a/xsdata/codegen/writer.py
+++ b/xsdata/codegen/writer.py
@@ -32,7 +32,7 @@ class CodeWriter:
         self.generator.designate(classes)
         for result in self.generator.render(classes):
             if result.source.strip():
-                logger.info("Generating package: %s", result.title)
+                logger.info("Generating package: %s (%s)", result.title, result.path.name)
 
                 result.path.parent.mkdir(parents=True, exist_ok=True)
                 result.path.write_text(result.source, encoding="utf-8")

--- a/xsdata/models/config.py
+++ b/xsdata/models/config.py
@@ -131,9 +131,11 @@ class GeneratorOutput:
     :param docstring_style: Select a docstring style
     :param compound_fields: Use compound fields for repeating choices.
         Enable if elements ordering matters for your case.
+    :param separate_classes: generate a separate python file for each top level class
     """
 
     max_line_length: int = attribute(default=79)
+    separate_classes: bool = attribute(default=False)
     package: str = element(default="generated")
     format: str = element(default="dataclasses")
     structure: OutputStructure = element(default=OutputStructure.FILENAMES)


### PR DESCRIPTION
When converting big XSD files such as AUTOSAR_00049_COMPACT.xsd (https://www.autosar.org/fileadmin/user_upload/standards/foundation/20-11/AUTOSAR_TR_XMLSchemaSupplement.zip), 
the generated file is very big resulting in:
- by default, not being parsed on some IDEs due to being to big e.g. PyCharm
- unpractical to work with in particular looking at class implementation for documentation

This pull request adds an option to generate one file per top-level class instead of all classes within one file.