### PR TITLE
Add model target_namespace meta property

### DIFF
--- a/docs/api/xml-nodes.rst
+++ b/docs/api/xml-nodes.rst
@@ -12,7 +12,6 @@ for models and their fields.
     :template: dataclass.rst
     :nosignatures:
 
-    XmlNode
     ElementNode
     WildcardNode
     UnionNode

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -104,6 +104,10 @@ procedures.
    * - namespace
      - str
      - The element xml namespace.
+   * - target_namespace
+     - str
+     - Specify the element target namespace for auto type locator, if module namespace
+       is not available or the type is not qualified.
    * - element_name_generator
      - Callable
      - Element name generator

--- a/tests/formats/dataclass/models/test_builders.py
+++ b/tests/formats/dataclass/models/test_builders.py
@@ -103,6 +103,21 @@ class XmlMetaBuilderTests(FactoryTestCase):
 
         self.assertEqual(f"Type '{int}' is not a dataclass.", str(cm.exception))
 
+    def test_target_namespace(self):
+        class Meta:
+            namespace = "bar"
+            target_namespace = "foo"
+
+        self.assertEqual("foo", self.builder.target_namespace(None, Meta))
+
+        del Meta.target_namespace
+        self.assertEqual("bar", self.builder.target_namespace(None, Meta))
+
+        class Module:
+            __NAMESPACE__ = "gl"
+
+        self.assertEqual("gl", self.builder.target_namespace(Module, Meta))
+
     def test_build_vars(self):
         result = self.builder.build_vars(BookForm, None, text.pascal_case, str.upper)
         self.assertIsInstance(result, Iterator)

--- a/tests/formats/dataclass/test_context.py
+++ b/tests/formats/dataclass/test_context.py
@@ -39,7 +39,7 @@ class XmlContextTests(FactoryTestCase):
         meta = XmlMetaFactory.create(
             clazz=Artist,
             qname="Artist",
-            source_qname="Artist",
+            target_qname="Artist",
             nillable=False,
         )
 

--- a/tests/formats/dataclass/test_elements.py
+++ b/tests/formats/dataclass/test_elements.py
@@ -143,7 +143,7 @@ class XmlMetaTests(TestCase):
             "XmlMeta("
             "clazz=<class 'tests.fixtures.models.TypeA'>, "
             "qname='a', "
-            "source_qname='a', "
+            "target_qname='a', "
             "nillable=False, "
             "text=None, "
             "choices=[], "

--- a/tests/formats/dataclass/test_generator.py
+++ b/tests/formats/dataclass/test_generator.py
@@ -147,6 +147,51 @@ class DataclassGeneratorTests(FactoryTestCase):
 
         self.assertEqual(expected, actual)
 
+    def test_render_module_with_mixed_target_namespaces(self):
+        classes = [
+            ClassFactory.elements(1, qname="{foo}bar"),
+            ClassFactory.elements(1, qname="{bar}foo"),
+        ]
+        resolver = DependenciesResolver({})
+
+        actual = self.generator.render_module(resolver, classes)
+        expected = (
+            "from dataclasses import dataclass, field\n"
+            "from typing import Optional\n"
+            "\n"
+            "\n"
+            "@dataclass\n"
+            "class Foo:\n"
+            "    class Meta:\n"
+            '        name = "foo"\n'
+            '        target_namespace = "bar"\n'
+            "\n"
+            "    attr_c: Optional[str] = field(\n"
+            "        default=None,\n"
+            "        metadata={\n"
+            '            "name": "attr_C",\n'
+            '            "type": "Element",\n'
+            "        }\n"
+            "    )\n"
+            "\n"
+            "\n"
+            "@dataclass\n"
+            "class Bar:\n"
+            "    class Meta:\n"
+            '        name = "bar"\n'
+            '        target_namespace = "foo"\n'
+            "\n"
+            "    attr_b: Optional[str] = field(\n"
+            "        default=None,\n"
+            "        metadata={\n"
+            '            "name": "attr_B",\n'
+            '            "type": "Element",\n'
+            "        }\n"
+            "    )\n"
+        )
+
+        self.assertEqual(expected, actual)
+
     def test_module_name(self):
         self.assertEqual("foo_bar", self.generator.module_name("fooBar"))
         self.assertEqual("foo_bar_wtf", self.generator.module_name("fooBar.wtf"))

--- a/xsdata/formats/dataclass/context.py
+++ b/xsdata/formats/dataclass/context.py
@@ -73,7 +73,7 @@ class XmlContext:
         """
         meta = self.build(clazz, parent_ns)
         subclass = None
-        if xsi_type and meta.source_qname != xsi_type:
+        if xsi_type and meta.target_qname != xsi_type:
             subclass = self.find_subclass(clazz, xsi_type)
 
         return self.build(subclass, parent_ns) if subclass else meta
@@ -86,12 +86,11 @@ class XmlContext:
 
         self.xsi_cache.clear()
 
+        name_generator = self.element_name_generator
         for clazz in self.get_subclasses(object):
             if self.class_type.is_model(clazz):
-                source_qname = XmlMetaBuilder.build_source_qname(
-                    clazz, self.element_name_generator
-                )
-                self.xsi_cache[source_qname].append(clazz)
+                qname = XmlMetaBuilder.build_target_qname(clazz, name_generator)
+                self.xsi_cache[qname].append(clazz)
 
         self.sys_modules = len(sys.modules)
 

--- a/xsdata/formats/dataclass/models/elements.py
+++ b/xsdata/formats/dataclass/models/elements.py
@@ -265,7 +265,7 @@ class XmlMeta(MetaMixin):
 
     :param clazz: The dataclass type
     :param qname: The namespace qualified name.
-    :param source_qname: The source namespace qualified name.
+    :param target_qname: The target namespace qualified name.
     :param nillable: Specifies whether an explicit empty value can be assigned.
     :param mixed_content: Has a wildcard with mixed flag enabled
     :param text: Text var
@@ -279,7 +279,7 @@ class XmlMeta(MetaMixin):
     __slots__ = (
         "clazz",
         "qname",
-        "source_qname",
+        "target_qname",
         "nillable",
         "text",
         "choices",
@@ -296,7 +296,7 @@ class XmlMeta(MetaMixin):
         self,
         clazz: Type,
         qname: str,
-        source_qname: str,
+        target_qname: str,
         nillable: bool,
         text: Optional[XmlVar],
         choices: Sequence[XmlVar],
@@ -309,7 +309,7 @@ class XmlMeta(MetaMixin):
         self.clazz = clazz
         self.qname = qname
         self.namespace = target_uri(qname)
-        self.source_qname = source_qname
+        self.target_qname = target_qname
         self.nillable = nillable
         self.text = text
         self.choices = choices

--- a/xsdata/formats/dataclass/serializers/xml.py
+++ b/xsdata/formats/dataclass/serializers/xml.py
@@ -76,7 +76,7 @@ class XmlSerializer(AbstractSerializer):
         qname = xsi_type = None
         if isinstance(obj, self.context.class_type.derived_element):
             meta = self.context.build(obj.value.__class__)
-            xsi_type = QName(meta.source_qname)
+            xsi_type = QName(meta.target_qname)
             qname = obj.qname
             obj = obj.value
 
@@ -192,7 +192,7 @@ class XmlSerializer(AbstractSerializer):
             xsi_type = None
             if value.type:
                 meta = self.context.build(value.value.__class__)
-                xsi_type = QName(meta.source_qname)
+                xsi_type = QName(meta.target_qname)
 
             yield from self.write_dataclass(
                 value.value, namespace, qname=value.qname, xsi_type=xsi_type
@@ -233,7 +233,7 @@ class XmlSerializer(AbstractSerializer):
         clazz = var.clazz
         if clazz is None or self.context.is_derived(value, clazz):
             meta = self.context.fetch(value.__class__, namespace)
-            return QName(meta.source_qname)
+            return QName(meta.target_qname)
 
         raise SerializerError(
             f"{value.__class__.__name__} is not derived from {clazz.__name__}"

--- a/xsdata/formats/dataclass/templates/class.jinja2
+++ b/xsdata/formats/dataclass/templates/class.jinja2
@@ -7,14 +7,15 @@
 {% set class_name =  obj.name|class_name -%}
 {% set local_name =  obj.meta_name or obj.name -%}
 {% set local_name = None if class_name == local_name or parents|length != 1 else local_name -%}
-{% set base_classes = obj.extensions|map(attribute='type')|map('type_name')|join(', ') %}
+{% set base_classes = obj.extensions|map(attribute='type')|map('type_name')|join(', ') -%}
+{% set target_namespace = obj.target_namespace if level == 0 and module_namespace != obj.target_namespace else None %}
 
 @dataclass
 class {{ class_name }}{{"({})".format(base_classes) if base_classes }}:
 {%- if help %}
 {{ help|indent(4, first=True) }}
 {%- endif -%}
-{%- if local_name or obj.is_nillable or obj.namespace is not none %}
+{%- if local_name or obj.is_nillable or obj.namespace is not none or target_namespace %}
     class Meta:
         {%- if local_name %}
         name = "{{ local_name }}"
@@ -24,6 +25,9 @@ class {{ class_name }}{{"({})".format(base_classes) if base_classes }}:
         {%- endif -%}
         {%- if obj.namespace is not none %}
         namespace = "{{ obj.namespace }}"
+        {%- endif %}
+        {%- if target_namespace and target_namespace != obj.namespace %}
+        target_namespace = "{{ target_namespace }}"
         {%- endif %}
 {% elif obj.attrs|length == 0 and not help %}
     pass

--- a/xsdata/utils/testing.py
+++ b/xsdata/utils/testing.py
@@ -404,7 +404,7 @@ class XmlMetaFactory(Factory):
         cls,
         clazz: Type,
         qname: Optional[str] = None,
-        source_qname: Optional[str] = None,
+        target_qname: Optional[str] = None,
         nillable: bool = False,
         text: Optional[XmlVar] = None,
         choices: Optional[Sequence[XmlVar]] = None,
@@ -418,8 +418,8 @@ class XmlMetaFactory(Factory):
         if qname is None:
             qname = clazz.__name__
 
-        if source_qname is None:
-            source_qname = qname
+        if target_qname is None:
+            target_qname = qname
 
         if choices is None:
             choices = []
@@ -439,7 +439,7 @@ class XmlMetaFactory(Factory):
         return XmlMeta(
             clazz=clazz,
             qname=qname,
-            source_qname=source_qname,
+            target_qname=target_qname,
             nillable=nillable,
             text=text,
             choices=choices,


### PR DESCRIPTION
Notes:
This property can bypass the module namespace, usefull.
if the target module involves more than one namespace

Priority order meta.target_namespace > module namespace > meta.namespace