### PR TITLE
Reduce context size

### DIFF
--- a/tests/formats/dataclass/models/test_builders.py
+++ b/tests/formats/dataclass/models/test_builders.py
@@ -20,28 +20,29 @@ from tests.fixtures.defxmlschema.chapter13 import ItemsType
 from xsdata.exceptions import XmlContextError
 from xsdata.formats.dataclass.models.builders import XmlMetaBuilder
 from xsdata.formats.dataclass.models.builders import XmlVarBuilder
-from xsdata.formats.dataclass.models.elements import XmlMeta
 from xsdata.formats.dataclass.models.elements import XmlType
-from xsdata.formats.dataclass.models.elements import XmlVar
 from xsdata.models.datatype import XmlDate
 from xsdata.utils import text
 from xsdata.utils.constants import return_input
 from xsdata.utils.constants import return_true
 from xsdata.utils.namespaces import build_qname
+from xsdata.utils.testing import FactoryTestCase
+from xsdata.utils.testing import XmlMetaFactory
+from xsdata.utils.testing import XmlVarFactory
 
 
-class XmlMetaBuilderTests(TestCase):
+class XmlMetaBuilderTests(FactoryTestCase):
     @mock.patch.object(XmlMetaBuilder, "build_vars")
     def test_build(self, mock_build_vars):
-        var = XmlVar(is_element=True, name="foo", qname="{foo}bar", types=(int,))
+        var = XmlVarFactory.create(
+            xml_type=XmlType.ELEMENT, name="foo", qname="{foo}bar", types=(int,)
+        )
         mock_build_vars.return_value = [var]
 
         result = XmlMetaBuilder.build(ItemsType, None, return_input, return_input)
-        expected = XmlMeta(
+        expected = XmlMetaFactory.create(
             clazz=ItemsType,
             qname="ItemsType",
-            source_qname="ItemsType",
-            nillable=False,
             elements={var.qname: [var]},
         )
 
@@ -110,51 +111,53 @@ class XmlMetaBuilderTests(TestCase):
         self.assertIsInstance(result, Iterator)
 
         expected = [
-            XmlVar(
-                is_element=True,
+            XmlVarFactory.create(
+                xml_type=XmlType.ELEMENT,
                 index=0,
                 name="author",
                 qname="Author",
                 types=(str,),
             ),
-            XmlVar(
-                is_element=True,
+            XmlVarFactory.create(
+                xml_type=XmlType.ELEMENT,
                 index=1,
                 name="title",
                 qname="Title",
                 types=(str,),
             ),
-            XmlVar(
-                is_element=True,
+            XmlVarFactory.create(
+                xml_type=XmlType.ELEMENT,
                 index=2,
                 name="genre",
                 qname="Genre",
                 types=(str,),
             ),
-            XmlVar(
-                is_element=True,
+            XmlVarFactory.create(
+                xml_type=XmlType.ELEMENT,
                 index=3,
                 name="price",
                 qname="Price",
                 types=(float,),
             ),
-            XmlVar(
-                is_element=True,
+            XmlVarFactory.create(
+                xml_type=XmlType.ELEMENT,
                 index=4,
                 name="pub_date",
                 qname="PubDate",
                 types=(XmlDate,),
             ),
-            XmlVar(
-                is_element=True,
+            XmlVarFactory.create(
+                xml_type=XmlType.ELEMENT,
                 index=5,
                 name="review",
                 qname="Review",
                 types=(str,),
             ),
-            XmlVar(is_attribute=True, index=6, name="id", qname="ID", types=(str,)),
-            XmlVar(
-                is_attribute=True,
+            XmlVarFactory.create(
+                xml_type=XmlType.ATTRIBUTE, index=6, name="id", qname="ID", types=(str,)
+            ),
+            XmlVarFactory.create(
+                xml_type=XmlType.ATTRIBUTE,
                 index=7,
                 name="lang",
                 qname="LANG",
@@ -167,7 +170,6 @@ class XmlMetaBuilderTests(TestCase):
         result = list(result)
         self.assertEqual(expected, result)
         for var in result:
-            self.assertFalse(var.dataclass)
             self.assertIsNone(var.clazz)
 
     def test_default_xml_type(self):
@@ -229,29 +231,28 @@ class XmlVarBuilderTests(TestCase):
             list,
             globalns,
         )
-        expected = XmlVar(
+        expected = XmlVarFactory.create(
             index=66,
-            is_elements=True,
+            xml_type=XmlType.ELEMENTS,
             name="compound",
             qname="compound",
             list_element=True,
             any_type=True,
             default=list,
             elements={
-                "{foo}node": XmlVar(
+                "{foo}node": XmlVarFactory.create(
                     index=0,
-                    is_element=True,
+                    xml_type=XmlType.ELEMENT,
                     name="compound",
                     qname="{foo}node",
-                    dataclass=True,
                     list_element=True,
                     types=(CompoundFieldExample,),
                     namespaces=("foo",),
                     derived=False,
                 ),
-                "{bar}x": XmlVar(
+                "{bar}x": XmlVarFactory.create(
                     index=1,
-                    is_element=True,
+                    xml_type=XmlType.ELEMENT,
                     name="compound",
                     qname="{bar}x",
                     tokens=True,
@@ -262,9 +263,9 @@ class XmlVarBuilderTests(TestCase):
                     default=return_true,
                     format="Nope",
                 ),
-                "{bar}y": XmlVar(
+                "{bar}y": XmlVarFactory.create(
                     index=2,
-                    is_element=True,
+                    xml_type=XmlType.ELEMENT,
                     name="compound",
                     qname="{bar}y",
                     nillable=True,
@@ -273,9 +274,9 @@ class XmlVarBuilderTests(TestCase):
                     namespaces=("bar",),
                     derived=False,
                 ),
-                "{bar}z": XmlVar(
+                "{bar}z": XmlVarFactory.create(
                     index=3,
-                    is_element=True,
+                    xml_type=XmlType.ELEMENT,
                     name="compound",
                     qname="{bar}z",
                     nillable=False,
@@ -284,9 +285,9 @@ class XmlVarBuilderTests(TestCase):
                     namespaces=("bar",),
                     derived=True,
                 ),
-                "{bar}o": XmlVar(
+                "{bar}o": XmlVarFactory.create(
                     index=4,
-                    is_element=True,
+                    xml_type=XmlType.ELEMENT,
                     name="compound",
                     qname="{bar}o",
                     nillable=False,
@@ -296,9 +297,9 @@ class XmlVarBuilderTests(TestCase):
                     derived=True,
                     any_type=True,
                 ),
-                "{bar}p": XmlVar(
+                "{bar}p": XmlVarFactory.create(
                     index=5,
-                    is_element=True,
+                    xml_type=XmlType.ELEMENT,
                     name="compound",
                     qname="{bar}p",
                     types=(float,),
@@ -308,9 +309,9 @@ class XmlVarBuilderTests(TestCase):
                 ),
             },
             wildcards=[
-                XmlVar(
+                XmlVarFactory.create(
                     index=6,
-                    is_wildcard=True,
+                    xml_type=XmlType.WILDCARD,
                     name="compound",
                     qname="{http://www.w3.org/1999/xhtml}any",
                     types=(object,),
@@ -384,12 +385,6 @@ class XmlVarBuilderTests(TestCase):
             "Unsupported typing: typing.List[typing.List[typing.List[int]]]",
             str(cm.exception),
         )
-
-    def test_build_xml_type(self):
-        self.builder.default_xml_type = XmlType.WILDCARD
-        self.assertEqual(XmlType.WILDCARD, self.builder.build_xml_type(None, False))
-        self.assertEqual(XmlType.ELEMENT, self.builder.build_xml_type("", True))
-        self.assertEqual(XmlType.TEXT, self.builder.build_xml_type(XmlType.TEXT, True))
 
     def test_is_valid(self):
         # Attributes need origin dict

--- a/tests/formats/dataclass/parsers/test_xml.py
+++ b/tests/formats/dataclass/parsers/test_xml.py
@@ -2,14 +2,16 @@ from unittest import mock
 from unittest.case import TestCase
 
 from tests.fixtures.books import Books
-from xsdata.formats.dataclass.models.elements import XmlVar
+from xsdata.formats.dataclass.models.elements import XmlType
 from xsdata.formats.dataclass.parsers.nodes import PrimitiveNode
 from xsdata.formats.dataclass.parsers.nodes import SkipNode
 from xsdata.formats.dataclass.parsers.xml import UserXmlParser
 from xsdata.models.enums import EventType
+from xsdata.utils.testing import FactoryTestCase
+from xsdata.utils.testing import XmlVarFactory
 
 
-class UserXmlParserTests(TestCase):
+class UserXmlParserTests(FactoryTestCase):
     def setUp(self):
         super().setUp()
         self.parser = UserXmlParser()
@@ -31,7 +33,7 @@ class UserXmlParserTests(TestCase):
     def test_end(self, mock_emit_event):
         objects = []
         queue = []
-        var = XmlVar(is_text=True, name="foo", qname="foo", types=(bool,))
+        var = XmlVarFactory.create(xml_type=XmlType.TEXT, name="foo", types=(bool,))
         queue.append(PrimitiveNode(var, {}))
 
         result = self.parser.end(queue, objects, "enabled", "true", None)

--- a/tests/formats/dataclass/test_context.py
+++ b/tests/formats/dataclass/test_context.py
@@ -1,18 +1,19 @@
+import copy
 from dataclasses import fields
 from dataclasses import make_dataclass
 from dataclasses import replace
 from unittest import mock
-from unittest import TestCase
 
 from tests.fixtures.books import BookForm
 from tests.fixtures.books import BooksForm
 from tests.fixtures.defxmlschema.chapter13 import ItemsType
 from xsdata.formats.dataclass.context import XmlContext
-from xsdata.formats.dataclass.models.elements import XmlMeta
 from xsdata.models.enums import DataType
+from xsdata.utils.testing import FactoryTestCase
+from xsdata.utils.testing import XmlMetaFactory
 
 
-class XmlContextTests(TestCase):
+class XmlContextTests(FactoryTestCase):
     def setUp(self):
         self.ctx = XmlContext()
         super().setUp()
@@ -20,12 +21,7 @@ class XmlContextTests(TestCase):
     @mock.patch.object(XmlContext, "find_subclass")
     @mock.patch.object(XmlContext, "build")
     def test_fetch(self, mock_build, mock_find_subclass):
-        meta = XmlMeta(
-            clazz=ItemsType,
-            qname="ItemsType",
-            source_qname="ItemsType",
-            nillable=False,
-        )
+        meta = XmlMetaFactory.create(clazz=ItemsType, qname="ItemsType")
         mock_build.return_value = meta
         actual = self.ctx.fetch(ItemsType, "foo")
         self.assertEqual(meta, actual)
@@ -37,7 +33,7 @@ class XmlContextTests(TestCase):
     def test_fetch_with_xsi_type_and_subclass_not_found(
         self, mock_build, mock_find_subclass
     ):
-        meta = XmlMeta(
+        meta = XmlMetaFactory.create(
             clazz=ItemsType,
             qname="ItemsType",
             source_qname="ItemsType",
@@ -55,13 +51,9 @@ class XmlContextTests(TestCase):
     def test_fetch_with_xsi_type_and_subclass_found(
         self, mock_build, mock_find_subclass
     ):
-        meta = XmlMeta(
-            clazz=ItemsType,
-            qname="ItemsType",
-            source_qname="ItemsType",
-            nillable=False,
-        )
-        xsi_meta = replace(meta, qname="XsiType")
+        meta = XmlMetaFactory.create(clazz=ItemsType)
+        xsi_meta = copy.deepcopy(meta)
+        xsi_meta.qname = "XsiType"
 
         mock_build.side_effect = [meta, xsi_meta]
         mock_find_subclass.return_value = xsi_meta

--- a/xsdata/formats/dataclass/models/elements.py
+++ b/xsdata/formats/dataclass/models/elements.py
@@ -1,97 +1,193 @@
 import operator
-from dataclasses import dataclass
-from dataclasses import field
 from dataclasses import is_dataclass
 from typing import Any
 from typing import Dict
 from typing import Iterator
 from typing import List
+from typing import Mapping
 from typing import Optional
 from typing import Sequence
-from typing import Tuple
 from typing import Type
 
 from xsdata.models.enums import NamespaceType
 from xsdata.utils import collections
 from xsdata.utils.constants import EMPTY_SEQUENCE
+from xsdata.utils.namespaces import local_name
 from xsdata.utils.namespaces import split_qname
+from xsdata.utils.namespaces import target_uri
 
 NoneType = type(None)
 
 
-@dataclass
-class XmlVar:
-    """
-    Dataclass field binding metadata.
+class XmlType:
+    """Xml node types."""
 
-    :param name: Field name
-    :param qname: Qualified name
-    :param init:  Include field in the constructor
-    :param mixed:  Field supports mixed content type values
-    :param tokens: Field is derived from xs:list
-    :param format: Value format information
-    :param derived: Wrap parsed values with
-        :class:`~xsdata.formats.dataclass.models.generics.DerivedElement`
-    :param any_type: Field supports dynamic value types
-    :param nillable: Field supports nillable content
-    :param dataclass: Field value is bound to a dataclass
-    :param sequential: Render values in sequential mode
-    :param list_element: Field is a list of elements
-    :param default: Field default value or factory
-    :param is_text: Field is derived from xs:simpleType
-    :param is_element: Field is derived from xs:element
-    :param is_elements: Field is derived from xs:choice
-    :param is_wildcard: Field is derived from xs:anyType
-    :param is_attribute: Field is derived from xs:attribute
-    :param is_attributes: Field is derived from xs:attributes
-    :param index: Field ordering
-    :param types: List of all the supported data types
-    :param namespaces: List of the supported namespaces
-    :param elements: Mapping of qname-repeatable elements
-    :param wildcards: List of repeatable wildcards
-    :ivar namespace_matches: Matching cache for the repeatable wildcards
-    """
+    TEXT = "Text"
+    ELEMENT = "Element"
+    ELEMENTS = "Elements"
+    WILDCARD = "Wildcard"
+    ATTRIBUTE = "Attribute"
+    ATTRIBUTES = "Attributes"
 
-    name: str
-    qname: str
-    init: bool = True
-    mixed: bool = False
-    tokens: bool = False
-    format: Optional[str] = None
-    derived: bool = False
-    any_type: bool = False
-    nillable: bool = False
-    dataclass: bool = False
-    sequential: bool = False
-    list_element: bool = False
-    default: Any = None
-    is_text: bool = False
-    is_element: bool = False
-    is_elements: bool = False
-    is_wildcard: bool = False
-    is_attribute: bool = False
-    is_attributes: bool = False
-    index: int = field(default_factory=int)
-    types: Tuple[Type, ...] = field(default_factory=tuple)
-    namespaces: Tuple[str, ...] = field(default_factory=tuple)
-    elements: Dict[str, "XmlVar"] = field(default_factory=dict)
-    wildcards: List["XmlVar"] = field(default_factory=list)
-    namespace_matches: Optional[Dict[str, bool]] = field(init=False, default=None)
+    @classmethod
+    def all(cls):
+        yield XmlType.TEXT
+        yield XmlType.ELEMENT
+        yield XmlType.ELEMENTS
+        yield XmlType.WILDCARD
+        yield XmlType.ATTRIBUTE
+        yield XmlType.ATTRIBUTES
 
-    @property
-    def lname(self) -> str:
-        """Local name."""
-        _, name = split_qname(self.qname)
-        return name
 
-    @property
-    def clazz(self) -> Optional[Type]:
-        """Return the first type if field is bound to a dataclass."""
-        return self.types[0] if self.dataclass else None
+class MetaMixin:
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, self.__class__):
+            return tuple(self) == tuple(other)
 
-    @property
-    def is_clazz_union(self) -> bool:
-        return self.dataclass and len(self.types) > 1
+        return NotImplemented
+
+    def __iter__(self) -> Iterator:
+        for field_name in self.__slots__:
+            yield getattr(self, field_name)
+
+
+class XmlVar(MetaMixin):
+    """Class field binding metadata."""
+
+    __slots__ = (
+        "name",
+        "qname",
+        "init",
+        "mixed",
+        "tokens",
+        "format",
+        "derived",
+        "any_type",
+        "nillable",
+        "sequential",
+        "list_element",
+        "default",
+        "is_text",
+        "is_element",
+        "is_elements",
+        "is_wildcard",
+        "is_attribute",
+        "is_attributes",
+        "index",
+        "types",
+        "namespaces",
+        "elements",
+        "wildcards",
+        "namespace_matches",
+        "clazz",
+        "is_clazz_union",
+        "local_name",
+    )
+
+    def __init__(
+        self,
+        *args: Any,
+        index: int,
+        name: str,
+        qname: str,
+        types: Sequence[Type],
+        init: bool,
+        mixed: bool,
+        tokens: bool,
+        format: Optional[str],
+        derived: bool,
+        any_type: bool,
+        nillable: bool,
+        sequential: bool,
+        list_element: bool,
+        default: Any,
+        xml_type: str,
+        namespaces: Sequence[str],
+        elements: Mapping[str, "XmlVar"],
+        wildcards: Sequence["XmlVar"],
+    ):
+        """
+        :param index: Field ordering
+        :param name: Field name
+        :param qname: Qualified name
+        :param types: List of all the supported data types
+        :param init:  Include field in the constructor
+        :param mixed:  Field supports mixed content type values
+        :param tokens: Field is derived from xs:list
+        :param format: Value format information
+        :param derived: Wrap parsed values with a generic type
+        :param any_type: Field supports dynamic value types
+        :param nillable: Field supports nillable content
+        :param sequential: Render values in sequential mode
+        :param list_element: Field is a list of elements
+        :param default: Field default value or factory
+        :param xml_Type: Field xml type
+        :param namespaces: List of the supported namespaces
+        :param elements: Mapping of qname-repeatable elements
+        :param wildcards: List of repeatable wildcards
+        """
+
+        self.index = index
+        self.name = name
+        self.qname = qname
+        self.types = types
+        self.init = init
+        self.mixed = mixed
+        self.tokens = tokens
+        self.format = format
+        self.derived = derived
+        self.any_type = any_type
+        self.nillable = nillable
+        self.sequential = sequential
+        self.list_element = list_element
+        self.default = default
+        self.namespaces = namespaces
+        self.elements = elements
+        self.wildcards = wildcards
+
+        self.namespace_matches: Optional[Dict[str, bool]] = None
+
+        self.clazz = collections.first(tp for tp in types if is_dataclass(tp))
+        self.is_clazz_union = self.clazz and len(types) > 1
+        self.local_name = local_name(qname)
+
+        self.is_text = False
+        self.is_element = False
+        self.is_elements = False
+        self.is_wildcard = False
+        self.is_attribute = False
+        self.is_attributes = False
+
+        if xml_type == XmlType.ELEMENT or self.clazz:
+            self.is_element = True
+        elif xml_type == XmlType.ELEMENTS:
+            self.is_elements = True
+        elif xml_type == XmlType.ATTRIBUTE:
+            self.is_attribute = True
+        elif xml_type == XmlType.ATTRIBUTES:
+            self.is_attributes = True
+        elif xml_type == XmlType.WILDCARD:
+            self.is_wildcard = True
+        else:
+            self.is_text = True
+
+    def get_xml_type(self) -> str:
+        if self.is_wildcard:
+            return XmlType.WILDCARD
+
+        if self.is_attribute:
+            return XmlType.ATTRIBUTE
+
+        if self.is_attributes:
+            return XmlType.ATTRIBUTES
+
+        if self.is_element:
+            return XmlType.ELEMENT
+
+        if self.is_elements:
+            return XmlType.ELEMENTS
+
+        return XmlType.TEXT
 
     def find_choice(self, qname: str) -> Optional["XmlVar"]:
         """Match and return a choice field by its qualified name."""
@@ -156,64 +252,110 @@ class XmlVar:
         if qname == "*":
             return True
 
-        namespace, tag = split_qname(qname)
-        if not self.namespaces and namespace is None:
+        uri = target_uri(qname)
+        if not self.namespaces and uri is None:
             return True
 
         for check in self.namespaces:
             if (
-                (not check and namespace is None)
-                or check == namespace
+                (not check and uri is None)
+                or check == uri
                 or check == NamespaceType.ANY_NS
-                or (check and check[0] == "!" and check[1:] != namespace)
+                or (check and check[0] == "!" and check[1:] != uri)
             ):
                 return True
 
         return False
 
+    def __repr__(self) -> str:
+        params = (
+            f"index={self.index}, "
+            f"name={self.name}, "
+            f"qname={self.qname}, "
+            f"types={self.types}, "
+            f"init={self.init}, "
+            f"mixed={self.mixed}, "
+            f"tokens={self.tokens}, "
+            f"format={self.format}, "
+            f"derived={self.derived}, "
+            f"any_type={self.any_type}, "
+            f"nillable={self.nillable}, "
+            f"sequential={self.sequential}, "
+            f"list_element={self.list_element}, "
+            f"default={self.default}, "
+            f"xml_type={self.get_xml_type()}, "
+            f"namespaces={self.namespaces}, "
+            f"elements={self.elements}, "
+            f"wildcards={self.wildcards}"
+        )
+        return f"{self.__class__.__name__}({params})"
+
 
 get_index = operator.attrgetter("index")
 
 
-@dataclass
-class XmlMeta:
-    """
-    Dataclass binding metadata.
+class XmlMeta(MetaMixin):
+    """Class binding metadata."""
 
-    :param clazz: The dataclass type
-    :param qname: The namespace qualified name.
-    :param source_qname: The source namespace qualified name.
-    :param nillable: Specifies whether an explicit empty value can be assigned.
-    :param mixed_content: Has a wildcard with mixed flag enabled
-    :param text: Text var
-    :param choices: List of compound vars
-    :param elements: Mapping of qname-element vars
-    :param wildcards: List of wildcard vars
-    :param attributes: Mapping of qname-attribute vars
-    :param any_attributes: List of wildcard attributes vars
-    """
+    __slots__ = (
+        "clazz",
+        "qname",
+        "source_qname",
+        "nillable",
+        "text",
+        "choices",
+        "elements",
+        "wildcards",
+        "attributes",
+        "any_attributes",
+        "mixed_content",
+    )
 
-    clazz: Type
-    qname: str
-    source_qname: str
-    nillable: bool
-    mixed_content: bool = field(default=False)
-    text: Optional[XmlVar] = field(default=None)
-    choices: List[XmlVar] = field(default_factory=list)
-    elements: Dict[str, List[XmlVar]] = field(default_factory=dict)
-    wildcards: List[XmlVar] = field(default_factory=list)
-    attributes: Dict[str, XmlVar] = field(default_factory=dict)
-    any_attributes: List[XmlVar] = field(default_factory=list)
+    def __init__(
+        self,
+        *args: Any,
+        clazz: Type,
+        qname: str,
+        source_qname: str,
+        nillable: bool,
+        text: Optional[XmlVar],
+        choices: Sequence[XmlVar],
+        elements: Mapping[str, Sequence[XmlVar]],
+        wildcards: Sequence[XmlVar],
+        attributes: Mapping[str, XmlVar],
+        any_attributes: Sequence[XmlVar],
+    ):
 
-    def __post_init__(self):
+        """
+        :param clazz: The dataclass type
+        :param qname: The namespace qualified name.
+        :param source_qname: The source namespace qualified name.
+        :param nillable: Specifies whether an explicit empty value can be assigned.
+        :param mixed_content: Has a wildcard with mixed flag enabled
+        :param text: Text var
+        :param choices: List of compound vars
+        :param elements: Mapping of qname-element vars
+        :param wildcards: List of wildcard vars
+        :param attributes: Mapping of qname-attribute vars
+        :param any_attributes: List of wildcard attributes vars
+        """
+
+        self.clazz = clazz
+        self.qname = qname
+        self.source_qname = source_qname
+        self.nillable = nillable
+        self.text = text
+        self.choices = choices
+        self.elements = elements
+        self.wildcards = wildcards
+        self.attributes = attributes
+        self.any_attributes = any_attributes
         self.mixed_content = any(wildcard.mixed for wildcard in self.wildcards)
 
     def get_element_vars(self) -> List[XmlVar]:
-        result = self.wildcards + self.choices
-
-        for elements in self.elements.values():
-            result.extend(elements)
-
+        result = list(
+            collections.concat(self.wildcards, self.choices, *self.elements.values())
+        )
         if self.text:
             result.append(self.text)
 
@@ -224,11 +366,15 @@ class XmlMeta:
         return sorted(result, key=get_index)
 
     def get_all_vars(self) -> List[XmlVar]:
-        result = self.wildcards + self.choices + self.any_attributes
-        result.extend(self.attributes.values())
-        for elements in self.elements.values():
-            result.extend(elements)
-
+        result = list(
+            collections.concat(
+                self.wildcards,
+                self.choices,
+                self.any_attributes,
+                self.attributes.values(),
+                *self.elements.values(),
+            )
+        )
         if self.text:
             result.append(self.text)
 
@@ -270,19 +416,23 @@ class XmlMeta:
         if chd:
             yield chd
 
+    def __repr__(self) -> str:
+        params = (
+            f"clazz={self.clazz}, "
+            f"qname={self.qname}, "
+            f"source_qname={self.source_qname}, "
+            f"nillable={self.nillable}, "
+            f"text={self.text}, "
+            f"choices={self.choices}, "
+            f"elements={self.elements}, "
+            f"wildcards={self.wildcards}, "
+            f"attributes={self.attributes}, "
+            f"any_attributes={self.any_attributes}"
+        )
+        return f"{self.__class__.__name__}({params})"
 
-class XmlType:
-    """Xml node types."""
 
-    TEXT = "Text"
-    ELEMENT = "Element"
-    ELEMENTS = "Elements"
-    WILDCARD = "Wildcard"
-    ATTRIBUTE = "Attribute"
-    ATTRIBUTES = "Attributes"
-
-
-def find_by_namespace(xml_vars: List[XmlVar], qname: str) -> Optional[XmlVar]:
+def find_by_namespace(xml_vars: Sequence[XmlVar], qname: str) -> Optional[XmlVar]:
     for xml_var in xml_vars:
         if xml_var.match_namespace(qname):
             return xml_var

--- a/xsdata/formats/dataclass/parsers/json.py
+++ b/xsdata/formats/dataclass/parsers/json.py
@@ -122,7 +122,7 @@ class JsonParser(AbstractParser):
         """Recursively build the given model from the input dict data."""
         params = {}
         for var in self.context.build(clazz).get_all_vars():
-            value = data.get(var.lname)
+            value = data.get(var.local_name)
 
             if value is None or not var.init:
                 continue
@@ -204,7 +204,7 @@ class JsonParser(AbstractParser):
         # Sometimes exact type match doesn't work, eg Decimals, try all of them
         is_list = isinstance(value, list)
         for choice in var.elements.values():
-            if choice.dataclass or choice.tokens != is_list:
+            if choice.clazz or choice.tokens != is_list:
                 continue
 
             with warnings.catch_warnings(record=True) as w:
@@ -238,7 +238,7 @@ class JsonParser(AbstractParser):
         for choice in var.elements.values():
             if choice.clazz:
                 meta = self.context.build(choice.clazz)
-                attrs = {var.lname for var in meta.get_all_vars()}
+                attrs = {var.local_name for var in meta.get_all_vars()}
                 if attrs == keys:
                     return self.bind_value(choice, value)
 

--- a/xsdata/formats/dataclass/parsers/tree.py
+++ b/xsdata/formats/dataclass/parsers/tree.py
@@ -5,6 +5,7 @@ from typing import List
 from typing import Optional
 from typing import Type
 
+from xsdata.formats.dataclass.models.elements import XmlType
 from xsdata.formats.dataclass.models.elements import XmlVar
 from xsdata.formats.dataclass.parsers.handlers import default_handler
 from xsdata.formats.dataclass.parsers.mixins import XmlHandler
@@ -37,10 +38,26 @@ class TreeParser(NodeParser):
             item = queue[-1]
             child = item.child(qname, attrs, ns_map, len(objects))
         except IndexError:
-            child = WildcardNode(
-                var=XmlVar(name=qname, qname=qname, is_wildcard=True),
-                attrs=attrs,
-                ns_map=ns_map,
-                position=0,
+            var = XmlVar(
+                name=qname,
+                qname=qname,
+                xml_type=XmlType.WILDCARD,
+                index=0,
+                types=(object,),
+                init=True,
+                mixed=False,
+                tokens=False,
+                format=None,
+                derived=False,
+                any_type=False,
+                nillable=False,
+                sequential=False,
+                list_element=False,
+                default=None,
+                namespaces=(),
+                elements={},
+                wildcards=(),
             )
+
+            child = WildcardNode(var=var, attrs=attrs, ns_map=ns_map, position=0)
         queue.append(child)

--- a/xsdata/formats/dataclass/serializers/json.py
+++ b/xsdata/formats/dataclass/serializers/json.py
@@ -66,7 +66,7 @@ class JsonSerializer(AbstractSerializer):
 
             return self.dict_factory(
                 [
-                    (var.lname, self.convert(getattr(obj, var.name), var))
+                    (var.local_name, self.convert(getattr(obj, var.name), var))
                     for var in self.context.build(obj.__class__).get_all_vars()
                 ]
             )

--- a/xsdata/utils/constants.py
+++ b/xsdata/utils/constants.py
@@ -1,9 +1,11 @@
 from typing import Any
 from typing import Dict
 from typing import Sequence
+from typing import Tuple
 
 EMPTY_MAP: Dict = {}
 EMPTY_SEQUENCE: Sequence = []
+EMPTY_TUPLE: Tuple = ()
 
 
 def return_true(*_: Any) -> bool:


### PR DESCRIPTION
Trying to squeeze what's possible for the binding metadata, save a bit on storage and attribute access