### PR TITLE
Performance tweaks

### DIFF
--- a/docs/api/parsing.rst
+++ b/docs/api/parsing.rst
@@ -10,6 +10,7 @@ Parsing
     :nosignatures:
 
     XmlParser
+    UserXmlParser
     JsonParser
 
 .. currentmodule:: xsdata.formats.dataclass.parsers.config

--- a/tests/formats/dataclass/parsers/test_json.py
+++ b/tests/formats/dataclass/parsers/test_json.py
@@ -126,7 +126,7 @@ class JsonParserTests(TestCase):
         self.assertEqual("Key `book` value is not iterable", str(cm.exception))
 
     def test_bind_value_with_attributes_var(self):
-        var = XmlVar(attributes=True, name="a", qname="a")
+        var = XmlVar(is_attributes=True, name="a", qname="a")
         value = {"a": 1}
         actual = self.parser.bind_value(var, value)
         self.assertEqual(value, actual)
@@ -138,7 +138,7 @@ class JsonParserTests(TestCase):
         c = make_dataclass("c", [("x", int), ("y", str), ("z", str)])
         d = make_dataclass("d", [("x", int)])
         var = XmlVar(
-            element=True,
+            is_element=True,
             name="union",
             qname="union",
             types=(a, b, c, int),
@@ -153,7 +153,7 @@ class JsonParserTests(TestCase):
     def test_bind_type_union(self):
         a = make_dataclass("a", [("x", int), ("y", str)])
         var = XmlVar(
-            element=True,
+            is_element=True,
             name="union",
             qname="union",
             types=(a, int, float),
@@ -165,22 +165,28 @@ class JsonParserTests(TestCase):
 
     def test_bind_choice_simple(self):
         var = XmlVar(
-            elements=True,
+            is_elements=True,
             qname="compound",
             name="compound",
-            choices=[
-                XmlVar(element=True, qname="int", name="int", types=(int,)),
-                XmlVar(
-                    element=True,
+            elements={
+                "int": XmlVar(is_element=True, qname="int", name="int", types=(int,)),
+                "tokens": XmlVar(
+                    is_element=True,
                     qname="tokens",
                     name="tokens",
                     types=(int,),
                     tokens=True,
                 ),
-                XmlVar(element=True, qname="generic", name="generic", dataclass=True),
-                XmlVar(element=True, qname="float", name="float", types=(float,)),
-                XmlVar(element=True, qname="qname", name="qname", types=(QName,)),
-            ],
+                "generic": XmlVar(
+                    is_element=True, qname="generic", name="generic", dataclass=True
+                ),
+                "float": XmlVar(
+                    is_element=True, qname="float", name="float", types=(float,)
+                ),
+                "qname": XmlVar(
+                    is_element=True, qname="qname", name="qname", types=(QName,)
+                ),
+            },
         )
         self.assertEqual(1.0, self.parser.bind_choice("1.0", var))
         self.assertEqual(1, self.parser.bind_choice(1, var))
@@ -203,14 +209,18 @@ class JsonParserTests(TestCase):
         b = make_dataclass("b", [("x", int), ("y", str)])
 
         var = XmlVar(
-            elements=True,
+            is_elements=True,
             qname="compound",
             name="compound",
-            choices=[
-                XmlVar(element=True, qname="c", name="c", types=(int,)),
-                XmlVar(element=True, qname="a", name="a", types=(a,), dataclass=True),
-                XmlVar(element=True, qname="b", name="b", types=(b,), dataclass=True),
-            ],
+            elements={
+                "a": XmlVar(
+                    is_element=True, qname="a", name="a", types=(a,), dataclass=True
+                ),
+                "b": XmlVar(
+                    is_element=True, qname="b", name="b", types=(b,), dataclass=True
+                ),
+                "c": XmlVar(is_element=True, qname="c", name="c", types=(int,)),
+            },
         )
 
         self.assertEqual(a(1), self.parser.bind_choice({"x": 1}, var))
@@ -226,13 +236,13 @@ class JsonParserTests(TestCase):
 
     def test_bind_choice_generic_with_derived(self):
         var = XmlVar(
-            elements=True,
+            is_elements=True,
             qname="compound",
             name="compound",
-            choices=[
-                XmlVar(element=True, name="a", qname="a", types=(int,)),
-                XmlVar(element=True, name="b", qname="b", types=(float,)),
-            ],
+            elements={
+                "a": XmlVar(is_element=True, name="a", qname="a", types=(int,)),
+                "b": XmlVar(is_element=True, name="b", qname="b", types=(float,)),
+            },
         )
         data = {"qname": "a", "value": 1, "substituted": True}
 
@@ -243,13 +253,13 @@ class JsonParserTests(TestCase):
 
     def test_bind_choice_generic_with_wildcard(self):
         var = XmlVar(
-            elements=True,
+            is_elements=True,
             qname="compound",
             name="compound",
-            choices=[
-                XmlVar(element=True, name="a", qname="a", types=(int,)),
-                XmlVar(element=True, name="b", qname="b", types=(float,)),
-            ],
+            elements={
+                "a": XmlVar(is_element=True, name="a", qname="a", types=(int,)),
+                "b": XmlVar(is_element=True, name="b", qname="b", types=(float,)),
+            },
         )
 
         self.assertEqual(
@@ -258,7 +268,7 @@ class JsonParserTests(TestCase):
         )
 
     def test_bind_choice_generic_with_unknown_qname(self):
-        var = XmlVar(elements=True, qname="compound", name="compound")
+        var = XmlVar(is_elements=True, qname="compound", name="compound")
 
         with self.assertRaises(ParserError) as cm:
             self.parser.bind_choice({"qname": "foo", "text": 1}, var)
@@ -270,7 +280,7 @@ class JsonParserTests(TestCase):
 
     def test_bind_wildcard_with_any_element(self):
         var = XmlVar(
-            wildcard=True,
+            is_wildcard=True,
             name="any_element",
             qname="any_element",
             types=(object,),

--- a/tests/formats/dataclass/parsers/test_utils.py
+++ b/tests/formats/dataclass/parsers/test_utils.py
@@ -18,7 +18,6 @@ from xsdata.formats.dataclass.models.elements import XmlVar
 from xsdata.formats.dataclass.models.generics import AnyElement
 from xsdata.formats.dataclass.models.generics import DerivedElement
 from xsdata.formats.dataclass.parsers.utils import ParserUtils
-from xsdata.models.enums import DataType
 from xsdata.models.enums import Namespace
 from xsdata.models.enums import QNames
 
@@ -37,18 +36,6 @@ class ParserUtilsTests(TestCase):
 
         attrs = {QNames.XSI_TYPE: "bar:foo"}
         self.assertEqual("{xsdata}foo", ParserUtils.xsi_type(attrs, ns_map))
-
-    def test_data_type(self):
-        ns_map = {"bar": "xsdata"}
-        attrs = {}
-        self.assertEqual(DataType.STRING, ParserUtils.data_type(attrs, ns_map))
-
-        ns_map = {"xs": Namespace.XS.uri}
-        attrs = {QNames.XSI_TYPE: "xs:foo"}
-        self.assertEqual(DataType.STRING, ParserUtils.data_type(attrs, ns_map))
-
-        attrs = {QNames.XSI_TYPE: "xs:float"}
-        self.assertEqual(DataType.FLOAT, ParserUtils.data_type(attrs, ns_map))
 
     @mock.patch.object(ConverterFactory, "deserialize", return_value=2)
     def test_parse_value(self, mock_deserialize):

--- a/tests/formats/dataclass/parsers/test_utils.py
+++ b/tests/formats/dataclass/parsers/test_utils.py
@@ -11,7 +11,6 @@ from tests.fixtures.defxmlschema.chapter12 import ProductType
 from tests.fixtures.defxmlschema.chapter12 import SizeType
 from xsdata.formats.converter import ConverterFactory
 from xsdata.formats.dataclass.context import XmlContext
-from xsdata.formats.dataclass.models.elements import FindMode
 from xsdata.formats.dataclass.models.elements import XmlMeta
 from xsdata.formats.dataclass.models.elements import XmlType
 from xsdata.formats.dataclass.models.elements import XmlVar
@@ -88,9 +87,9 @@ class ParserUtilsTests(TestCase):
 
         ctx = XmlContext()
         meta = ctx.build(A)
-        x = meta.find_var("x")
-        y = meta.find_var("y")
-        w = meta.find_var("wild")
+        x = meta.find_elements("x")[0]
+        y = meta.find_elements("y")[0]
+        w = meta.find_wildcard("wild")
         wild_element = AnyElement(qname="foo")
 
         objects = [
@@ -136,7 +135,7 @@ class ParserUtilsTests(TestCase):
             (None, "foo"),
         ]
 
-        var = XmlVar(wildcard=True, name="foo", qname="{any}foo")
+        var = XmlVar(is_wildcard=True, name="foo", qname="{any}foo")
         params = {}
         ParserUtils.bind_mixed_objects(params, var, 1, objects)
 
@@ -155,7 +154,7 @@ class ParserUtilsTests(TestCase):
         mock_parse_value.return_value = "2020-03-02"
         mock_parse_any_attribute.return_value = "foobar"
         metadata = self.ctx.build(ProductType)
-        eff_date = metadata.find_var("effDate")
+        eff_date = metadata.find_attribute("effDate")
 
         params = {}
         ns_map = {}
@@ -200,43 +199,49 @@ class ParserUtilsTests(TestCase):
     def test_bind_attrs_doesnt_overwrite_values(self):
         metadata = self.ctx.build(ProductType)
         params = dict(eff_date="foo")
-        attrs = {"effDate": "2020-03-01"}
+        attrs = {"effDate": "2020-03-01", "bar": "foo"}
         ns_map = {}
 
         ParserUtils.bind_attrs(params, metadata, attrs, ns_map)
 
-        expected = {"eff_date": "foo", "other_attributes": {"effDate": "2020-03-01"}}
+        expected = {
+            "eff_date": "foo",
+            "other_attributes": {"effDate": "2020-03-01", "bar": "foo"},
+        }
         self.assertEqual(expected, params)
 
     def test_bind_attrs_ignore_init_false_vars(self):
         metadata = self.ctx.build(ProductType)
-        eff_date = metadata.find_var("effDate")
+        eff_date = metadata.find_attribute("effDate")
+        eff_date = replace(eff_date, init=False)
 
-        meta_vars = list(metadata.vars)
-        meta_vars.remove(eff_date)
-        meta_vars.append(replace(eff_date, init=False, text=True))
-        metadata.vars = tuple(meta_vars)
-
+        metadata.attributes[eff_date.qname] = eff_date
         params = {}
         attrs = {"effDate": "2020-03-01"}
-        ns_map = {}
 
-        ParserUtils.bind_attrs(params, metadata, attrs, ns_map)
-        self.assertEqual({"other_attributes": {}}, params)
+        ParserUtils.bind_attrs(params, metadata, attrs, {})
+        self.assertEqual({}, params)
 
-    @mock.patch.object(XmlMeta, "find_var")
-    def test_bind_attrs_skip_empty_attrs(self, mock_find_var):
+    @mock.patch.object(XmlMeta, "find_attribute")
+    def test_bind_attrs_skip_empty_attrs(self, mock_find_attribute):
         metadata = self.ctx.build(ProductType)
 
         params = {}
         ParserUtils.bind_attrs(params, metadata, {}, {})
         self.assertEqual(0, len(params))
-        self.assertEqual(0, mock_find_var.call_count)
+        self.assertEqual(0, mock_find_attribute.call_count)
+
+    def test_bind_unknown_attrs(self):
+        metadata = self.ctx.build(SizeType)
+        params = {}
+        ParserUtils.bind_attrs(params, metadata, {"a": "b"}, {})
+
+        self.assertEqual({}, params)
 
     @mock.patch.object(ParserUtils, "parse_value", return_value="yes!")
     def test_bind_content(self, mock_parse_value):
         metadata = self.ctx.build(SizeType)
-        var = metadata.find_var(mode=FindMode.TEXT)
+        var = metadata.text
         params = {}
         ns_map = {"a": "b"}
 
@@ -256,7 +261,7 @@ class ParserUtilsTests(TestCase):
         self.assertEqual({}, params)
 
     def test_bind_var(self):
-        var = XmlVar(name="a", qname="a")
+        var = XmlVar(name="a", qname="a", is_element=True)
         params = {}
 
         status = ParserUtils.bind_var(params, var, 1)
@@ -268,7 +273,7 @@ class ParserUtilsTests(TestCase):
         self.assertEqual({"a": 1}, params)
 
     def test_bind_var_with_list_var(self):
-        var = XmlVar(name="a", qname="a", list_element=True)
+        var = XmlVar(name="a", qname="a", list_element=True, is_element=True)
         params = {}
 
         status = ParserUtils.bind_var(params, var, 1)
@@ -281,7 +286,7 @@ class ParserUtilsTests(TestCase):
 
     def test_bind_wild_var(self):
         params = {}
-        var = XmlVar(name="a", qname="a")
+        var = XmlVar(name="a", qname="a", is_wildcard=True)
         qname = "b"
         one = AnyElement(qname=qname, text="one")
         two = AnyElement(qname=qname, text="two")
@@ -299,7 +304,7 @@ class ParserUtilsTests(TestCase):
 
     def test_bind_wild_var_with_list_var(self):
         params = {}
-        var = XmlVar(name="a", qname="a", list_element=True)
+        var = XmlVar(name="a", qname="a", list_element=True, is_element=True)
         qname = "b"
         one = AnyElement(qname=qname, text="one")
         two = AnyElement(qname=qname, text="two")
@@ -312,7 +317,7 @@ class ParserUtilsTests(TestCase):
         self.assertEqual(dict(a=[one, two, three]), params)
 
     def test_bind_wild_content(self):
-        var = XmlVar(name="a", qname="a")
+        var = XmlVar(name="a", qname="a", is_wildcard=True)
         params = {}
         attrs = {}
         ns_map = {}
@@ -334,7 +339,13 @@ class ParserUtilsTests(TestCase):
         self.assertEqual(dict(a=expected), params)
 
     def test_bind_wildcard_when_var_is_list(self):
-        var = XmlVar(name="a", qname="a", default=list, list_element=True)
+        var = XmlVar(
+            name="a",
+            qname="a",
+            default=list,
+            list_element=True,
+            is_wildcard=True,
+        )
         params = {}
         attrs = {"a", "b"}
         ns_map = {"ns0", "a"}

--- a/tests/formats/dataclass/parsers/test_xml.py
+++ b/tests/formats/dataclass/parsers/test_xml.py
@@ -31,7 +31,7 @@ class UserXmlParserTests(TestCase):
     def test_end(self, mock_emit_event):
         objects = []
         queue = []
-        var = XmlVar(text=True, name="foo", qname="foo", types=(bool,))
+        var = XmlVar(is_text=True, name="foo", qname="foo", types=(bool,))
         queue.append(PrimitiveNode(var, {}))
 
         result = self.parser.end(queue, objects, "enabled", "true", None)

--- a/tests/formats/dataclass/parsers/test_xml.py
+++ b/tests/formats/dataclass/parsers/test_xml.py
@@ -5,17 +5,17 @@ from tests.fixtures.books import Books
 from xsdata.formats.dataclass.models.elements import XmlVar
 from xsdata.formats.dataclass.parsers.nodes import PrimitiveNode
 from xsdata.formats.dataclass.parsers.nodes import SkipNode
-from xsdata.formats.dataclass.parsers.xml import XmlParser
+from xsdata.formats.dataclass.parsers.xml import UserXmlParser
 from xsdata.models.enums import EventType
 
 
-class XmlParserTests(TestCase):
+class UserXmlParserTests(TestCase):
     def setUp(self):
         super().setUp()
-        self.parser = XmlParser()
+        self.parser = UserXmlParser()
         self.parser.objects = [(x, x) for x in "abcde"]
 
-    @mock.patch.object(XmlParser, "emit_event")
+    @mock.patch.object(UserXmlParser, "emit_event")
     def test_start(self, mock_emit_event):
         attrs = {"a": "b"}
         queue = []
@@ -27,7 +27,7 @@ class XmlParserTests(TestCase):
             EventType.START, "{urn:books}books", attrs=attrs
         )
 
-    @mock.patch.object(XmlParser, "emit_event")
+    @mock.patch.object(UserXmlParser, "emit_event")
     def test_end(self, mock_emit_event):
         objects = []
         queue = []
@@ -40,7 +40,7 @@ class XmlParserTests(TestCase):
         self.assertEqual(("enabled", True), objects[-1])
         mock_emit_event.assert_called_once_with(EventType.END, "enabled", obj=result)
 
-    @mock.patch.object(XmlParser, "emit_event")
+    @mock.patch.object(UserXmlParser, "emit_event")
     def test_end_with_no_result(self, mock_emit_event):
         objects = []
         queue = [SkipNode()]

--- a/tests/formats/dataclass/test_elements.py
+++ b/tests/formats/dataclass/test_elements.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from dataclasses import make_dataclass
+from typing import Iterator
 from unittest import mock
 from unittest.case import TestCase
 
@@ -183,3 +184,29 @@ class XmlMetaTests(TestCase):
         self.assertEqual(wildcards[1], self.meta.find_wildcard("a"))
 
         mock_match_namespace.assert_has_calls([mock.call("a") for _ in range(4)])
+
+    def test_find_children(self):
+        element1 = XmlVar(is_element=True, qname="a", name="a")
+        element2 = XmlVar(is_element=True, qname="a", name="a1")
+
+        option1 = XmlVar(is_element=True, qname="a", name="a3")
+        option2 = XmlVar(is_element=True, qname="b", name="b")
+
+        choice = XmlVar(
+            is_elements=True,
+            qname="c1",
+            name="c1",
+            elements={
+                "a": option1,
+                "b": option2,
+            },
+        )
+        wildcard = XmlVar(is_wildcard=True, qname="any", name="any")
+
+        self.meta.elements["a"] = [element1, element2]
+        self.meta.choices.append(choice)
+        self.meta.wildcards.append(wildcard)
+
+        result = self.meta.find_children("a")
+        self.assertIsInstance(result, Iterator)
+        self.assertEqual([element1, element2, option1, wildcard], list(result))

--- a/tests/formats/dataclass/test_elements.py
+++ b/tests/formats/dataclass/test_elements.py
@@ -1,13 +1,9 @@
 from dataclasses import dataclass
 from dataclasses import make_dataclass
-from dataclasses import replace
+from unittest import mock
 from unittest.case import TestCase
 
-from tests.fixtures.books.books import BookForm
-from xsdata.exceptions import XmlContextError
-from xsdata.formats.dataclass.context import XmlContext
-from xsdata.formats.dataclass.models.elements import FindMode
-from xsdata.formats.dataclass.models.elements import XmlType
+from xsdata.formats.dataclass.models.elements import XmlMeta
 from xsdata.formats.dataclass.models.elements import XmlVar
 
 
@@ -42,91 +38,148 @@ class XmlValTests(TestCase):
         var = XmlVar(name="foo", qname="foo", types=(int,), list_element=True)
         self.assertTrue(var.list_element)
 
-    def test_matches(self):
-        var = XmlVar(name="foo", qname="foo")
-        self.assertTrue(var.matches("*"))
-        self.assertTrue(var.matches(var.qname))
-        self.assertFalse(var.matches("bar"))
-
     def test_find_choice(self):
-        choices = [
-            XmlVar(element=True, name="a", qname="{a}a"),
-            XmlVar(element=True, name="b", qname="b"),
-        ]
-        var = XmlVar(elements=True, name="foo", qname="foo", choices=choices)
+        var = XmlVar(
+            is_elements=True,
+            name="foo",
+            qname="foo",
+            elements={
+                "{a}a": XmlVar(is_element=True, name="a", qname="{a}a"),
+                "b": XmlVar(is_element=True, name="b", qname="b"),
+            },
+        )
 
-        self.assertFalse(var.matches("a"))
         self.assertIsNone(var.find_choice("a"))
+        self.assertEqual("a", var.find_choice("{a}a").name)
+        self.assertEqual("b", var.find_choice("b").name)
 
-        self.assertEqual(choices[0], var.find_choice("{a}a"))
-        self.assertTrue(var.matches("{a}a"))
+        var.elements.clear()
+        var.wildcards = [
+            XmlVar(
+                is_wildcard=True, name="target", qname="target", namespaces=("foo",)
+            ),
+            XmlVar(is_wildcard=True, name="other", qname="other", namespaces=("!foo",)),
+        ]
 
-        self.assertEqual(choices[1], var.find_choice("b"))
-        self.assertTrue(var.matches("b"))
+        self.assertEqual(var.wildcards[1], var.find_choice("{a}a"))
+        self.assertEqual(var.wildcards[0], var.find_choice("{foo}a"))
 
     def test_find_value_choice(self):
         c = make_dataclass("C", fields=[])
         d = make_dataclass("D", fields=[], bases=(c,))
 
+        elements = [
+            XmlVar(is_element=True, qname="a", name="a", types=(int,)),
+            XmlVar(is_element=True, qname="b", name="b", types=(int,), tokens=True),
+            XmlVar(is_element=True, qname="c", name="c", types=(c,), dataclass=True),
+            XmlVar(is_element=True, qname="d", name="d", types=(float,), nillable=True),
+        ]
+
         var = XmlVar(
-            elements=True,
+            is_elements=True,
             name="compound",
             qname="compound",
-            choices=[
-                XmlVar(element=True, qname="a", name="a", types=(int,)),
-                XmlVar(element=True, qname="b", name="b", types=(int,), tokens=True),
-                XmlVar(element=True, qname="c", name="c", types=(c,), dataclass=True),
-                XmlVar(
-                    element=True, qname="d", name="d", types=(float,), nillable=True
-                ),
-            ],
+            elements={x.qname: x for x in elements},
         )
 
         self.assertIsNone(var.find_value_choice("foo"))
-        self.assertEqual(var.choices[0], var.find_value_choice(1))
-        self.assertEqual(var.choices[1], var.find_value_choice([1, 2]))
-        self.assertEqual(var.choices[2], var.find_value_choice(d()))
-        self.assertEqual(var.choices[2], var.find_value_choice(c()))
-        self.assertEqual(var.choices[3], var.find_value_choice(None))
+        self.assertEqual(elements[0], var.find_value_choice(1))
+        self.assertEqual(elements[1], var.find_value_choice([1, 2]))
+        self.assertEqual(elements[2], var.find_value_choice(d()))
+        self.assertEqual(elements[2], var.find_value_choice(c()))
+        self.assertEqual(elements[3], var.find_value_choice(None))
 
-    def test_matches_widlcard(self):
-        var = XmlVar(wildcard=True, name="foo", qname="foo")
-        self.assertTrue(var.matches("*"))
-        self.assertTrue(var.matches("a"))
+    def test_match_namespace(self):
+        var = XmlVar(is_wildcard=True, name="foo", qname="foo")
+        self.assertTrue(var.match_namespace("*"))
+        self.assertTrue(var.match_namespace("a"))
 
-        var = XmlVar(wildcard=True, name="foo", qname="foo", namespaces=("tns",))
-        self.assertFalse(var.matches("a"))
-        self.assertTrue(var.matches("{tns}a"))
+        var = XmlVar(is_wildcard=True, name="foo", qname="foo", namespaces=("tns",))
+        self.assertFalse(var.match_namespace("a"))
+        self.assertTrue(var.match_namespace("{tns}a"))
 
-        var = XmlVar(wildcard=True, name="foo", qname="foo", namespaces=("##any",))
-        self.assertTrue(var.matches("a"))
-        self.assertTrue(var.matches("{tns}a"))
+        var = XmlVar(is_wildcard=True, name="foo", qname="foo", namespaces=("##any",))
+        self.assertTrue(var.match_namespace("a"))
+        self.assertTrue(var.match_namespace("{tns}a"))
 
-        var = XmlVar(wildcard=True, name="foo", qname="foo", namespaces=("",))
-        self.assertTrue(var.matches("a"))
-        self.assertFalse(var.matches("{tns}a"))
+        var = XmlVar(is_wildcard=True, name="foo", qname="foo", namespaces=("",))
+        self.assertTrue(var.match_namespace("a"))
+        self.assertFalse(var.match_namespace("{tns}a"))
 
-        var = XmlVar(wildcard=True, name="foo", qname="foo", namespaces=("!tns",))
-        self.assertTrue(var.matches("{foo}a"))
-        self.assertFalse(var.matches("{tns}a"))
+        var = XmlVar(is_wildcard=True, name="foo", qname="foo", namespaces=("!tns",))
+        self.assertTrue(var.match_namespace("{foo}a"))
+        self.assertFalse(var.match_namespace("{tns}a"))
+
+        var.namespace_matches["{tns}cached"] = True
+        self.assertTrue(var.match_namespace("{tns}cached"))
 
 
 class XmlMetaTests(TestCase):
-    def test_find_var(self):
-        ctx = XmlContext()
-        meta = ctx.build(BookForm)
+    def setUp(self) -> None:
+        a = make_dataclass("a", [])
+        self.meta = XmlMeta(clazz=a, qname="a", source_qname="a", nillable=False)
 
-        self.assertTrue(meta.find_var("author").element)
-        self.assertIsNone(meta.find_var("author", FindMode.ATTRIBUTE))
-        self.assertIsNone(meta.find_var("nope"))
+    def test_find_attribute(self):
+        a = XmlVar(is_attribute=True, qname="a", name="a")
+        b = XmlVar(is_attribute=True, qname="b", name="b")
 
-    def test_find_var_uses_cache(self):
-        ctx = XmlContext()
-        meta = ctx.build(BookForm)
+        self.meta.attributes[a.qname] = a
+        self.meta.attributes[b.qname] = b
 
-        self.assertEqual("author", meta.find_var("author").name)
-        self.assertEqual(1, len(meta.cache))
-        key = tuple(meta.cache.keys())[0]
+        self.assertEqual(a, self.meta.find_attribute("a"))
+        self.assertEqual(b, self.meta.find_attribute("b"))
 
-        meta.cache[key] = 1
-        self.assertEqual("title", meta.find_var("author").name)
+    def test_find_elements(self):
+        a_1 = XmlVar(is_attribute=True, qname="a", name="a_1")
+        a_2 = XmlVar(is_attribute=True, qname="a", name="a_2")
+
+        self.meta.elements[a_1.qname] = [a_1, a_2]
+
+        self.assertEqual([a_1, a_2], self.meta.find_elements("a"))
+        self.assertEqual([], self.meta.find_elements("b"))
+
+    @mock.patch.object(XmlVar, "find_choice")
+    def test_find_choice(self, mock_find_choice):
+        a_1 = XmlVar(is_attribute=True, qname="a", name="a_1")
+        a_2 = XmlVar(is_attribute=True, qname="a", name="a_2")
+
+        mock_find_choice.side_effect = [None, None, None, a_1, a_2]
+        choice_1 = XmlVar(is_attribute=True, qname="compound_1", name="compound_1")
+        choice_2 = XmlVar(is_attribute=True, qname="compound_2", name="compound_2")
+        self.meta.choices = [choice_1, choice_2]
+
+        self.assertIsNone(self.meta.find_choice("a"))
+        self.assertEqual(a_1, self.meta.find_choice("a"))
+        self.assertEqual(a_2, self.meta.find_choice("a"))
+
+        mock_find_choice.assert_has_calls([mock.call("a") for _ in range(5)])
+
+    @mock.patch.object(XmlVar, "match_namespace")
+    def test_find_any_attributes(self, mock_match_namespace):
+        mock_match_namespace.side_effect = [False, False, False, True]
+
+        attributes = [
+            XmlVar(is_attributes=True, qname="any", name="any"),
+            XmlVar(is_attributes=True, qname="other", name="any"),
+        ]
+        self.meta.any_attributes = attributes
+
+        self.assertIsNone(self.meta.find_any_attributes("a"))
+        self.assertEqual(attributes[1], self.meta.find_any_attributes("a"))
+
+        mock_match_namespace.assert_has_calls([mock.call("a") for _ in range(4)])
+
+    @mock.patch.object(XmlVar, "match_namespace")
+    def test_find_wildcard(self, mock_match_namespace):
+        mock_match_namespace.side_effect = [False, False, False, True]
+
+        wildcards = [
+            XmlVar(is_wildcard=True, qname="any", name="any"),
+            XmlVar(is_wildcard=True, qname="other", name="any"),
+        ]
+        self.meta.wildcards = wildcards
+
+        self.assertIsNone(self.meta.find_wildcard("a"))
+        self.assertEqual(wildcards[1], self.meta.find_wildcard("a"))
+
+        mock_match_namespace.assert_has_calls([mock.call("a") for _ in range(4)])

--- a/xsdata/codegen/parsers/schema.py
+++ b/xsdata/codegen/parsers/schema.py
@@ -11,7 +11,7 @@ from urllib.parse import urljoin
 from xsdata.formats.bindings import T
 from xsdata.formats.dataclass.parsers.mixins import XmlNode
 from xsdata.formats.dataclass.parsers.nodes import Parsed
-from xsdata.formats.dataclass.parsers.xml import XmlParser
+from xsdata.formats.dataclass.parsers.xml import UserXmlParser
 from xsdata.models import xsd
 from xsdata.models.enums import FormType
 from xsdata.models.enums import Mode
@@ -19,7 +19,7 @@ from xsdata.models.enums import Namespace
 
 
 @dataclass
-class SchemaParser(XmlParser):
+class SchemaParser(UserXmlParser):
     """
     A simple parser to convert an xsd schema to an easy to handle data
     structure based on dataclasses.

--- a/xsdata/formats/dataclass/parsers/__init__.py
+++ b/xsdata/formats/dataclass/parsers/__init__.py
@@ -1,5 +1,6 @@
 from xsdata.formats.dataclass.parsers.json import JsonParser
 from xsdata.formats.dataclass.parsers.tree import TreeParser
+from xsdata.formats.dataclass.parsers.xml import UserXmlParser
 from xsdata.formats.dataclass.parsers.xml import XmlParser
 
-__all__ = ["JsonParser", "XmlParser", "TreeParser"]
+__all__ = ["JsonParser", "XmlParser", "UserXmlParser", "TreeParser"]

--- a/xsdata/formats/dataclass/parsers/tree.py
+++ b/xsdata/formats/dataclass/parsers/tree.py
@@ -38,7 +38,7 @@ class TreeParser(NodeParser):
             child = item.child(qname, attrs, ns_map, len(objects))
         except IndexError:
             child = WildcardNode(
-                var=XmlVar(name=qname, qname=qname, wildcard=True),
+                var=XmlVar(name=qname, qname=qname, is_wildcard=True),
                 attrs=attrs,
                 ns_map=ns_map,
                 position=0,

--- a/xsdata/formats/dataclass/parsers/utils.py
+++ b/xsdata/formats/dataclass/parsers/utils.py
@@ -15,7 +15,6 @@ from xsdata.formats.dataclass.models.elements import XmlVar
 from xsdata.formats.dataclass.models.generics import AnyElement
 from xsdata.formats.dataclass.models.generics import DerivedElement
 from xsdata.logger import logger
-from xsdata.models.enums import DataType
 from xsdata.models.enums import QNames
 from xsdata.utils import text
 from xsdata.utils.namespaces import build_qname
@@ -31,17 +30,6 @@ class ParserUtils:
 
         namespace, name = QNameConverter.resolve(xsi_type, ns_map)
         return build_qname(namespace, name)
-
-    @classmethod
-    def data_type(cls, attrs: Dict, ns_map: Dict) -> DataType:
-        """Convert the xsi:type attribute to a DataType, defaults to
-        DataType.STRING."""
-        xsi_type = cls.xsi_type(attrs, ns_map)
-        datatype = DataType.STRING
-        if xsi_type:
-            datatype = DataType.from_qname(xsi_type) or datatype
-
-        return datatype
 
     @classmethod
     def is_nillable(cls, attrs: Dict) -> bool:

--- a/xsdata/formats/dataclass/serializers/json.py
+++ b/xsdata/formats/dataclass/serializers/json.py
@@ -67,7 +67,7 @@ class JsonSerializer(AbstractSerializer):
             return self.dict_factory(
                 [
                     (var.lname, self.convert(getattr(obj, var.name), var))
-                    for var in self.context.build(obj.__class__).vars
+                    for var in self.context.build(obj.__class__).get_all_vars()
                 ]
             )
 


### PR DESCRIPTION
Quick wins after profiling with the netex collection and the 150mb sample from #476 

**1. The xml parser comes with an event emitter**

The emitter was designed for the the internal Schema and Defintions parsers.
Split the emitter to a new UserXmlParser for whoever needs it instead of imposing it for all.

**2. Refactor xml var finders to avoid iterations and extra caching**

All class xml vars are stored in a sequence, during lookup we loop through all vars in order to identify the best matching option, although the result is cached and the current solution is quite elegant is not fully optimized. Split the vars into dedicated properties that won't need additional caching at all and will allow direct qname lookup for attributes/elements

Bonuses
 - This opens the way for **truly** sequential fields, 
 - This fixed a few mismatches for classes that include multiple xs:anyAttribute derived fields.


**Before:**
first parse - xml context warmup: 51.35779690742493
parse - lxml EventHandler: 51.03626036643982
parse - xml EventHandler (native python): 46.76586675643921

**After:**
first parse - xml context warmup: 42.239562034606934
parse - lxml EventHandler: 41.22812223434448
parse - xml EventHandler (native python): 37.97033977508545


