### PR TITLE
Deprecate JsonSerializer.indent prop

### DIFF
--- a/docs/json.rst
+++ b/docs/json.rst
@@ -211,6 +211,7 @@ Serialize json to string
 
     >>> from xsdata.formats.dataclass.context import XmlContext
     >>> from xsdata.formats.dataclass.serializers import JsonSerializer
+    >>> from xsdata.formats.dataclass.serializers.config import SerializerConfig
     >>> from xsdata.models.datatype import XmlDate
     >>> books = Books(
     ...    book=[
@@ -232,7 +233,8 @@ Serialize json to string
     ...        ),
     ...    ]
     ... )
-    >>> serializer = JsonSerializer(context=XmlContext(), indent=2)
+    >>> config = SerializerConfig(pretty_print=True)
+    >>> serializer = JsonSerializer(context=XmlContext(), config=config)
     >>> print(serializer.render(books))
     {
       "book": [
@@ -313,7 +315,8 @@ By using a custom dict factory you can change the output behaviour, like filter 
     ...     return {k: v for k, v in x if v is not None}
     >>>
     >>> books.book[0].genre = None
-    >>> serializer = JsonSerializer(dict_factory=filter_none, indent=2)
+    >>> config = SerializerConfig(pretty_print=True)
+    >>> serializer = JsonSerializer(dict_factory=filter_none, config=config)
     >>> print(serializer.render(books.book[0]))
     {
       "author": "Hightower, Kim",
@@ -346,4 +349,4 @@ other implementation as long as it's has a compatible signature.
 
     import ujson
 
-    serializer = JsonSerializer(dump_factory=ujson.dump, indent=0)
+    serializer = JsonSerializer(dump_factory=ujson.dump)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,8 @@ def validate_bindings(schema: Path, clazz: Type):
 
     sample = schema.parent.joinpath("sample.xml")
     obj = XmlParser().from_path(sample, clazz)
-    actual = JsonSerializer(indent=4).render(obj)
+    config = SerializerConfig(pretty_print=True)
+    actual = JsonSerializer(config=config).render(obj)
 
     expected = sample.with_suffix(".json")
     if expected.exists():

--- a/tests/fixtures/compound/sample.json
+++ b/tests/fixtures/compound/sample.json
@@ -1,28 +1,28 @@
 {
-    "alpha_or_bravo": [
-        {
-            "a": true
-        },
-        {
-            "a": true
-        },
-        {
-            "b": true
-        },
-        {
-            "b": true
-        },
-        {
-            "a": true
-        },
-        {
-            "b": true
-        },
-        {
-            "a": true
-        },
-        {
-            "b": true
-        }
-    ]
+  "alpha_or_bravo": [
+    {
+      "a": true
+    },
+    {
+      "a": true
+    },
+    {
+      "b": true
+    },
+    {
+      "b": true
+    },
+    {
+      "a": true
+    },
+    {
+      "b": true
+    },
+    {
+      "a": true
+    },
+    {
+      "b": true
+    }
+  ]
 }

--- a/tests/fixtures/primer/sample.json
+++ b/tests/fixtures/primer/sample.json
@@ -1,40 +1,40 @@
 {
-    "shipTo": {
-        "name": "Alice Smith",
-        "street": "123 Maple Street",
-        "city": "Mill Valley",
-        "state": "CA",
-        "zip": "90952",
-        "country": "US"
-    },
-    "billTo": {
-        "name": "Robert Smith",
-        "street": "8 Oak Avenue",
-        "city": "Old Town",
-        "state": "PA",
-        "zip": "95819",
-        "country": "US"
-    },
-    "comment": "Hurry, my lawn is going wild!",
-    "items": {
-        "item": [
-            {
-                "productName": "Lawnmower",
-                "quantity": 1,
-                "USPrice": "148.95",
-                "comment": "Confirm this is electric",
-                "shipDate": null,
-                "partNum": "872-AA"
-            },
-            {
-                "productName": "Baby Monitor",
-                "quantity": 1,
-                "USPrice": "39.98",
-                "comment": null,
-                "shipDate": "1999-05-21",
-                "partNum": "926-AA"
-            }
-        ]
-    },
-    "orderDate": "1999-10-20"
+  "shipTo": {
+    "name": "Alice Smith",
+    "street": "123 Maple Street",
+    "city": "Mill Valley",
+    "state": "CA",
+    "zip": "90952",
+    "country": "US"
+  },
+  "billTo": {
+    "name": "Robert Smith",
+    "street": "8 Oak Avenue",
+    "city": "Old Town",
+    "state": "PA",
+    "zip": "95819",
+    "country": "US"
+  },
+  "comment": "Hurry, my lawn is going wild!",
+  "items": {
+    "item": [
+      {
+        "productName": "Lawnmower",
+        "quantity": 1,
+        "USPrice": "148.95",
+        "comment": "Confirm this is electric",
+        "shipDate": null,
+        "partNum": "872-AA"
+      },
+      {
+        "productName": "Baby Monitor",
+        "quantity": 1,
+        "USPrice": "39.98",
+        "comment": null,
+        "shipDate": "1999-05-21",
+        "partNum": "926-AA"
+      }
+    ]
+  },
+  "orderDate": "1999-10-20"
 }

--- a/tests/formats/dataclass/serializers/test_json.py
+++ b/tests/formats/dataclass/serializers/test_json.py
@@ -1,5 +1,9 @@
 import json
+import warnings
 from unittest.case import TestCase
+from unittest.mock import ANY
+from unittest.mock import call
+from unittest.mock import Mock
 
 from tests.fixtures.books import BookForm
 from tests.fixtures.books import Books
@@ -86,3 +90,29 @@ class JsonSerializerTests(TestCase):
         serializer = JsonSerializer(dict_factory=DictFactory.FILTER_NONE)
         actual = serializer.convert(Telephone(30, 234, 56783), var)
         self.assertEqual("30-234-56783", actual)
+
+    def test_indent_deprecation(self):
+        dump_factory = Mock(json.dump)
+
+        with warnings.catch_warnings(record=True) as w:
+            serializer = JsonSerializer(dump_factory=dump_factory)
+            serializer.render(self.books)
+
+            serializer.config.pretty_print = True
+            serializer.render(self.books)
+
+            serializer.indent = 4
+            serializer.render(self.books)
+
+        dump_factory.assert_has_calls(
+            [
+                call(ANY, ANY, indent=None),
+                call(ANY, ANY, indent=2),
+                call(ANY, ANY, indent=4),
+            ]
+        )
+
+        self.assertEqual(
+            "JsonSerializer indent property is deprecated, use SerializerConfig",
+            str(w[-1].message),
+        )

--- a/tests/integration/test_series.py
+++ b/tests/integration/test_series.py
@@ -8,6 +8,7 @@ from tests import root
 from xsdata.cli import cli
 from xsdata.formats.dataclass.parsers import JsonParser
 from xsdata.formats.dataclass.serializers import JsonSerializer
+from xsdata.formats.dataclass.serializers.config import SerializerConfig
 from xsdata.utils.testing import load_class
 
 os.chdir(root)
@@ -27,7 +28,8 @@ def test_json_documents():
     clazz = load_class(result.output, "Series")
 
     parser = JsonParser()
-    serializer = JsonSerializer(indent=4)
+    config = SerializerConfig(pretty_print=True)
+    serializer = JsonSerializer(config=config)
 
     for i in range(1, 3):
         ori = filepath.joinpath(f"samples/show{i}.json").read_text()

--- a/tests/integration/test_stripe.py
+++ b/tests/integration/test_stripe.py
@@ -8,6 +8,7 @@ from tests import root
 from xsdata.cli import cli
 from xsdata.formats.dataclass.parsers import JsonParser
 from xsdata.formats.dataclass.serializers import JsonSerializer
+from xsdata.formats.dataclass.serializers.config import SerializerConfig
 from xsdata.utils.testing import load_class
 
 os.chdir(root)
@@ -32,7 +33,8 @@ def test_json_documents():
     clazz = load_class(result.output, "Balance")
 
     parser = JsonParser()
-    serializer = JsonSerializer(indent=4)
+    config = SerializerConfig(pretty_print=True)
+    serializer = JsonSerializer(config=config)
 
     for sample in filepath.joinpath("samples").glob("*.json"):
         ori = sample.read_text()


### PR DESCRIPTION
This has the potential to annoy a lot of people, but finally we inject the SerializerConfig to the JsonSerializer which is necessary for some features coming...

After this for all formats the default indent will be 2 spaces
