### PR TITLE
Automate generate options

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: tests/fixtures
 
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.23.1
+    rev: v2.23.3
     hooks:
       - id: pyupgrade
         args: [--py37-plus]

--- a/docs/examples/dataclasses-features.rst
+++ b/docs/examples/dataclasses-features.rst
@@ -3,8 +3,8 @@ Dataclasses Features
 ====================
 
 By default xsdata with generate :mod:`python:dataclasses` with the default features on
-but you can use a :ref:`generator config <Generator Config>` to toggle almost all of
-them.
+but you can use the cli flags or a :ref:`generator config <Generator Config>` to toggle
+all of them.
 
 
 .. literalinclude:: /../tests/fixtures/stripe/.xsdata.xml

--- a/tests/codegen/handlers/test_class_designate.py
+++ b/tests/codegen/handlers/test_class_designate.py
@@ -64,7 +64,7 @@ class ClassDesignateHandlerTests(FactoryTestCase):
         ]
 
         self.container.extend(classes)
-        self.config.output.structure = StructureStyle.NAMESPACES
+        self.config.output.structure_style = StructureStyle.NAMESPACES
         self.config.output.package = "bar"
 
         self.handler.run()
@@ -84,7 +84,7 @@ class ClassDesignateHandlerTests(FactoryTestCase):
         ]
 
         self.container.extend(classes)
-        self.config.output.structure = StructureStyle.SINGLE_PACKAGE
+        self.config.output.structure_style = StructureStyle.SINGLE_PACKAGE
         self.config.output.package = "foo.bar.thug"
 
         self.handler.run()
@@ -113,7 +113,7 @@ class ClassDesignateHandlerTests(FactoryTestCase):
         classes[1].attrs.append(AttrFactory.reference(classes[2].qname))
         classes[2].attrs.append(AttrFactory.reference(classes[3].qname))
 
-        self.config.output.structure = StructureStyle.CLUSTERS
+        self.config.output.structure_style = StructureStyle.CLUSTERS
         self.config.output.package = "foo.bar"
         self.container.extend(classes)
 
@@ -144,7 +144,7 @@ class ClassDesignateHandlerTests(FactoryTestCase):
         classes[2].attrs.append(AttrFactory.reference(classes[3].qname))
         classes[3].attrs.append(AttrFactory.reference(classes[1].qname, circular=True))
 
-        self.config.output.structure = StructureStyle.NAMESPACE_CLUSTERS
+        self.config.output.structure_style = StructureStyle.NAMESPACE_CLUSTERS
         self.config.output.package = "models"
         self.container.extend(classes)
 
@@ -172,7 +172,7 @@ class ClassDesignateHandlerTests(FactoryTestCase):
         classes[2].attrs.append(AttrFactory.reference(classes[3].qname))
         classes[3].attrs.append(AttrFactory.reference(classes[1].qname, circular=True))
 
-        self.config.output.structure = StructureStyle.NAMESPACE_CLUSTERS
+        self.config.output.structure_style = StructureStyle.NAMESPACE_CLUSTERS
         self.config.output.package = "models"
         self.container.extend(classes)
 

--- a/tests/codegen/handlers/test_class_name_conflict.py
+++ b/tests/codegen/handlers/test_class_name_conflict.py
@@ -58,7 +58,7 @@ class ClassNameConflictHandlerTests(FactoryTestCase):
             ClassFactory.create(qname="a"),
         ]
 
-        self.container.config.output.structure = StructureStyle.SINGLE_PACKAGE
+        self.container.config.output.structure_style = StructureStyle.SINGLE_PACKAGE
         self.container.extend(classes)
         self.processor.run()
 
@@ -71,7 +71,7 @@ class ClassNameConflictHandlerTests(FactoryTestCase):
             ClassFactory.create(qname="{bar}a"),
             ClassFactory.create(qname="a"),
         ]
-        self.container.config.output.structure = StructureStyle.CLUSTERS
+        self.container.config.output.structure_style = StructureStyle.CLUSTERS
         self.container.extend(classes)
         self.processor.run()
 

--- a/tests/integration/test_compound.py
+++ b/tests/integration/test_compound.py
@@ -16,7 +16,7 @@ def test_xml_documents():
     package = "tests.fixtures.compound.models"
     runner = CliRunner()
     result = runner.invoke(
-        cli, [str(schema), "-p", package, "-ss", "single-package", "-cf"]
+        cli, [str(schema), "-p", package, "-ss", "single-package", "--compound-fields"]
     )
 
     if result.exception:

--- a/tests/utils/test_objects.py
+++ b/tests/utils/test_objects.py
@@ -1,0 +1,18 @@
+from types import SimpleNamespace
+from unittest import TestCase
+
+from xsdata.utils import objects
+
+
+class ObjectsTests(TestCase):
+    def test_update(self):
+
+        obj = SimpleNamespace()
+        obj.foo = SimpleNamespace()
+        obj.foo.bar = 2
+        obj.bar = 1
+
+        kwargs = {"foo.bar": 1, "bar": 2}
+        objects.update(obj, **kwargs)
+        self.assertEqual(1, obj.foo.bar)
+        self.assertEqual(2, obj.bar)

--- a/xsdata/codegen/handlers/class_designate.py
+++ b/xsdata/codegen/handlers/class_designate.py
@@ -30,7 +30,7 @@ class ClassDesignateHandler(ContainerHandlerInterface):
     __slots__ = ()
 
     def run(self):
-        structure_style = self.container.config.output.structure
+        structure_style = self.container.config.output.structure_style
         if structure_style == StructureStyle.NAMESPACES:
             self.group_by_namespace()
         elif structure_style == StructureStyle.SINGLE_PACKAGE:

--- a/xsdata/codegen/handlers/class_name_conflict.py
+++ b/xsdata/codegen/handlers/class_name_conflict.py
@@ -44,7 +44,7 @@ class ClassNameConflictHandler(ContainerHandlerInterface):
         - All classes have the same source location.
         """
         return (
-            self.container.config.output.structure in REQUIRE_UNIQUE_NAMES
+            self.container.config.output.structure_style in REQUIRE_UNIQUE_NAMES
             or len(set(map(get_location, self.container))) == 1
         )
 

--- a/xsdata/utils/click.py
+++ b/xsdata/utils/click.py
@@ -1,0 +1,89 @@
+import enum
+from dataclasses import fields
+from dataclasses import is_dataclass
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import get_type_hints
+from typing import Iterator
+from typing import Type
+from typing import TypeVar
+
+import click
+from click import Command
+
+from xsdata.codegen.writer import CodeWriter
+from xsdata.utils import text
+
+F = TypeVar("F", bound=Callable[..., Any])
+FC = TypeVar("FC", Callable[..., Any], Command)
+
+
+def model_options(obj: Any) -> Callable[[FC], FC]:
+    def decorator(f: F) -> F:
+        for option in reversed(list(build_options(obj, ""))):
+            option(f)
+        return f
+
+    return decorator
+
+
+def build_options(obj: Any, parent: str) -> Iterator[Callable[[FC], FC]]:
+    type_hints = get_type_hints(obj)
+    doc_hints = get_doc_hints(obj)
+
+    for field in fields(obj):
+        type_hint = type_hints[field.name]
+        doc_hint = doc_hints[field.name]
+        qname = f"{parent}.{field.name}".strip(".")
+
+        if is_dataclass(type_hint):
+            yield from build_options(type_hint, qname)
+        else:
+            is_flag = False
+            opt_type = type_hint
+            if field.name == "value":
+                opt_type = click.Choice(CodeWriter.generators.keys())
+                names = ["-o", "--output"]
+            elif type_hint is bool:
+                is_flag = True
+                opt_type = None
+                name = text.kebab_case(field.name)
+                names = [f"--{name}/--no-{name}"]
+            else:
+                if issubclass(type_hint, enum.Enum):
+                    opt_type = EnumChoice(type_hint)
+
+                parts = text.split_words(field.name)
+                name = "-".join(parts)
+                name_short = "".join(part[0] for part in parts)
+                names = [f"--{name}", f"-{name_short}"]
+
+            names.append("__".join(qname.split(".")))
+
+            yield click.option(
+                *names,
+                help=doc_hint,
+                is_flag=is_flag,
+                type=opt_type,
+                default=None,
+            )
+
+
+def get_doc_hints(obj: Any) -> Dict[str, str]:
+    result = {}
+    for line in obj.__doc__.split(":param "):
+        if line[0].isalpha():
+            param, hint = line.split(":", 1)
+            result[param] = " ".join(hint.split())
+
+    return result
+
+
+class EnumChoice(click.Choice):
+    def __init__(self, enumeration: Type[enum.Enum]):
+        self.enumeration = enumeration
+        super().__init__([e.value for e in enumeration])
+
+    def convert(self, value: Any, *args: Any) -> enum.Enum:
+        return self.enumeration(value)

--- a/xsdata/utils/objects.py
+++ b/xsdata/utils/objects.py
@@ -1,0 +1,17 @@
+from typing import Any
+
+
+def update(obj: Any, **kwargs: Any):
+    """Update an object from keyword arguments with dotted keys."""
+
+    for key, value in kwargs.items():
+        attrsetter(obj, key, value)
+
+
+def attrsetter(obj: Any, attr: str, value: Any):
+    names = attr.split(".")
+    last = names.pop()
+    for name in names:
+        obj = getattr(obj, name)
+
+    setattr(obj, last, value)


### PR DESCRIPTION
### Description

Almost all the generator flag options are available only through config. I want to be able to toggle and override any flag or directive from the config.


### What I did

- I added a new decorator that accepts a dataclass and builds click.options dynamically
- The new options support enabling/disabling any flag and overriding the options in the config as well
- Deprecated short names -cf/-ri since the click true/false arguments can't have secondary names

8 new options are now available as cli options :ok: 


```console
  -c, --config TEXT               Project configuration
  -pp, --print                    Print output
  -p, --package TEXT              Target package, default: generated
  -o, --output [dataclasses]      Output format name, default: dataclasses
  --repr / --no-repr              Generate __repr__ method, default: true
  --eq / --no-eq                  Generate __eq__ method, default: true
  --order / --no-order            Generate __lt__, __le__, __gt__, and __ge__
                                  methods, default: false
  --unsafe-hash / --no-unsafe-hash
                                  Generate __hash__ method if not frozen,
                                  default: false
  --frozen / --no-frozen          Enable read only properties, default false
  --slots / --no-slots            Enable __slots__, default: false,
                                  python>=3.10 Only
  --kw-only / --no-kw-only        Enable keyword only arguments, default:
                                  false, python>=3.10 Only
  -ss, --structure-style [filenames|namespaces|clusters|single-package|namespace-clusters]
                                  Output structure style, default: filenames
  -ds, --docstring-style [reStructuredText|NumPy|Google|Accessible|Blank]
                                  Docstring style, default: reStructuredText
  --relative-imports / --no-relative-imports
                                  Use relative imports, default: false
  --compound-fields / --no-compound-fields
                                  Use compound fields for repeatable elements,
                                  default: false
  -mll, --max-line-length INTEGER
                                  Adjust the maximum line length, default: 79
  --help                          Show this message and exit.


```