### PR TITLE
Remove sequential flag from override validations

### DIFF
--- a/tests/codegen/models/test_restrictions.py
+++ b/tests/codegen/models/test_restrictions.py
@@ -121,3 +121,18 @@ class RestrictionsTests(TestCase):
 
         self.assertEqual(clone, restrictions)
         self.assertIsNot(clone, restrictions)
+
+    def test_compare(self):
+        clone = self.restrictions.clone()
+        self.assertEqual(clone, self.restrictions)
+
+        clone.min_occurs = 54
+        clone.max_occurs = 56
+        self.assertEqual(clone, self.restrictions)
+
+        clone.choice = 145
+        clone.sequential = True
+        self.assertEqual(clone, self.restrictions)
+
+        clone.max_length = 11
+        self.assertNotEqual(clone, self.restrictions)

--- a/xsdata/codegen/models.py
+++ b/xsdata/codegen/models.py
@@ -75,7 +75,7 @@ class Restrictions:
     pattern: Optional[str] = field(default=None)
     explicit_timezone: Optional[str] = field(default=None)
     nillable: Optional[bool] = field(default=None)
-    sequential: Optional[bool] = field(default=None)
+    sequential: Optional[bool] = field(default=None, compare=False)
     tokens: Optional[bool] = field(default=None)
     format: Optional[str] = field(default=None)
     choice: Optional[str] = field(default=None, compare=False)


### PR DESCRIPTION
This affects the override fields validations and it will allow more fields to be safely removed from child classes.