### PR TITLE
Generate relative imports

### DIFF
--- a/tests/codegen/models/test_class.py
+++ b/tests/codegen/models/test_class.py
@@ -137,6 +137,11 @@ class ClassTests(FactoryTestCase):
         obj.extensions.append(ExtensionFactory.create())
         self.assertFalse(obj.is_simple_type)
 
+    def test_property_is_group(self):
+        self.assertTrue(ClassFactory.create(tag=Tag.GROUP).is_group)
+        self.assertTrue(ClassFactory.create(tag=Tag.ATTRIBUTE_GROUP).is_group)
+        self.assertFalse(ClassFactory.create(tag=Tag.ELEMENT).is_group)
+
     def test_property_should_generate(self):
         obj = ClassFactory.create(tag=Tag.ELEMENT)
         self.assertTrue(obj.should_generate)

--- a/tests/formats/dataclass/test_generator.py
+++ b/tests/formats/dataclass/test_generator.py
@@ -44,7 +44,13 @@ class DataclassGeneratorTests(FactoryTestCase):
             (cwd.joinpath("thug/life/tests.py"), "thug.life.tests", "module"),
         ]
         self.assertEqual(expected, actual)
-        mock_render_package.assert_has_calls([mock.call([x]) for x in classes])
+        mock_render_package.assert_has_calls(
+            [
+                mock.call([classes[0]], "foo.bar"),
+                mock.call([classes[1]], "bar.foo"),
+                mock.call([classes[2]], "thug.life"),
+            ]
+        )
         mock_render_module.assert_has_calls([mock.call(mock.ANY, [x]) for x in classes])
 
     def test_render_package(self):
@@ -57,7 +63,7 @@ class DataclassGeneratorTests(FactoryTestCase):
 
         random.shuffle(classes)
 
-        actual = self.generator.render_package(classes)
+        actual = self.generator.render_package(classes, "foo.tests")
         expected = "\n".join(
             [
                 "from foo.bar import A as BarA",

--- a/tests/integration/test_books.py
+++ b/tests/integration/test_books.py
@@ -20,9 +20,8 @@ def test_books_schema():
             str(schema),
             "--package",
             package,
-            "--ns-struct",
-            "--docstring-style",
-            "Google",
+            "--structure-style=namespaces",
+            "--docstring-style=Google",
         ],
         catch_exceptions=False,
     )

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -1,12 +1,10 @@
 import tempfile
-import warnings
 from pathlib import Path
 from unittest import TestCase
 
 from xsdata import __version__
 from xsdata.exceptions import ParserError
 from xsdata.models.config import GeneratorConfig
-from xsdata.models.config import GeneratorOutput
 
 
 class GeneratorConfigTests(TestCase):

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -13,15 +13,6 @@ class GeneratorConfigTests(TestCase):
     def setUp(self) -> None:
         self.maxDiff = None
 
-    def test_deprecation_warning(self):
-        with warnings.catch_warnings(record=True) as w:
-            output = GeneratorOutput(format="pydata")
-
-        self.assertEqual(
-            "Output format 'pydata' renamed to 'dataclasses'", str(w[-1].message)
-        )
-        self.assertEqual("dataclasses", output.format)
-
     def test_create(self):
         file_path = Path(tempfile.mktemp())
         obj = GeneratorConfig.create()

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -33,7 +33,7 @@ class GeneratorConfigTests(TestCase):
             f'<Config xmlns="http://pypi.org/project/xsdata" version="{__version__}">\n'
             '  <Output maxLineLength="79">\n'
             "    <Package>generated</Package>\n"
-            "    <Format>dataclasses</Format>\n"
+            '    <Format relativeImports="false">dataclasses</Format>\n'
             "    <Structure>filenames</Structure>\n"
             "    <DocstringStyle>reStructuredText</DocstringStyle>\n"
             "    <CompoundFields>false</CompoundFields>\n"
@@ -81,7 +81,7 @@ class GeneratorConfigTests(TestCase):
             f'<Config xmlns="http://pypi.org/project/xsdata" version="{__version__}">\n'
             '  <Output maxLineLength="79">\n'
             "    <Package>foo.bar</Package>\n"
-            "    <Format>dataclasses</Format>\n"
+            '    <Format relativeImports="false">dataclasses</Format>\n'
             "    <Structure>filenames</Structure>\n"
             "    <DocstringStyle>reStructuredText</DocstringStyle>\n"
             "    <CompoundFields>false</CompoundFields>\n"

--- a/tests/models/test_mixins.py
+++ b/tests/models/test_mixins.py
@@ -173,7 +173,7 @@ class ElementBaseTests(TestCase):
         element = ElementBase()
         self.assertIsNone(element.xs_prefix)
 
-        element.ns_map["foo"] = Namespace.XS.uri
+        element.ns_map = {"a": "a", "foo": Namespace.XS.uri}
         self.assertEqual("foo", element.xs_prefix)
 
     def test_children(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,7 +32,7 @@ class CliTests(TestCase):
         self.assertIsNone(result.exception)
         self.assertFalse(mock_init.call_args[1]["print"])
         self.assertEqual("foo", config.output.package)
-        self.assertEqual("dataclasses", config.output.format)
+        self.assertEqual("dataclasses", config.output.format.value)
         self.assertEqual(StructureStyle.FILENAMES, config.output.structure)
         self.assertEqual([source.as_uri()], mock_process.call_args[0][0])
 
@@ -60,7 +60,7 @@ class CliTests(TestCase):
         self.assertEqual([source.as_uri()], mock_process.call_args[0][0])
         self.assertFalse(mock_init.call_args[1]["print"])
         self.assertEqual("foo", config.output.package)
-        self.assertEqual("dataclasses", config.output.format)
+        self.assertEqual("dataclasses", config.output.format.value)
         self.assertEqual(StructureStyle.NAMESPACES, config.output.structure)
 
     @mock.patch.object(SchemaTransformer, "process")
@@ -77,7 +77,7 @@ class CliTests(TestCase):
         self.assertEqual([source.as_uri()], mock_process.call_args[0][0])
         self.assertFalse(mock_init.call_args[1]["print"])
         self.assertEqual("foo", config.output.package)
-        self.assertEqual("dataclasses", config.output.format)
+        self.assertEqual("dataclasses", config.output.format.value)
         self.assertEqual(StructureStyle.SINGLE_PACKAGE, config.output.structure)
 
     @mock.patch.object(SchemaTransformer, "process")
@@ -112,7 +112,7 @@ class CliTests(TestCase):
         self.assertIsNone(result.exception)
         self.assertFalse(mock_init.call_args[1]["print"])
         self.assertEqual("foo.bar", config.output.package)
-        self.assertEqual("dataclasses", config.output.format)
+        self.assertEqual("dataclasses", config.output.format.value)
         self.assertEqual(StructureStyle.NAMESPACES, config.output.structure)
         self.assertEqual([source.as_uri()], mock_process.call_args[0][0])
         file_path.unlink()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,6 +33,7 @@ class CliTests(TestCase):
         self.assertFalse(mock_init.call_args[1]["print"])
         self.assertEqual("foo", config.output.package)
         self.assertEqual("dataclasses", config.output.format.value)
+        self.assertFalse(config.output.format.relative_imports)
         self.assertEqual(StructureStyle.FILENAMES, config.output.structure)
         self.assertEqual([source.as_uri()], mock_process.call_args[0][0])
 
@@ -46,22 +47,6 @@ class CliTests(TestCase):
         self.assertEqual([source.as_uri()], mock_process.call_args[0][0])
         self.assertEqual(logging.ERROR, logger.getEffectiveLevel())
         self.assertTrue(mock_init.call_args[1]["print"])
-
-    @mock.patch.object(SchemaTransformer, "process")
-    @mock.patch.object(SchemaTransformer, "__init__", return_value=None)
-    def test_generate_with_ns_struct_mode(self, mock_init, mock_process):
-        source = fixtures_dir.joinpath("defxmlschema/chapter03.xsd")
-        result = self.runner.invoke(
-            cli, [str(source), "--package", "foo", "--ns-struct"]
-        )
-        config = mock_init.call_args[1]["config"]
-
-        self.assertIsNone(result.exception)
-        self.assertEqual([source.as_uri()], mock_process.call_args[0][0])
-        self.assertFalse(mock_init.call_args[1]["print"])
-        self.assertEqual("foo", config.output.package)
-        self.assertEqual("dataclasses", config.output.format.value)
-        self.assertEqual(StructureStyle.NAMESPACES, config.output.structure)
 
     @mock.patch.object(SchemaTransformer, "process")
     @mock.patch.object(SchemaTransformer, "__init__", return_value=None)
@@ -132,17 +117,17 @@ class CliTests(TestCase):
             cli,
             [
                 str(source),
-                "--config",
-                str(file_path),
-                "--package",
-                "foo",
-                "--ns-struct",
+                f"--config={file_path}",
+                "--package=foo",
+                "--structure-style=namespaces",
+                "--relative-imports",
             ],
         )
         config = mock_init.call_args[1]["config"]
 
         self.assertIsNone(result.exception)
         self.assertEqual("foo", config.output.package)
+        self.assertTrue(config.output.format.relative_imports)
         self.assertEqual(StructureStyle.NAMESPACES, config.output.structure)
         file_path.unlink()
 

--- a/tests/utils/test_collections.py
+++ b/tests/utils/test_collections.py
@@ -11,12 +11,6 @@ class CollectionsTests(TestCase):
         self.assertEqual(-1, collections.find([0, 1], 2))
         self.assertEqual(1, collections.find([0, 1], 1))
 
-    def test_map_key(self):
-        dictionary = {"a": "b"}
-
-        self.assertIsNone(collections.map_key(dictionary, "x"))
-        self.assertEqual("a", collections.map_key(dictionary, "b"))
-
     def test_prepend(self):
         target = [1, 2, 3]
         prepend_values = [4, 5, 6]

--- a/xsdata/cli.py
+++ b/xsdata/cli.py
@@ -14,6 +14,7 @@ from xsdata.codegen.writer import CodeWriter
 from xsdata.logger import logger
 from xsdata.models.config import DocstringStyle
 from xsdata.models.config import GeneratorConfig
+from xsdata.models.config import OutputFormat
 from xsdata.models.config import StructureStyle
 from xsdata.utils.downloader import Downloader
 from xsdata.utils.hooks import load_entry_points
@@ -179,7 +180,7 @@ def generate(**kwargs: Any):
             config.output.package = kwargs["package"]
     else:
         config = GeneratorConfig()
-        config.output.format = kwargs["output"]
+        config.output.format = OutputFormat(value=kwargs["output"])
         config.output.package = kwargs["package"]
         config.output.compound_fields = kwargs["compound_fields"]
         config.output.docstring_style = DocstringStyle(kwargs["docstring_style"])

--- a/xsdata/cli.py
+++ b/xsdata/cli.py
@@ -88,11 +88,6 @@ def download(source: str, output: str):
     help=(
         "Specify the target package to be created inside the current working directory "
         "Default: generated"
-        "\n\n"
-        "The generated module structure relies on the common input source path"
-        "\n\n"
-        "Use the --ns-struct option for a more flat structure and to avoid circular "
-        "import errors."
     ),
     default="generated",
 )
@@ -115,17 +110,6 @@ def download(source: str, output: str):
         "Default: reStructuredText"
     ),
     default="reStructuredText",
-)
-@click.option(
-    "-ns",
-    "--ns-struct",
-    is_flag=True,
-    default=False,
-    help=(
-        "Use namespaces to group classes in modules. "
-        "Useful against circular import errors. "
-        "Deprecated use '--structure-style namespaces'"
-    ),
 )
 @click.option(
     "-ss",
@@ -156,6 +140,13 @@ def download(source: str, output: str):
     ),
 )
 @click.option(
+    "-ri",
+    "--relative-imports",
+    is_flag=True,
+    default=False,
+    help="Enable relative imports",
+)
+@click.option(
     "-pp",
     "--print",
     is_flag=True,
@@ -180,18 +171,18 @@ def generate(**kwargs: Any):
             config.output.package = kwargs["package"]
     else:
         config = GeneratorConfig()
-        config.output.format = OutputFormat(value=kwargs["output"])
+        config.output.format = OutputFormat(
+            value=kwargs["output"], relative_imports=kwargs["relative_imports"]
+        )
         config.output.package = kwargs["package"]
         config.output.compound_fields = kwargs["compound_fields"]
         config.output.docstring_style = DocstringStyle(kwargs["docstring_style"])
 
-    if kwargs["ns_struct"]:
-        config.output.structure = StructureStyle.NAMESPACES
-        logger.warning(
-            "--ns-struct is deprecated switch to '--structure-style namespaces'"
-        )
-    elif kwargs["structure_style"] != StructureStyle.FILENAMES.value:
+    if kwargs["structure_style"] != StructureStyle.FILENAMES.value:
         config.output.structure = StructureStyle(kwargs["structure_style"])
+
+    if kwargs["relative_imports"]:
+        config.output.format.relative_imports = True
 
     uris = resolve_source(kwargs["source"])
     transformer = SchemaTransformer(config=config, print=kwargs["print"])

--- a/xsdata/codegen/handlers/attribute_compound_choice.py
+++ b/xsdata/codegen/handlers/attribute_compound_choice.py
@@ -1,3 +1,4 @@
+from operator import attrgetter
 from typing import List
 
 from xsdata.codegen.mixins import HandlerInterface
@@ -17,7 +18,7 @@ class AttributeCompoundChoiceHandler(HandlerInterface):
     __slots__ = ()
 
     def process(self, target: Class):
-        groups = group_by(target.attrs, lambda x: x.restrictions.choice)
+        groups = group_by(target.attrs, attrgetter("restrictions.choice"))
         for choice, attrs in groups.items():
             if choice and len(attrs) > 1 and any(attr.is_list for attr in attrs):
                 self.group_fields(target, attrs)

--- a/xsdata/codegen/handlers/attribute_group.py
+++ b/xsdata/codegen/handlers/attribute_group.py
@@ -1,9 +1,10 @@
+from operator import attrgetter
+
 from xsdata.codegen.mixins import RelativeHandlerInterface
 from xsdata.codegen.models import Attr
 from xsdata.codegen.models import Class
 from xsdata.codegen.utils import ClassUtils
 from xsdata.exceptions import AnalyzerValueError
-from xsdata.models.enums import Tag
 
 
 class AttributeGroupHandler(RelativeHandlerInterface):
@@ -36,9 +37,7 @@ class AttributeGroupHandler(RelativeHandlerInterface):
         :raises AnalyzerValueError: if source class is not found.
         """
         qname = attr.types[0].qname  # group attributes have one type only.
-        source = self.container.find(
-            qname, condition=lambda x: x.tag in (Tag.ATTRIBUTE_GROUP, Tag.GROUP)
-        )
+        source = self.container.find(qname, condition=attrgetter("is_group"))
 
         if not source:
             raise AnalyzerValueError(f"Group attribute not found: `{qname}`")

--- a/xsdata/codegen/models.py
+++ b/xsdata/codegen/models.py
@@ -210,6 +210,10 @@ class AttrType:
     circular: bool = field(default=False)
 
     @property
+    def datatype(self) -> Optional[DataType]:
+        return DataType.from_qname(self.qname) if self.native else None
+
+    @property
     def name(self) -> str:
         """Shortcut for qname local name."""
         return namespaces.local_name(self.qname)
@@ -221,10 +225,6 @@ class AttrType:
         return not (
             self.forward or self.native or (not allow_circular and self.circular)
         )
-
-    @property
-    def datatype(self) -> Optional[DataType]:
-        return DataType.from_qname(self.qname) if self.native else None
 
     def clone(self) -> "AttrType":
         """Return a deep cloned instance."""
@@ -464,6 +464,12 @@ class Class:
         """Return whether this instance is derived from an non abstract
         xs:element."""
         return self.tag == Tag.ELEMENT
+
+    @property
+    def is_group(self) -> bool:
+        """Return whether this attribute is derived from an xs:group or
+        xs:attributeGroup."""
+        return self.tag in (Tag.ATTRIBUTE_GROUP, Tag.GROUP)
 
     @property
     def is_enumeration(self) -> bool:

--- a/xsdata/codegen/writer.py
+++ b/xsdata/codegen/writer.py
@@ -49,12 +49,12 @@ class CodeWriter:
 
     @classmethod
     def from_config(cls, config: GeneratorConfig) -> "CodeWriter":
-        if config.output.format not in cls.generators:
+        if config.output.format.value not in cls.generators:
             raise CodeGenerationError(
-                f"Unknown output format: '{config.output.format}'"
+                f"Unknown output format: '{config.output.format.value}'"
             )
 
-        generator_class = cls.generators[config.output.format]
+        generator_class = cls.generators[config.output.format.value]
         return cls(generator=generator_class(config))
 
     @classmethod

--- a/xsdata/formats/dataclass/generator.py
+++ b/xsdata/formats/dataclass/generator.py
@@ -29,7 +29,7 @@ class DataclassGenerator(AbstractGenerator):
 
         tpl_dir = Path(__file__).parent.joinpath("templates")
         self.env = Environment(loader=FileSystemLoader(str(tpl_dir)), autoescape=False)
-        self.filters = Filters.from_config(config)
+        self.filters = Filters(config)
         self.filters.register(self.env)
 
     def render(self, classes: List[Class]) -> Iterator[GeneratorResult]:
@@ -37,29 +37,30 @@ class DataclassGenerator(AbstractGenerator):
         Return a iterator of the generated results.
 
         Group classes into modules and yield an output per module and
-        per package __init__.py file.
+        per path __init__.py file.
         """
         packages = {obj.qname: obj.target_module for obj in classes}
         resolver = DependenciesResolver(packages=packages)
 
         # Generate packages
-        for package, cluster in self.group_by_package(classes).items():
+        for path, cluster in self.group_by_package(classes).items():
+            module = ".".join(path.relative_to(Path.cwd()).parts)
             yield GeneratorResult(
-                path=package.joinpath("__init__.py"),
+                path=path.joinpath("__init__.py"),
                 title="init",
-                source=self.render_package(cluster),
+                source=self.render_package(cluster, module),
             )
-            yield from self.ensure_packages(package.parent)
+            yield from self.ensure_packages(path.parent)
 
         # Generate modules
-        for module, cluster in self.group_by_module(classes).items():
+        for path, cluster in self.group_by_module(classes).items():
             yield GeneratorResult(
-                path=module.with_suffix(".py"),
+                path=path.with_suffix(".py"),
                 title=cluster[0].target_module,
                 source=self.render_module(resolver, cluster),
             )
 
-    def render_package(self, classes: List[Class]) -> str:
+    def render_package(self, classes: List[Class], module: str) -> str:
         """Render the source code for the __init__.py with all the imports of
         the generated class names."""
 
@@ -80,7 +81,10 @@ class DataclassGenerator(AbstractGenerator):
                 add = "_".join(part for part in parts if part in diff)
                 cur.alias = f"{add}:{cur.name}"
 
-        output = self.env.get_template("package.jinja2").render(imports=imports)
+        output = self.env.get_template("package.jinja2").render(
+            imports=imports,
+            module=module,
+        )
         return f"{output.strip()}\n"
 
     def render_module(
@@ -92,9 +96,13 @@ class DataclassGenerator(AbstractGenerator):
         imports = resolver.sorted_imports()
         output = self.render_classes(resolver.sorted_classes())
         namespace = classes[0].target_namespace
+        module = classes[0].target_module
 
         return self.env.get_template("module.jinja2").render(
-            output=output, imports=imports, namespace=namespace
+            output=output,
+            module=module,
+            imports=imports,
+            namespace=namespace,
         )
 
     def render_classes(self, classes: List[Class]) -> str:

--- a/xsdata/formats/dataclass/templates/imports.jinja2
+++ b/xsdata/formats/dataclass/templates/imports.jinja2
@@ -1,18 +1,10 @@
-{% macro import_statement(item) -%}
-    {% if item.alias %}
-        {{- "{} as {}".format(item.name|class_name, item.alias|class_name) -}}
-    {% else %}
-        {{- item.name|class_name -}}
-    {% endif %}
-{%- endmacro %}
-
 {%- for source, items in imports|groupby("source") -%}
 {%- if items|length == 1 -%}
-from {{ source }} import {{ import_statement(items[0]) }}
+from {{ source | import_module(module)  }} import {{ items[0].name | import_class(alias=items[0].alias) }}
 {% else -%}
-from {{ source }} import (
+from {{ source | import_module(module) }} import (
 {%- for item in items %}
-    {{ import_statement(item) }},
+    {{ item.name | import_class(alias=item.alias) }},
 {%- endfor %}
 )
 {% endif -%}

--- a/xsdata/models/config.py
+++ b/xsdata/models/config.py
@@ -1,4 +1,3 @@
-import warnings
 from dataclasses import dataclass
 from dataclasses import field
 from enum import Enum
@@ -126,16 +125,15 @@ class DocstringStyle(Enum):
 
 @dataclass
 class OutputFormat:
+    """
+    Output format options.
+
+    :param value: Name of the format
+    :param relative_imports: Enable relative imports
+    """
+
     value: str = field(default="dataclasses")
     relative_imports: bool = attribute(default=False)
-
-    def __post_init__(self):
-        if self.value == "pydata":
-            warnings.warn(
-                "Output format 'pydata' renamed to 'dataclasses'",
-                DeprecationWarning,
-            )
-            self.value = "dataclasses"
 
 
 @dataclass

--- a/xsdata/models/config.py
+++ b/xsdata/models/config.py
@@ -1,5 +1,6 @@
 import warnings
 from dataclasses import dataclass
+from dataclasses import field
 from enum import Enum
 from pathlib import Path
 from typing import Any
@@ -124,6 +125,20 @@ class DocstringStyle(Enum):
 
 
 @dataclass
+class OutputFormat:
+    value: str = field(default="dataclasses")
+    relative_imports: bool = attribute(default=False)
+
+    def __post_init__(self):
+        if self.value == "pydata":
+            warnings.warn(
+                "Output format 'pydata' renamed to 'dataclasses'",
+                DeprecationWarning,
+            )
+            self.value = "dataclasses"
+
+
+@dataclass
 class GeneratorOutput:
     """
     Main generator output options.
@@ -139,18 +154,10 @@ class GeneratorOutput:
 
     max_line_length: int = attribute(default=79)
     package: str = element(default="generated")
-    format: str = element(default="dataclasses")
+    format: OutputFormat = element(default_factory=OutputFormat)
     structure: StructureStyle = element(default=StructureStyle.FILENAMES)
     docstring_style: DocstringStyle = element(default=DocstringStyle.RST)
     compound_fields: bool = element(default=False)
-
-    def __post_init__(self):
-        if self.format == "pydata":
-            warnings.warn(
-                "Output format 'pydata' renamed to 'dataclasses'",
-                DeprecationWarning,
-            )
-            self.format = "dataclasses"
 
 
 @dataclass

--- a/xsdata/models/mixins.py
+++ b/xsdata/models/mixins.py
@@ -14,7 +14,6 @@ from xsdata.models.enums import DataType
 from xsdata.models.enums import FormType
 from xsdata.models.enums import Namespace
 from xsdata.models.enums import NamespaceType
-from xsdata.utils import collections
 from xsdata.utils import text
 from xsdata.utils.constants import return_true
 
@@ -168,7 +167,11 @@ class ElementBase:
     @property
     def xs_prefix(self) -> Optional[str]:
         """Return the xml schema uri prefix."""
-        return collections.map_key(self.ns_map, Namespace.XS.uri)
+        for prefix, uri in self.ns_map.items():
+            if uri == Namespace.XS.uri:
+                return prefix
+
+        return None
 
     def get_restrictions(self) -> Dict[str, Any]:
         """Return the restrictions dictionary of this element."""

--- a/xsdata/utils/collections.py
+++ b/xsdata/utils/collections.py
@@ -11,10 +11,10 @@ from typing import Sequence
 
 def unique_sequence(items: Iterable, key: Optional[str] = None) -> List:
     """
-    Return a new list with the unique values from the sequence.
+    Return a new list with the unique values from an iterable.
 
     Optionally you can also provide a lambda to generate the unique key
-    of each item in the sequence.
+    of each item in the iterable object.
     """
     seen = set()
 
@@ -37,15 +37,20 @@ def remove(items: Iterable, predicate: Callable) -> List:
 
 
 def group_by(items: Iterable, key: Callable) -> Dict[Any, List]:
-    """Group the items of a sequence by the result of the callable."""
+    """Group the items of an iterable object by the result of the callable."""
     result = defaultdict(list)
     for item in items:
         result[key(item)].append(item)
     return result
 
 
+def index_by(items: Iterable, key: Callable) -> Dict[Any, Any]:
+    """Index the items of an iterable object by the result of the callable."""
+    return {key(item): item for item in items}
+
+
 def apply(items: Iterable, func: Callable):
-    """Apply the given function to each item of the sequence."""
+    """Apply the given function to each item of the iterable object."""
     for item in items:
         func(item)
 
@@ -62,15 +67,6 @@ def find(items: Sequence, value: Any) -> int:
 def first(items: Iterator) -> Any:
     """Return the first item of the iterator."""
     return next(items, None)
-
-
-def map_key(dictionary: Dict, search: Any) -> Any:
-    """Find and return they key for given search value."""
-    for key, value in dictionary.items():
-        if value == search:
-            return key
-
-    return None
 
 
 def prepend(target: List, *args: Any):

--- a/xsdata/utils/collections.py
+++ b/xsdata/utils/collections.py
@@ -44,11 +44,6 @@ def group_by(items: Iterable, key: Callable) -> Dict[Any, List]:
     return result
 
 
-def index_by(items: Iterable, key: Callable) -> Dict[Any, Any]:
-    """Index the items of an iterable object by the result of the callable."""
-    return {key(item): item for item in items}
-
-
 def apply(items: Iterable, func: Callable):
     """Apply the given function to each item of the iterable object."""
     for item in items:


### PR DESCRIPTION
### Implement relative imports option

Currently the generator assumes your are running it from the root directory of a project and generates only absolute imports. If that's not the case you have to manually edit all imports to reflect the true structure of the models.

### Enable through cli flag

Use `--relative-imports` or `-ri`

### Enable through the generator configuration

```xml
<?xml version="1.0" encoding="UTF-8"?>
<Config xmlns="http://pypi.org/project/xsdata" version="21.6">
  <Output maxLineLength="79">
    <Package>autosar.models</Package>
    <Format relativeImports="true">dataclasses</Format>  <!-- default is false -->
    <Structure>clusters</Structure>
    <DocstringStyle>reStructuredText</DocstringStyle>
    <CompoundFields>false</CompoundFields>
  </Output>
...
</Config>
```