### PR TITLE
AttributeTypeHandler: allow bare types

### DIFF
--- a/tests/models/xsd/test_attribute.py
+++ b/tests/models/xsd/test_attribute.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 from xsdata.exceptions import SchemaValueError
+from xsdata.models.enums import Namespace
 from xsdata.models.enums import UseType
 from xsdata.models.xsd import Attribute
 from xsdata.models.xsd import Length
@@ -64,7 +65,12 @@ class AttributeTests(TestCase):
 
     def test_property_bases(self):
         obj = Attribute()
+        obj.ns_map["xs"] = Namespace.XS.uri
+        self.assertEqual(["xs:string"], list(obj.bases))
+
+        obj.simple_type = SimpleType()
         self.assertEqual([], list(obj.bases))
 
         obj.type = "foo"
+        obj.simple_type = None
         self.assertEqual(["foo"], list(obj.bases))

--- a/xsdata/codegen/handlers/attribute_type.py
+++ b/xsdata/codegen/handlers/attribute_type.py
@@ -110,15 +110,15 @@ class AttributeTypeHandler(RelativeHandlerInterface):
         Process an attributes type that depends on any global type.
 
         Strategies:
-            1. Reset absent or dummy attribute types with a warning
+            1. Reset absent types with a warning
             2. Copy attribute properties from a simple type
             3. Copy format restriction from an enumeration
             4. Set circular flag for the rest
         """
 
         source = self.find_dependency(attr_type, attr.tag)
-        if not source or (not source.attrs and not source.extensions):
-            logger.warning("Reset dummy type: %s", attr_type.name)
+        if not source:
+            logger.warning("Reset absent type: %s", attr_type.name)
             use_str = not source or not source.is_complex
             self.reset_attribute_type(attr_type, use_str)
         elif source.is_simple_type:
@@ -167,6 +167,8 @@ class AttributeTypeHandler(RelativeHandlerInterface):
 
         attr.restrictions = restrictions
         attr.help = attr.help or source_attr.help
+        attr.fixed = attr.fixed or source_attr.fixed
+        attr.default = attr.default or source_attr.default
 
     def set_circular_flag(self, source: Class, target: Class, attr_type: AttrType):
         """Update circular reference flag."""

--- a/xsdata/models/xsd.py
+++ b/xsdata/models/xsd.py
@@ -315,6 +315,8 @@ class Attribute(AnnotationBase):
     def bases(self) -> Iterator[str]:
         if self.type:
             yield self.type
+        elif not self.has_children:
+            yield DataType.STRING.prefixed(self.xs_prefix)
 
     @property
     def is_attribute(self) -> bool:


### PR DESCRIPTION
resolves #540 

This is one of the oldest hacks in the code generation process. I guess  I could't figure out how certain types weren't flattened and weren't generated either. It turns out I didn't set the default base type for xs:attributes.

