### PR TITLE
Preserve all repeatable choices

### DIFF
--- a/xsdata/cli.py
+++ b/xsdata/cli.py
@@ -12,6 +12,7 @@ from xsdata import __version__
 from xsdata.codegen.transformer import SchemaTransformer
 from xsdata.codegen.writer import CodeWriter
 from xsdata.logger import logger
+from xsdata.models.config import CompoundFieldStyle
 from xsdata.models.config import DocstringStyle
 from xsdata.models.config import GeneratorConfig
 from xsdata.models.config import OutputFormat
@@ -132,8 +133,7 @@ def download(source: str, output: str):
 @click.option(
     "-cf",
     "--compound-fields",
-    is_flag=True,
-    default=False,
+    default="simplify",
     help=(
         "Use compound fields for repeating choices in order to maintain elements "
         "ordering between data binding operations."
@@ -174,7 +174,7 @@ def generate(**kwargs: Any):
         config.output.format = OutputFormat(value=kwargs["output"])
         config.output.package = kwargs["package"]
         config.output.relative_imports = kwargs["relative_imports"]
-        config.output.compound_fields = kwargs["compound_fields"]
+        config.output.compound_fields = CompoundFieldStyle(kwargs["compound_fields"])
         config.output.docstring_style = DocstringStyle(kwargs["docstring_style"])
 
     if kwargs["structure_style"] != StructureStyle.FILENAMES.value:

--- a/xsdata/codegen/handlers/attribute_compound_choice.py
+++ b/xsdata/codegen/handlers/attribute_compound_choice.py
@@ -9,6 +9,7 @@ from xsdata.codegen.models import get_restriction_choice
 from xsdata.codegen.models import get_slug
 from xsdata.codegen.models import Restrictions
 from xsdata.codegen.utils import ClassUtils
+from xsdata.models.config import CompoundFieldStyle
 from xsdata.models.enums import DataType
 from xsdata.models.enums import Tag
 from xsdata.utils.collections import group_by
@@ -18,18 +19,19 @@ class AttributeCompoundChoiceHandler(RelativeHandlerInterface):
     """Group attributes that belong in the same choice and replace them by
     compound fields."""
 
-    __slots__ = "compound_fields"
+    __slots__ = "style"
 
     def __init__(self, container: ContainerInterface):
         super().__init__(container)
 
-        self.compound_fields = container.config.output.compound_fields
+        self.style = container.config.output.compound_fields
 
     def process(self, target: Class):
-        if self.compound_fields:
+        if self.style != CompoundFieldStyle.SIMPLIFY:
+            preserve = self.style == CompoundFieldStyle.PRESERVE
             groups = group_by(target.attrs, get_restriction_choice)
             for choice, attrs in groups.items():
-                if choice and len(attrs) > 1 and any(attr.is_list for attr in attrs):
+                if choice and len(attrs) > 1 and  (preserve or any(attr.is_list for attr in attrs)):
                     self.group_fields(target, attrs)
 
         for index in range(len(target.attrs)):

--- a/xsdata/formats/dataclass/models/builders.py
+++ b/xsdata/formats/dataclass/models/builders.py
@@ -129,7 +129,7 @@ class XmlMetaBuilder:
 
         for index, field in enumerate(self.class_type.get_fields(clazz)):
             var = builder.build(
-                index,
+                index + 1,
                 field.name,
                 type_hints[field.name],
                 field.metadata,
@@ -273,14 +273,14 @@ class XmlVarBuilder:
 
         elements = {}
         wildcards = []
-        for choice in self.build_choices(name, choices, origin, globalns):
+        for choice in self.build_choices(index, name, choices, origin, globalns):
             if choice.is_element:
                 elements[choice.qname] = choice
             else:  # choice.is_wildcard:
                 wildcards.append(choice)
 
         return XmlVar(
-            index=index + 1,
+            index=index,
             name=name,
             qname=qname,
             init=init,
@@ -302,12 +302,13 @@ class XmlVarBuilder:
         )
 
     def build_choices(
-        self, name: str, choices: List[Dict], factory: Callable, globalns: Any
+        self, index: int, name: str, choices: List[Dict], factory: Callable, globalns: Any
     ) -> Iterator[XmlVar]:
         """Build the binding metadata for a compound dataclass field."""
         existing_types: Set[type] = set()
 
-        for index, choice in enumerate(choices):
+
+        for point, choice in enumerate(choices):
             default_value = self.class_type.default_choice_value(choice)
 
             metadata = choice.copy()
@@ -320,7 +321,7 @@ class XmlVarBuilder:
                 metadata["type"] = XmlType.ELEMENT
 
             var = self.build(
-                index,
+                float(f"{index}.{point}"),
                 name,
                 type_hint,
                 metadata,

--- a/xsdata/models/config.py
+++ b/xsdata/models/config.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from dataclasses import field
 from enum import Enum
 from pathlib import Path
+from types import Union
 from typing import Any
 from typing import Callable
 from typing import Dict
@@ -127,6 +128,20 @@ class DocstringStyle(Enum):
     BLANK = "Blank"
 
 
+class CompoundFieldStyle(Enum):
+    """
+    Compound field style.
+
+    :cvar SIMPLIFY: simplify will only group mixed content elements
+    :cvar SELECT: select will group fields if necessary for elements ordering
+    :cvar PRESERVE: preserve will always group together repeatable elements
+    """
+
+    SIMPLIFY = "simplify"
+    SELECT = "select"
+    PRESERVE = "preserve"
+
+
 @dataclass
 class OutputFormat:
     """
@@ -192,7 +207,14 @@ class GeneratorOutput:
     structure: StructureStyle = element(default=StructureStyle.FILENAMES)
     docstring_style: DocstringStyle = element(default=DocstringStyle.RST)
     relative_imports: bool = element(default=False)
-    compound_fields: bool = element(default=False)
+    compound_fields: CompoundFieldStyle = element(default=CompoundFieldStyle.SIMPLIFY)
+
+    def __post_init__(self):
+        if self.compound_fields is True:
+            self.compound_fields = CompoundFieldStyle.SELECT
+
+        if self.compound_fields is False:
+            self.compound_fields = CompoundFieldStyle.SIMPLIFY
 
 
 @dataclass

--- a/xsdata/models/xsd.py
+++ b/xsdata/models/xsd.py
@@ -503,12 +503,11 @@ class Choice(AnnotationBase):
     any: Array["Any"] = array_element()
 
     def get_restrictions(self) -> Dict[str, Anything]:
-        min_occurs = self.min_occurs if self.min_occurs > 1 else 0
         max_occurs = sys.maxsize if self.max_occurs == "unbounded" else self.max_occurs
 
         return {
             "choice": str(id(self)),
-            "min_occurs": min_occurs,
+            "min_occurs": self.min_occurs,
             "max_occurs": max_occurs,
         }
 
@@ -1056,7 +1055,7 @@ class Alternative(AnnotationBase):
     def get_restrictions(self) -> Dict[str, Anything]:
         return {
             "choice": str(id(self)),
-            "min_occurs": 0,
+            "min_occurs": 1,
         }
 
 


### PR DESCRIPTION
Currently we generate compound fields only when it's absolutely necessary in order to maintain elements ordering between roundtrips. It would be nice to have an option to always group together choice elements just to be explicit with what is truly expected.

Original issue #561 

### Blocking issues

I have a couple of blocking cases that unfortunately I can't seem to find a proper way to tackle them

1. repeatable sequences

```xml
  <xsd:group name="G1">
    <xsd:choice>
      <xsd:sequence>
        <xsd:element name="date" type="xsd:date"/>
        <xsd:element name="marked" type="xsd:boolean"/>
      </xsd:sequence>
      <xsd:sequence>
        <xsd:element name="num" type="xsd:int"/>
      </xsd:sequence>
    </xsd:choice>
  </xsd:group>
```


2. Repeatable groups

```xml
	<xsd:complexType name="PurchaseOrderType">
		<xsd:sequence>
			<xsd:element ref="ipo:ExternFirstElement"/>
			<xsd:choice>
				<xsd:group ref="ipo:shipAndBill"/>
				<xsd:element name="singleAddress" type="ipo:AddressType"/>
			</xsd:choice>
			<xsd:element ref="ipo:comment" minOccurs="0"/>
			<xsd:element name="items" type="ipo:ItemsType"/>
		</xsd:sequence>
		<xsd:attribute name="orderDate" type="xsd:date"/>
	</xsd:complexType>
```





