### PR TITLE
WSDL Message part type can also be a qualified element

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: tests/fixtures
 
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.0
+    rev: v2.29.1
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
@@ -11,7 +11,7 @@ repos:
     hooks:
       - id: reorder-python-imports
   - repo: https://github.com/ambv/black
-    rev: 21.10b0
+    rev: 21.11b1
     hooks:
       - id: black
   - repo: https://gitlab.com/pycqa/flake8
@@ -42,11 +42,11 @@ repos:
       - id: mypy
         additional_dependencies: [tokenize-rt, types-requests, types-Jinja2, types-click, types-docutils]
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.19.0
+    rev: v1.20.0
     hooks:
       - id: setup-cfg-fmt
         args: ["--max-py-version=3.10"]
   - repo: https://github.com/PyCQA/doc8
-    rev: 0.9.1
+    rev: 0.10.1
     hooks:
       - id: doc8

--- a/tests/codegen/handlers/test_attribute_type.py
+++ b/tests/codegen/handlers/test_attribute_type.py
@@ -414,3 +414,21 @@ class AttributeTypeHandlerTests(FactoryTestCase):
         attr = AttrFactory.native(DataType.HEX_BINARY)
         self.processor.update_restrictions(attr, attr.types[0].datatype)
         self.assertEqual("base16", attr.restrictions.format)
+
+    def test_detect_lazy_namespace(self):
+        source = ClassFactory.create(namespace="foo", tag=Tag.ELEMENT)
+        target = ClassFactory.create()
+        attr = AttrFactory.create(namespace="##lazy")
+
+        self.processor.detect_lazy_namespace(source, target, attr)
+        self.assertEqual("foo", attr.namespace)
+
+        attr.namespace = "##lazy"
+        source.namespace = None
+        self.processor.detect_lazy_namespace(source, target, attr)
+        self.assertIsNone(attr.namespace)
+
+        attr.namespace = "##lazy"
+        target.namespace = "foo"
+        self.processor.detect_lazy_namespace(source, target, attr)
+        self.assertEqual("", attr.namespace)

--- a/tests/codegen/mappers/test_definitions.py
+++ b/tests/codegen/mappers/test_definitions.py
@@ -694,7 +694,7 @@ class DefinitionsMapperTests(FactoryTestCase):
                 "arg0", str(DataType.STRING), namespace="", native=True
             ),
             DefinitionsMapper.build_attr(
-                "arg1", build_qname("boo", "cafe"), namespace="", native=False
+                "arg1", build_qname("boo", "cafe"), namespace="##lazy", native=False
             ),
         ]
         self.assertIsInstance(result, Generator)
@@ -714,10 +714,11 @@ class DefinitionsMapperTests(FactoryTestCase):
         mock_create_message_attributes.return_value = attrs
         actual = DefinitionsMapper.build_message_class(definitions, port_type_message)
         expected = Class(
-            qname=build_qname("xsdata", "bar"),
-            status=Status.FLATTENED,
+            qname=build_qname("bar", "bar"),
+            status=Status.RAW,
             tag=Tag.ELEMENT,
             location="foo.wsdl",
+            namespace="bar",
             ns_map=message.ns_map,
             attrs=attrs,
         )

--- a/tests/fixtures/hello/hello.py
+++ b/tests/fixtures/hello/hello.py
@@ -36,6 +36,7 @@ class HelloError:
 class GetHelloAsString:
     class Meta:
         name = "getHelloAsString"
+        namespace = "http://hello/"
 
     arg0: Optional[str] = field(
         default=None,
@@ -50,6 +51,7 @@ class GetHelloAsString:
 class GetHelloAsStringResponse:
     class Meta:
         name = "getHelloAsStringResponse"
+        namespace = "http://hello/"
 
     return_value: Optional[str] = field(
         default=None,

--- a/xsdata/codegen/handlers/attribute_type.py
+++ b/xsdata/codegen/handlers/attribute_type.py
@@ -144,6 +144,7 @@ class AttributeTypeHandler(RelativeHandlerInterface):
             if source.nillable:
                 attr.restrictions.nillable = True
             self.set_circular_flag(source, target, attr_type)
+            self.detect_lazy_namespace(source, target, attr)
 
     @classmethod
     def copy_attribute_properties(
@@ -227,3 +228,26 @@ class AttributeTypeHandler(RelativeHandlerInterface):
 
         if datatype in (DataType.NMTOKENS, DataType.IDREFS):
             attr.restrictions.tokens = True
+
+    @classmethod
+    def detect_lazy_namespace(cls, source: Class, target: Class, attr: Attr):
+        """
+        Override attr namespace with the source namespace when during the
+        initial mapping the namespace detection wasn't possible.
+
+        Case 1: WSDL message part type can be an element, complex or
+        simple type, we can't do the detection during the initial
+        mapping to class objects.
+        """
+        if attr.namespace == "##lazy":
+            logger.warning(
+                "Overriding field type namespace %s:%s (%s)",
+                target.name,
+                attr.name,
+                source.namespace,
+            )
+
+            if not source.namespace:
+                attr.namespace = "" if target.namespace else None
+            else:
+                attr.namespace = source.namespace


### PR DESCRIPTION
Closes #612 

Apparently WSDL message part type can be either an element, complex or simple type. We can't detect the namespace during the initial mapping, we have to postpone the detection to the class processor attribute type.