### PR TITLE
Add support for choice elements with maxOccurs=1

### DIFF
--- a/tests/fixtures/compound/models.py
+++ b/tests/fixtures/compound/models.py
@@ -49,5 +49,6 @@ class Root:
                     "type": Bravo,
                 },
             ),
+            "min_occurs": 1,
         }
     )

--- a/tests/models/xsd/test_choice.py
+++ b/tests/models/xsd/test_choice.py
@@ -10,7 +10,7 @@ class ChoiceTests(TestCase):
 
         expected = {
             "choice": str(id(obj)),
-            "min_occurs": 0,
+            "min_occurs": 1,
             "max_occurs": 2,
         }
         self.assertEqual(expected, obj.get_restrictions())
@@ -18,7 +18,7 @@ class ChoiceTests(TestCase):
         obj = Choice(max_occurs="unbounded")
         expected = {
             "choice": str(id(obj)),
-            "min_occurs": 0,
+            "min_occurs": 1,
             "max_occurs": sys.maxsize,
         }
         self.assertEqual(expected, obj.get_restrictions())

--- a/xsdata/codegen/handlers/attribute_compound_choice.py
+++ b/xsdata/codegen/handlers/attribute_compound_choice.py
@@ -29,7 +29,7 @@ class AttributeCompoundChoiceHandler(RelativeHandlerInterface):
         if self.compound_fields:
             groups = group_by(target.attrs, get_restriction_choice)
             for choice, attrs in groups.items():
-                if choice and len(attrs) > 1 and any(attr.is_list for attr in attrs):
+                if choice and len(attrs) > 1 and any(attr.is_list or get_restriction_choice(attr) for attr in attrs):
                     self.group_fields(target, attrs)
 
         for index in range(len(target.attrs)):

--- a/xsdata/codegen/handlers/attribute_compound_choice.py
+++ b/xsdata/codegen/handlers/attribute_compound_choice.py
@@ -29,7 +29,13 @@ class AttributeCompoundChoiceHandler(RelativeHandlerInterface):
         if self.compound_fields:
             groups = group_by(target.attrs, get_restriction_choice)
             for choice, attrs in groups.items():
-                if choice and len(attrs) > 1 and any(attr.is_list or get_restriction_choice(attr) for attr in attrs):
+                if (
+                    choice
+                    and len(attrs) > 1
+                    and any(
+                        attr.is_list or get_restriction_choice(attr) for attr in attrs
+                    )
+                ):
                     self.group_fields(target, attrs)
 
         for index in range(len(target.attrs)):

--- a/xsdata/models/xsd.py
+++ b/xsdata/models/xsd.py
@@ -503,12 +503,11 @@ class Choice(AnnotationBase):
     any: Array["Any"] = array_element()
 
     def get_restrictions(self) -> Dict[str, Anything]:
-        min_occurs = self.min_occurs if self.min_occurs > 1 else 0
         max_occurs = sys.maxsize if self.max_occurs == "unbounded" else self.max_occurs
 
         return {
             "choice": str(id(self)),
-            "min_occurs": min_occurs,
+            "min_occurs": self.min_occurs,
             "max_occurs": max_occurs,
         }
 


### PR DESCRIPTION
Fixes #561. Compound field logic was ignoring elements with maxOccurs=1 because this will cause attrs.is_list to return False. Updated this to include choice elements. Also removed the logic that minOccurs=1 will be changed to 0 on choice elements.

sample xml:
```xml
<xs:complexType name="DeemedRateType2Choice">
    <xs:choice minOccurs="1" maxOccurs="1">
        <xs:element name="Cd" type="DeemedRateType1Code"/>
        <xs:element name="Prtry" type="GenericIdentification47"/>
    </xs:choice>
</xs:complexType>
```

generated class:
```python
@dataclass
class DeemedRateType2Choice:
    cd_or_prtry: Optional[object] = field(
        default=None,
        metadata={
            "type": "Elements",
            "choices": (
                {
                    "name": "Cd",
                    "type": DeemedRateType1Code,
                    "namespace": "urn:iso:std:iso:20022:tech:xsd:seev.036.002.09",
                },
                {
                    "name": "Prtry",
                    "type": GenericIdentification47,
                    "namespace": "urn:iso:std:iso:20022:tech:xsd:seev.036.002.09",
                },
            ),
            "required": True,
        }
    )
```