### PR TITLE
Make warnings more informative by including the class being parsed

### DIFF
--- a/xsdata/formats/dataclass/parsers/nodes/element.py
+++ b/xsdata/formats/dataclass/parsers/nodes/element.py
@@ -5,7 +5,7 @@ from typing import Optional
 from typing import Set
 from typing import Type
 
-from xsdata.exceptions import ParserError
+from xsdata.exceptions import ConverterWarning, ParserError
 from xsdata.formats.converter import converter
 from xsdata.formats.dataclass.context import XmlContext
 from xsdata.formats.dataclass.models.elements import XmlMeta
@@ -17,7 +17,7 @@ from xsdata.formats.dataclass.parsers.utils import ParserUtils
 from xsdata.formats.dataclass.parsers.utils import PendingCollection
 from xsdata.logger import logger
 from xsdata.models.enums import DataType
-from xsdata.utils import namespaces
+from xsdata.utils import namespaces, warning_transform
 
 
 class ElementNode(XmlNode):
@@ -130,7 +130,10 @@ class ElementNode(XmlNode):
         for qname, value in self.attrs.items():
             var = self.meta.find_attribute(qname)
             if var and var.name not in params:
-                self.bind_attr(params, var, value)
+                with warning_transform.warning_transform(
+                        lambda msg: msg + f" when parsing {var.name} of {self.meta.clazz}",
+                        ConverterWarning):
+                    self.bind_attr(params, var, value)
             else:
                 var = self.meta.find_any_attributes(qname)
                 if var:

--- a/xsdata/utils/warning_transform.py
+++ b/xsdata/utils/warning_transform.py
@@ -1,0 +1,31 @@
+import warnings
+from contextlib import contextmanager
+from typing import Callable, Tuple, Type, Union
+
+
+@contextmanager
+def warning_transform(func: Callable[[str], str],
+                      warning_types: Union[Type[Warning],
+                                           Tuple[Type[Warning],
+                                                 ...]] = Warning):
+    """
+    Transform messages of the warnings emitted inside the context.
+
+    :param func: Transformation to apply to messages
+    :param warning_types: Warnings to apply to
+    """
+    updated_warnings = list()
+    with warnings.catch_warnings(record=True) as w:
+        yield
+        for warning in w:
+            if isinstance(warning.message, warning_types):
+                payload, *rest = warning.message.args
+                payload = func(payload)
+                warning.message.args = (payload, *rest)
+            updated_warnings.append(warning)
+    for warning in updated_warnings:
+        warnings.warn_explicit(warning.message,
+                               warning.category,
+                               warning.filename,
+                               warning.lineno,
+                               source=warning.source)


### PR DESCRIPTION
Current converter warnings only include the token and the types it is being matched to. This makes it hard to narrow down what exactly they refer to without stepping up the frames in the debugger (and not very useful if the only thing you have is a warning in a log).

This PR adds a wrapper that catches and re-emits the converter warnings after adding field and class names to the warning message.