### PR TITLE
Sort classes by name before renaming

### DIFF
--- a/tests/codegen/handlers/test_class_name_conflict.py
+++ b/tests/codegen/handlers/test_class_name_conflict.py
@@ -77,11 +77,11 @@ class ClassNameConflictHandlerTests(FactoryTestCase):
 
         mock_rename_class.assert_has_calls(
             [
-                mock.call(classes[0], False),
                 mock.call(classes[1], False),
+                mock.call(classes[0], False),
                 mock.call(classes[2], False),
-                mock.call(classes[0], True),
                 mock.call(classes[1], True),
+                mock.call(classes[0], True),
                 mock.call(classes[2], True),
             ]
         )

--- a/xsdata/codegen/handlers/attribute_default_value.py
+++ b/xsdata/codegen/handlers/attribute_default_value.py
@@ -1,3 +1,4 @@
+from operator import attrgetter
 from typing import Optional
 
 from xsdata.codegen.mixins import RelativeHandlerInterface
@@ -85,6 +86,5 @@ class AttributeDefaultValueHandler(RelativeHandlerInterface):
         if attr_type.native:
             return None
 
-        return self.container.find(
-            attr_type.qname, condition=lambda x: x.is_enumeration
-        )
+        is_enumeration = attrgetter("is_enumeration")
+        return self.container.find(attr_type.qname, condition=is_enumeration)

--- a/xsdata/codegen/handlers/class_name_conflict.py
+++ b/xsdata/codegen/handlers/class_name_conflict.py
@@ -40,7 +40,7 @@ class ClassNameConflictHandler(ContainerHandlerInterface):
         the list.
         """
         total_elements = sum(x.is_element for x in classes)
-        for target in classes:
+        for target in sorted(classes, key=operator.attrgetter("name")):
             if not target.is_element or total_elements > 1:
                 self.rename_class(target, use_name)
 


### PR DESCRIPTION
Specially in netex collection it's common to have base types that have an underscore prefix or a suffix, when it's time to resolve these conflict the handler assigns auto increment suffixes by following whatever order the classes arrive in the handler.

So for example  the class type `ParkingSpace` is renamed to `ParkingSpace2` and the type `_ParkingSpace` to `ParkingSpace1`, which seems a bit unfair, so sort the classes by name before assigning new names

