### PR TITLE
Vacuum bare inner classes

### DIFF
--- a/tests/codegen/handlers/test_class_bar_inner.py
+++ b/tests/codegen/handlers/test_class_bar_inner.py
@@ -1,0 +1,58 @@
+from xsdata.codegen.handlers import ClassBareInnerHandler
+from xsdata.models.enums import DataType
+from xsdata.utils.testing import ClassFactory
+from xsdata.utils.testing import ExtensionFactory
+from xsdata.utils.testing import FactoryTestCase
+
+
+class ClassBareInnerHandlerTests(FactoryTestCase):
+    def setUp(self):
+        super().setUp()
+        self.processor = ClassBareInnerHandler()
+
+    def test_process(self):
+        target = ClassFactory.elements(3)
+
+        inner_1 = ClassFactory.elements(2)
+        inner_2 = ClassFactory.create(extensions=ExtensionFactory.list(2))
+
+        inner_3 = ClassFactory.create()
+        inner_4 = ClassFactory.create(
+            extensions=[ExtensionFactory.reference("foo", reference=15)]
+        )
+
+        target.inner.extend([inner_1, inner_2, inner_3, inner_4])
+
+        target.attrs[1].types[0].qname = inner_3.qname
+        target.attrs[1].types[0].forward = True
+        target.attrs[1].types[0].reference = 4
+
+        target.attrs[2].types[0].qname = inner_4.qname
+        target.attrs[2].types[0].forward = True
+        target.attrs[2].types[0].circular = True
+        target.attrs[2].types[0].reference = 5
+
+        self.processor.process(target)
+
+        self.assertEqual(2, len(target.inner))
+
+        # Not bare: has attrs
+        self.assertIn(inner_1, target.inner)
+        # Not bare: has more than one extension
+        self.assertIn(inner_2, target.inner)
+
+        self.assertEqual(str(DataType.ANY_SIMPLE_TYPE), target.attrs[1].types[0].qname)
+        self.assertEqual(0, target.attrs[1].types[0].reference)
+        self.assertFalse(target.attrs[1].types[0].forward)
+        self.assertFalse(target.attrs[1].types[0].circular)
+        self.assertTrue(target.attrs[1].types[0].native)
+
+        self.assertEqual(
+            inner_4.extensions[0].type.qname, target.attrs[2].types[0].qname
+        )
+        self.assertEqual(
+            inner_4.extensions[0].type.reference, target.attrs[2].types[0].reference
+        )
+        self.assertFalse(target.attrs[2].types[0].forward)
+        self.assertFalse(target.attrs[2].types[0].circular)
+        self.assertFalse(target.attrs[2].types[0].native)

--- a/tests/codegen/test_container.py
+++ b/tests/codegen/test_container.py
@@ -4,7 +4,6 @@ from xsdata.codegen.container import ClassContainer
 from xsdata.codegen.models import Class
 from xsdata.codegen.models import Status
 from xsdata.models.config import GeneratorConfig
-from xsdata.models.config import StructureStyle
 from xsdata.models.enums import Tag
 from xsdata.utils.testing import ClassFactory
 from xsdata.utils.testing import FactoryTestCase
@@ -53,6 +52,7 @@ class ClassContainerTests(FactoryTestCase):
                 "AttributeDefaultValueHandler",
                 "AttributeRestrictionsHandler",
                 "AttributeNameConflictHandler",
+                "ClassBareInnerHandler",
             ],
             [x.__class__.__name__ for x in container.post_processors],
         )
@@ -67,6 +67,7 @@ class ClassContainerTests(FactoryTestCase):
                 "AttributeDefaultValueHandler",
                 "AttributeRestrictionsHandler",
                 "AttributeNameConflictHandler",
+                "ClassBareInnerHandler",
             ],
             [x.__class__.__name__ for x in container.post_processors],
         )
@@ -107,7 +108,9 @@ class ClassContainerTests(FactoryTestCase):
         mock_pre_process_class.assert_called_once_with(first)
 
     def test_pre_process_class(self):
-        target = ClassFactory.create(inner=ClassFactory.list(2))
+        target = ClassFactory.create(
+            inner=[ClassFactory.elements(2), ClassFactory.elements(1)]
+        )
         self.container.add(target)
 
         self.container.process()

--- a/xsdata/codegen/container.py
+++ b/xsdata/codegen/container.py
@@ -19,6 +19,7 @@ from xsdata.codegen.handlers import AttributeOverridesHandler
 from xsdata.codegen.handlers import AttributeRestrictionsHandler
 from xsdata.codegen.handlers import AttributeSubstitutionHandler
 from xsdata.codegen.handlers import AttributeTypeHandler
+from xsdata.codegen.handlers import ClassBareInnerHandler
 from xsdata.codegen.handlers import ClassEnumerationHandler
 from xsdata.codegen.handlers import ClassExtensionHandler
 from xsdata.codegen.handlers import ClassNameConflictHandler
@@ -65,6 +66,7 @@ class ClassContainer(ContainerInterface):
             AttributeDefaultValueHandler(self),
             AttributeRestrictionsHandler(),
             AttributeNameConflictHandler(),
+            ClassBareInnerHandler(),
         ]
         if self.config.output.compound_fields:
             self.post_processors.insert(0, AttributeCompoundChoiceHandler())

--- a/xsdata/codegen/handlers/__init__.py
+++ b/xsdata/codegen/handlers/__init__.py
@@ -1,41 +1,35 @@
-from xsdata.codegen.handlers.attribute_compound_choice import (
-    AttributeCompoundChoiceHandler,
-)
-from xsdata.codegen.handlers.attribute_default_validate import (
-    AttributeDefaultValidateHandler,
-)
-from xsdata.codegen.handlers.attribute_default_value import AttributeDefaultValueHandler
-from xsdata.codegen.handlers.attribute_effective_choice import (
-    AttributeEffectiveChoiceHandler,
-)
-from xsdata.codegen.handlers.attribute_group import AttributeGroupHandler
-from xsdata.codegen.handlers.attribute_merge import AttributeMergeHandler
-from xsdata.codegen.handlers.attribute_mixed_content import AttributeMixedContentHandler
-from xsdata.codegen.handlers.attribute_name_conflict import AttributeNameConflictHandler
-from xsdata.codegen.handlers.attribute_overrides import AttributeOverridesHandler
-from xsdata.codegen.handlers.attribute_restrictions import AttributeRestrictionsHandler
-from xsdata.codegen.handlers.attribute_substitution import AttributeSubstitutionHandler
-from xsdata.codegen.handlers.attribute_type import AttributeTypeHandler
-from xsdata.codegen.handlers.class_enumeration import ClassEnumerationHandler
-from xsdata.codegen.handlers.class_extension import ClassExtensionHandler
-from xsdata.codegen.handlers.class_name_conflict import ClassNameConflictHandler
-
+from .attribute_compound_choice import AttributeCompoundChoiceHandler
+from .attribute_default_validate import AttributeDefaultValidateHandler
+from .attribute_default_value import AttributeDefaultValueHandler
+from .attribute_effective_choice import AttributeEffectiveChoiceHandler
+from .attribute_group import AttributeGroupHandler
+from .attribute_merge import AttributeMergeHandler
+from .attribute_mixed_content import AttributeMixedContentHandler
+from .attribute_name_conflict import AttributeNameConflictHandler
+from .attribute_overrides import AttributeOverridesHandler
+from .attribute_restrictions import AttributeRestrictionsHandler
+from .attribute_substitution import AttributeSubstitutionHandler
+from .attribute_type import AttributeTypeHandler
+from .class_bar_inner import ClassBareInnerHandler
+from .class_enumeration import ClassEnumerationHandler
+from .class_extension import ClassExtensionHandler
+from .class_name_conflict import ClassNameConflictHandler
 
 __all__ = [
-    "ClassEnumerationHandler",
+    "AttributeCompoundChoiceHandler",
+    "AttributeDefaultValidateHandler",
+    "AttributeDefaultValueHandler",
+    "AttributeEffectiveChoiceHandler",
     "AttributeGroupHandler",
     "AttributeMergeHandler",
-    "AttributeOverridesHandler",
     "AttributeMixedContentHandler",
+    "AttributeNameConflictHandler",
+    "AttributeOverridesHandler",
+    "AttributeRestrictionsHandler",
     "AttributeSubstitutionHandler",
     "AttributeTypeHandler",
+    "ClassBareInnerHandler",
+    "ClassEnumerationHandler",
     "ClassExtensionHandler",
-    "AttributeCompoundChoiceHandler",
-    "AttributeRestrictionsHandler",
-    "AttributeDefaultValueHandler",
-    "AttributeRestrictionsHandler",
-    "AttributeNameConflictHandler",
-    "AttributeDefaultValidateHandler",
-    "AttributeEffectiveChoiceHandler",
     "ClassNameConflictHandler",
 ]

--- a/xsdata/codegen/handlers/class_bar_inner.py
+++ b/xsdata/codegen/handlers/class_bar_inner.py
@@ -1,0 +1,42 @@
+from xsdata.codegen.mixins import HandlerInterface
+from xsdata.codegen.models import Class
+from xsdata.models.enums import DataType
+
+
+class ClassBareInnerHandler(HandlerInterface):
+    """
+    Search and vacuum inner classes with no attributes or a single extension.
+
+    Cases:
+        1. Removing identical overriding fields can some times leave a class
+           bare with just an extension. For inner classes we can safely
+           replace the forward reference with the inner extension reference.
+        2. Empty nested complexContent with no restrictions or extensions,
+           we can replace these references with xs:anySimpleType
+    """
+
+    def process(self, target: Class):
+        for inner in list(target.inner):
+            if not inner.attrs and len(inner.extensions) < 2:
+                self.remove_inner(target, inner)
+
+    @classmethod
+    def remove_inner(cls, target: Class, inner: Class):
+        target.inner.remove(inner)
+
+        for attr in target.attrs:
+            for attr_type in attr.types:
+
+                if attr_type.forward and attr_type.qname == inner.qname:
+                    attr_type.circular = False
+                    attr_type.forward = False
+
+                    if inner.extensions:
+                        ext = inner.extensions[0]
+                        attr_type.reference = ext.type.reference
+                        attr_type.qname = ext.type.qname
+                        attr_type.native = False
+                    else:
+                        attr_type.native = True
+                        attr_type.qname = str(DataType.ANY_SIMPLE_TYPE)
+                        attr_type.reference = 0

--- a/xsdata/utils/testing.py
+++ b/xsdata/utils/testing.py
@@ -188,7 +188,10 @@ class ExtensionFactory(Factory):
 
     @classmethod
     def reference(cls, qname: str, **kwargs: Any) -> Extension:
-        return cls.create(AttrTypeFactory.create(qname=qname), **kwargs)
+        restrictions = kwargs.pop("restrictions", None)
+        return cls.create(
+            AttrTypeFactory.create(qname=qname, **kwargs), restrictions=restrictions
+        )
 
     @classmethod
     def native(cls, datatype: DataType, **kwargs: Any) -> Extension:


### PR DESCRIPTION
    Search and vacuum inner classes with no attributes or a single extension.

    Cases:
        1. Removing identical overriding fields can some times leave  a class
           bare with just an extension. For inner classes we can safely
           replace the forward reference with the inner extension reference.
        2. Empty nested complexContent with no restrictions or extensions,
           we can replace these references with xs:anySimpleType