### PR TITLE
Adding config option fail_on_unknown_attributes

### DIFF
--- a/docs/json.rst
+++ b/docs/json.rst
@@ -115,6 +115,7 @@ errors through configuration.
     ...
     >>> config = ParserConfig(
     ...     fail_on_unknown_properties=False,
+    ...     fail_on_unknown_attributes=False,
     ... )
     >>> json_string = """{
     ...   "author": "Hightower, Kim",

--- a/docs/xml.rst
+++ b/docs/xml.rst
@@ -169,6 +169,7 @@ The configuration allows to enable/disable various features and failures.
     ...     base_url=None,
     ...     process_xinclude=False,
     ...     fail_on_unknown_properties=False,
+    ...     fail_on_unknown_attributes=False,
     ... )
     >>> parser = XmlParser(config=config)
     >>> order = parser.from_bytes(xml_path.read_bytes())

--- a/tests/formats/dataclass/parsers/nodes/test_element.py
+++ b/tests/formats/dataclass/parsers/nodes/test_element.py
@@ -196,7 +196,7 @@ class ElementNodeTests(FactoryTestCase):
     
     def test_bind_attrs_with_fail_on_unknown_attributes(self):
         self.node.meta = self.context.build(AttrsType)
-        self.node.config.fail_on_unknown_attributes = False
+        self.node.config.fail_on_unknown_attributes = True
         self.node.attrs = {
             "index": "0",
             "fixed": "will be ignored",

--- a/tests/formats/dataclass/parsers/nodes/test_element.py
+++ b/tests/formats/dataclass/parsers/nodes/test_element.py
@@ -210,6 +210,17 @@ class ElementNodeTests(FactoryTestCase):
         expected = {"attrs": {"extended": "attr", "{what}ever": "qname"}, "index": 0}
         self.assertEqual(expected, params)
 
+    def test_bind_with_fail_on_unknown_attributes(self):
+        self.node.meta = self.context.build(ExtendedType)
+        self.node.config.fail_on_unknown_attributes = True
+        self.node.attrs = {"a": "b"}
+
+        objects = [("a", "1")]
+        with self.assertRaises(ParserError) as cm:
+            self.node.bind("foo", "text", "tail", objects)
+
+        self.assertEqual("Unknown attribute ExtendedType:a", str(cm.exception))
+
     @mock.patch("xsdata.formats.dataclass.parsers.nodes.element.logger.warning")
     def test_bind_objects(self, mock_warning):
         self.node.meta = self.context.build(TypeC)

--- a/tests/formats/dataclass/parsers/nodes/test_element.py
+++ b/tests/formats/dataclass/parsers/nodes/test_element.py
@@ -193,7 +193,7 @@ class ElementNodeTests(FactoryTestCase):
 
         expected = {"attrs": {"extended": "attr", "{what}ever": "qname"}, "index": 0}
         self.assertEqual(expected, params)
-    
+
     def test_bind_attrs_with_fail_on_unknown_attributes(self):
         self.node.meta = self.context.build(AttrsType)
         self.node.config.fail_on_unknown_attributes = True

--- a/tests/formats/dataclass/parsers/nodes/test_element.py
+++ b/tests/formats/dataclass/parsers/nodes/test_element.py
@@ -193,6 +193,22 @@ class ElementNodeTests(FactoryTestCase):
 
         expected = {"attrs": {"extended": "attr", "{what}ever": "qname"}, "index": 0}
         self.assertEqual(expected, params)
+    
+    def test_bind_attrs_with_fail_on_unknown_attributes(self):
+        self.node.meta = self.context.build(AttrsType)
+        self.node.config.fail_on_unknown_attributes = False
+        self.node.attrs = {
+            "index": "0",
+            "fixed": "will be ignored",
+            "{what}ever": "qname",
+            "extended": "attr",
+        }
+
+        params = {}
+        self.node.bind_attrs(params)
+
+        expected = {"attrs": {"extended": "attr", "{what}ever": "qname"}, "index": 0}
+        self.assertEqual(expected, params)
 
     @mock.patch("xsdata.formats.dataclass.parsers.nodes.element.logger.warning")
     def test_bind_objects(self, mock_warning):

--- a/xsdata/formats/dataclass/parsers/config.py
+++ b/xsdata/formats/dataclass/parsers/config.py
@@ -41,7 +41,7 @@ class ParserConfig:
         process_xinclude: bool = False,
         class_factory: Callable[[Type[T], Dict], T] = default_class_factory,
         fail_on_unknown_properties: bool = True,
-        fail_on_unknown_attributes: bool = True,
+        fail_on_unknown_attributes: bool = False,
         fail_on_converter_warnings: bool = False,
     ):
         self.base_url = base_url

--- a/xsdata/formats/dataclass/parsers/config.py
+++ b/xsdata/formats/dataclass/parsers/config.py
@@ -20,6 +20,8 @@ class ParserConfig:
     :param class_factory: Override default object instantiation
     :param fail_on_unknown_properties: Skip unknown properties or
         fail with exception
+    :param fail_on_unknown_attributes: Skip unknown XML attributes
+        or fail with exception
     :param fail_on_converter_warnings: Turn converter warnings to
         exceptions
     """
@@ -29,6 +31,7 @@ class ParserConfig:
         "process_xinclude",
         "class_factory",
         "fail_on_unknown_properties",
+        "fail_on_unknown_attributes",
         "fail_on_converter_warnings",
     )
 
@@ -38,10 +41,12 @@ class ParserConfig:
         process_xinclude: bool = False,
         class_factory: Callable[[Type[T], Dict], T] = default_class_factory,
         fail_on_unknown_properties: bool = True,
+        fail_on_unknown_attributes: bool = True,
         fail_on_converter_warnings: bool = False,
     ):
         self.base_url = base_url
         self.process_xinclude = process_xinclude
         self.class_factory = class_factory
         self.fail_on_unknown_properties = fail_on_unknown_properties
+        self.fail_on_unknown_attributes = fail_on_unknown_attributes
         self.fail_on_converter_warnings = fail_on_converter_warnings

--- a/xsdata/formats/dataclass/parsers/nodes/element.py
+++ b/xsdata/formats/dataclass/parsers/nodes/element.py
@@ -137,7 +137,9 @@ class ElementNode(XmlNode):
                     self.bind_any_attr(params, var, qname, value)
                 else:
                     if self.config.fail_on_unknown_attributes:
-                        raise ParserError(f"Unknown attribute {self.meta.qname}:{qname}")
+                        raise ParserError(
+                            f"Unknown attribute {self.meta.qname}:{qname}"
+                        )
 
     def bind_attr(self, params: Dict, var: XmlVar, value: Any):
         if var.init:

--- a/xsdata/formats/dataclass/parsers/nodes/element.py
+++ b/xsdata/formats/dataclass/parsers/nodes/element.py
@@ -135,6 +135,9 @@ class ElementNode(XmlNode):
                 var = self.meta.find_any_attributes(qname)
                 if var:
                     self.bind_any_attr(params, var, qname, value)
+                else:
+                    if self.config.fail_on_unknown_attributes:
+                        raise ParserError(f"Unknown attribute {self.meta.qname}:{qname}")
 
     def bind_attr(self, params: Dict, var: XmlVar, value: Any):
         if var.init:


### PR DESCRIPTION
* Allows to raise a ParseError when an XML element has attributes,
  which were not defined as part of the known schema

Allows #597 