### PR TITLE
Add warning on unexpected duplicate types

### DIFF
--- a/tests/codegen/test_validator.py
+++ b/tests/codegen/test_validator.py
@@ -60,21 +60,23 @@ class ClassValidatorTests(FactoryTestCase):
         self.validator.remove_invalid_classes(classes)
         self.assertEqual([second, third], classes)
 
-    @mock.patch.object(ClassValidator, "select_winner")
-    def test_handle_duplicate_types(self, mock_select_winner):
+    @mock.patch("xsdata.codegen.mappers.definitions.logger.warning")
+    def test_handle_duplicate_types(self, mock_warning):
 
-        one = ClassFactory.create()
+        one = ClassFactory.create(tag=Tag.ELEMENT)
         two = one.clone()
         three = one.clone()
-        four = ClassFactory.create()
-
-        mock_select_winner.return_value = 0
+        four = ClassFactory.create(tag=Tag.ATTRIBUTE)
 
         classes = [one, two, three, four]
 
         self.validator.handle_duplicate_types(classes)
-        self.assertEqual([one, four], classes)
-        mock_select_winner.assert_called_once_with([one, two, three])
+        self.assertEqual([three, four], classes)
+        mock_warning.assert_called_once_with(
+            "Duplicate types (%d) found: %s, will keep the last defined",
+            3,
+            "{xsdata}class_B",
+        )
 
     @mock.patch.object(ClassValidator, "merge_redefined_type")
     @mock.patch.object(ClassValidator, "select_winner")

--- a/xsdata/codegen/models.py
+++ b/xsdata/codegen/models.py
@@ -579,6 +579,7 @@ class Import:
 get_location = operator.attrgetter("location")
 get_name = operator.attrgetter("name")
 get_qname = operator.attrgetter("qname")
+get_tag = operator.attrgetter("tag")
 get_restriction_choice = operator.attrgetter("restrictions.choice")
 get_slug = operator.attrgetter("slug")
 get_target_namespace = operator.attrgetter("target_namespace")

--- a/xsdata/codegen/validator.py
+++ b/xsdata/codegen/validator.py
@@ -5,7 +5,9 @@ from xsdata.codegen.container import ClassContainer
 from xsdata.codegen.models import Attr
 from xsdata.codegen.models import Class
 from xsdata.codegen.models import Extension
+from xsdata.codegen.models import get_tag
 from xsdata.codegen.utils import ClassUtils
+from xsdata.logger import logger
 from xsdata.models.enums import Tag
 from xsdata.utils import collections
 from xsdata.utils.collections import group_by
@@ -57,12 +59,19 @@ class ClassValidator:
         """Handle classes with same namespace, name that are derived from the
         same xs type."""
 
-        grouped = group_by(classes, lambda x: f"{x.tag}{x.qname}")
-        for items in grouped.values():
+        for items in group_by(classes, get_tag).values():
             if len(items) == 1:
                 continue
 
             index = cls.select_winner(list(items))
+
+            if index == -1:
+                logger.warning(
+                    "Duplicate types (%d) found: %s, will keep the last defined",
+                    len(items),
+                    items[0].qname,
+                )
+
             winner = items.pop(index)
 
             for item in items:


### PR DESCRIPTION
Resolve #564


```console
 xsdata xsdata-w3c-tests/w3c/msData/particles/particlesJs001.xsd
Parsing schema particlesJs001.xsd
Parsing schema particlesJs001.imp
Compiling schema particlesJs001.imp
Builder: 4 main and 0 inner classes
Compiling schema particlesJs001.xsd
Builder: 3 main and 0 inner classes
Analyzer input: 7 main and 0 inner classes
warning: Duplicate types (2) found: {http://xsdtesting}B, will keep the last defined!
Analyzer output: 6 main and 0 inner classes
Generating package: init
Generating package: generated.particles_js001
Generating package: generated.particles_js001_imp


```