### PR TITLE
ClassSanitizer: use unique ids to rename references

### DIFF
--- a/tests/codegen/handlers/test_attribute_type.py
+++ b/tests/codegen/handlers/test_attribute_type.py
@@ -270,6 +270,7 @@ class AttributeTypeHandlerTests(FactoryTestCase):
 
         self.processor.set_circular_flag(source, target, attr_type)
         self.assertTrue(attr_type.circular)
+        self.assertEqual(id(source), attr_type.reference)
 
         mock_is_circular_dependency.assert_called_once_with(source, target, set())
 

--- a/tests/codegen/handlers/test_class_extension.py
+++ b/tests/codegen/handlers/test_class_extension.py
@@ -293,6 +293,7 @@ class ClassExtensionHandlerTests(FactoryTestCase):
 
         mock_should_remove_extension.assert_called_once_with(source, target)
         self.assertEqual(0, mock_copy_attributes.call_count)
+        self.assertEqual(0, extension.type.reference)
 
     @mock.patch.object(ClassUtils, "copy_attributes")
     @mock.patch.object(ClassExtensionHandler, "should_flatten_extension")
@@ -305,6 +306,7 @@ class ClassExtensionHandlerTests(FactoryTestCase):
         source = ClassFactory.create()
 
         self.processor.process_complex_extension(source, target, extension)
+        self.assertEqual(0, extension.type.reference)
         mock_compare_attributes.assert_called_once_with(source, target)
         mock_should_flatten_extension.assert_called_once_with(source, target, extension)
 
@@ -321,6 +323,7 @@ class ClassExtensionHandlerTests(FactoryTestCase):
 
         self.processor.process_complex_extension(source, target, extension)
         self.assertEqual(1, len(target.extensions))
+        self.assertEqual(id(source), extension.type.reference)
 
     def test_find_dependency(self):
         attr_type = AttrTypeFactory.create(qname="a")

--- a/xsdata/codegen/handlers/attribute_type.py
+++ b/xsdata/codegen/handlers/attribute_type.py
@@ -125,6 +125,7 @@ class AttributeTypeHandler(HandlerInterface):
             attr.restrictions.format = collections.first(
                 x.restrictions.format for x in source.attrs if x.restrictions.format
             )
+            attr_type.reference = id(source)
         else:
             self.set_circular_flag(source, target, attr_type)
 
@@ -161,6 +162,7 @@ class AttributeTypeHandler(HandlerInterface):
 
     def set_circular_flag(self, source: Class, target: Class, attr_type: AttrType):
         """Update circular reference flag."""
+        attr_type.reference = id(source)
         attr_type.circular = self.is_circular_dependency(source, target, set())
 
     def is_circular_dependency(self, source: Class, target: Class, seen: Set) -> bool:

--- a/xsdata/codegen/handlers/class_extension.py
+++ b/xsdata/codegen/handlers/class_extension.py
@@ -137,6 +137,7 @@ class ClassExtensionHandler(HandlerInterface):
         elif cls.should_flatten_extension(source, target):
             ClassUtils.copy_attributes(source, target, ext)
         else:
+            ext.type.reference = id(source)
             logger.debug("Ignore extension: %s", ext.type.name)
 
     def find_dependency(self, attr_type: AttrType) -> Optional[Class]:

--- a/xsdata/codegen/models.py
+++ b/xsdata/codegen/models.py
@@ -196,6 +196,7 @@ class AttrType:
 
     :param qname:
     :param alias:
+    :param reference:
     :param native:
     :param forward:
     :param circular:
@@ -203,6 +204,7 @@ class AttrType:
 
     qname: str
     alias: Optional[str] = field(default=None, compare=False)
+    reference: int = field(default=0, compare=False)
     native: bool = field(default=False)
     forward: bool = field(default=False)
     circular: bool = field(default=False)

--- a/xsdata/utils/testing.py
+++ b/xsdata/utils/testing.py
@@ -206,6 +206,7 @@ class AttrTypeFactory(Factory):
         native: bool = False,
         forward: bool = False,
         circular: bool = False,
+        reference: int = 0,
         **kwargs: Any,
     ) -> AttrType:
         if not qname:
@@ -217,6 +218,7 @@ class AttrTypeFactory(Factory):
             native=native,
             circular=circular,
             forward=forward,
+            reference=reference,
         )
 
     @classmethod


### PR DESCRIPTION
The sanitizer has to rename duplicate class names  and their references. This could lead in renaming incorrectly references just because they share the same qualified name.


```xsd
<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
  <xsd:element name="Duplicate" type="foobar" />
  <xsd:complexType name="Duplicate">
    <xsd:sequence>
      <xsd:element ref="Duplicate" minOccurs="0" maxOccurs="unbounded" />
    </xsd:sequence>
  </xsd:complexType>
  <xsd:complexType name="foobar">
    <xsd:sequence>
      <xsd:element name="value" type="xsd:string" minOccurs="0" maxOccurs="1" />
    </xsd:sequence>
  </xsd:complexType>
</xsd:schema>
```

wrong output, here the sanitizer renames the duplicate field type by mistake because of the same qname.
 
```python
@dataclass
class Duplicate1:
    class Meta:
        name = "Duplicate"

    duplicate: List[Duplicate1] = field(
        default_factory=list,
        metadata={
            "name": "Duplicate",
            "type": "Element",
        }
    )
```


correct output, after using the id to find and locate the correct reference to rename

```python
@dataclass
class Duplicate1:
    class Meta:
        name = "Duplicate"

    duplicate: List[Duplicate] = field(
        default_factory=list,
        metadata={
            "name": "Duplicate",
            "type": "Element",
        }
    )
```



