### PR TITLE
Explicit required field metadata property

### DIFF
--- a/tests/formats/dataclass/test_filters.py
+++ b/tests/formats/dataclass/test_filters.py
@@ -329,14 +329,9 @@ class FiltersTests(FactoryTestCase):
         expected = {"nillable": True, "max_inclusive": 2}
         self.assertEqual(expected, self.filters.field_metadata(attr, None, []))
 
-        attr.default = "foo"
-        attr.restrictions.nillable = False
-        expected = {"max_inclusive": 2}
-        self.assertEqual(expected, self.filters.field_metadata(attr, None, []))
-
         attr.default = None
         attr.restrictions.tokens = True
-        expected = {"max_inclusive": 2, "tokens": True}
+        expected = {"max_inclusive": 2, "nillable": True, "tokens": True}
         self.assertEqual(expected, self.filters.field_metadata(attr, None, []))
 
     def test_field_metadata_mixed(self):

--- a/tests/models/xsd/test_attribute.py
+++ b/tests/models/xsd/test_attribute.py
@@ -44,13 +44,6 @@ class AttributeTests(TestCase):
         obj = Attribute()
         self.assertEqual({"max_occurs": 1, "min_occurs": 0}, obj.get_restrictions())
 
-        obj.default = "foo"
-        self.assertEqual({"max_occurs": 1, "min_occurs": 1}, obj.get_restrictions())
-        obj.default = None
-        obj.fixed = "foo"
-        self.assertEqual({"max_occurs": 1, "min_occurs": 1}, obj.get_restrictions())
-
-        obj.fixed = None
         obj.use = UseType.REQUIRED
         expected = {"max_occurs": 1, "min_occurs": 1}
         self.assertEqual(expected, obj.get_restrictions())

--- a/xsdata/formats/dataclass/filters.py
+++ b/xsdata/formats/dataclass/filters.py
@@ -302,9 +302,6 @@ class Filters:
 
         restrictions = attr.restrictions.asdict(attr.native_types)
 
-        if attr.default or attr.is_factory:
-            restrictions.pop("required", None)
-
         metadata = {
             "name": name,
             "type": attr.xml_type,

--- a/xsdata/models/xsd.py
+++ b/xsdata/models/xsd.py
@@ -332,17 +332,12 @@ class Attribute(AnnotationBase):
             yield self.ref
 
     def get_restrictions(self) -> Dict[str, Anything]:
-        restrictions = {}
-
-        if self.default or self.fixed:
-            self.use = UseType.REQUIRED
-
         if self.use == UseType.REQUIRED:
-            restrictions.update({"min_occurs": 1, "max_occurs": 1})
+            restrictions = {"min_occurs": 1, "max_occurs": 1}
         elif self.use == UseType.PROHIBITED:
-            restrictions.update({"max_occurs": 0, "min_occurs": 0})
+            restrictions = {"max_occurs": 0, "min_occurs": 0}
         else:
-            restrictions.update({"max_occurs": 1, "min_occurs": 0})
+            restrictions = {"max_occurs": 1, "min_occurs": 0}
 
         if self.simple_type:
             restrictions.update(self.simple_type.get_restrictions())


### PR DESCRIPTION
Notes:
Removed a couple of hacks that omitted generating the required property.