### PR TITLE
Add generator config search & replace substitutions

### DIFF
--- a/docs/api/codegen.rst
+++ b/docs/api/codegen.rst
@@ -3,7 +3,17 @@ Generator Config
 ================
 
 The configuration offers more advance options to further tail the output to your needs,
-like naming conventions and aliases.
+like naming conventions and substitutions.
+
+.. warning::
+
+    Since v21.12 the aliases were replaced by the substitutions config which is a more
+    flexible search and replace process with support for regular expressions.
+
+    During initialization aliases will be migrated to substitutions and the config
+    will be automatically updated, but you should also verify you still get the desired
+    output.
+
 
 .. cli:: xsdata init-config --print
     :language: xml
@@ -21,9 +31,10 @@ like naming conventions and aliases.
 
     OutputFormat
     GeneratorConventions
-    GeneratorAliases
+    GeneratorSubstitutions
     StructureStyle
     DocstringStyle
-    GeneratorAlias
+    ObjectType
+    GeneratorSubstitution
     NameConvention
     NameCase

--- a/tests/codegen/handlers/test_class_designate.py
+++ b/tests/codegen/handlers/test_class_designate.py
@@ -1,8 +1,9 @@
 from xsdata.codegen.container import ClassContainer
 from xsdata.codegen.handlers import ClassDesignateHandler
 from xsdata.exceptions import CodeGenerationError
-from xsdata.models.config import GeneratorAlias
 from xsdata.models.config import GeneratorConfig
+from xsdata.models.config import GeneratorSubstitution
+from xsdata.models.config import ObjectType
 from xsdata.models.config import StructureStyle
 from xsdata.models.enums import Namespace
 from xsdata.utils.testing import AttrFactory
@@ -190,8 +191,10 @@ class ClassDesignateHandlerTests(FactoryTestCase):
         result = self.handler.combine_ns_package(namespace)
         self.assertEqual(["generated", "bar", "foo", "add"], result)
 
-        alias = GeneratorAlias(source=namespace, target="add.again")
-        self.config.aliases.package_name.append(alias)
+        alias = GeneratorSubstitution(
+            type=ObjectType.PACKAGE, search=namespace, replace="add.again"
+        )
+        self.config.substitutions.substitution.append(alias)
 
         result = self.handler.combine_ns_package(namespace)
         self.assertEqual(["generated", "add", "again"], result)

--- a/tests/fixtures/calculator/AddRQ.xml
+++ b/tests/fixtures/calculator/AddRQ.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/">
-  <soap-env:Body>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+  <soapenv:Body>
     <ns1:Add xmlns:ns1="http://tempuri.org/">
       <ns1:intA>1</ns1:intA>
       <ns1:intB>3</ns1:intB>
     </ns1:Add>
-  </soap-env:Body>
-</soap-env:Envelope>
+  </soapenv:Body>
+</soapenv:Envelope>

--- a/tests/fixtures/hello/HelloRQ.xml
+++ b/tests/fixtures/hello/HelloRQ.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/">
-  <soap-env:Body>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+  <soapenv:Body>
     <ns1:getHelloAsString xmlns:ns1="http://hello/">
       <arg0>chris</arg0>
     </ns1:getHelloAsString>
-  </soap-env:Body>
-</soap-env:Envelope>
+  </soapenv:Body>
+</soapenv:Envelope>

--- a/tests/fixtures/stripe/.xsdata.xml
+++ b/tests/fixtures/stripe/.xsdata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Config xmlns="http://pypi.org/project/xsdata" version="21.8">
+<Config xmlns="http://pypi.org/project/xsdata" version="21.11">
   <Output maxLineLength="79">
     <Package>tests.fixtures.stripe.models.balance</Package>
     <Format repr="true" eq="true" order="true" unsafeHash="false" frozen="true" slots="false" kwOnly="false">dataclasses</Format>
@@ -16,4 +16,5 @@
     <PackageName case="snakeCase" safePrefix="pkg"/>
   </Conventions>
   <Aliases/>
+  <Substitutions/>
 </Config>

--- a/tests/utils/test_namespaces.py
+++ b/tests/utils/test_namespaces.py
@@ -22,11 +22,11 @@ class NamespacesTests(TestCase):
         self.assertEqual("ns0", load_prefix("a", ns_map))
         self.assertEqual("ns0", load_prefix("a", ns_map))
         self.assertEqual("xs", load_prefix(Namespace.XS.uri, ns_map))
-        self.assertEqual("soap-env", load_prefix(Namespace.SOAP_ENV.uri, ns_map))
+        self.assertEqual("soapenv", load_prefix(Namespace.SOAP_ENV.uri, ns_map))
 
         expected = {
             "ns0": "a",
-            "soap-env": "http://schemas.xmlsoap.org/soap/envelope/",
+            "soapenv": "http://schemas.xmlsoap.org/soap/envelope/",
             "xs": "http://www.w3.org/2001/XMLSchema",
         }
         self.assertEqual(expected, ns_map)
@@ -35,13 +35,13 @@ class NamespacesTests(TestCase):
         ns_map: Dict = {}
         self.assertEqual("ns0", generate_prefix("a", ns_map))
         self.assertEqual("xs", generate_prefix(Namespace.XS.uri, ns_map))
-        self.assertEqual("soap-env", generate_prefix(Namespace.SOAP_ENV.uri, ns_map))
+        self.assertEqual("soapenv", generate_prefix(Namespace.SOAP_ENV.uri, ns_map))
         self.assertEqual("ns3", generate_prefix("b", ns_map))
 
         expected = {
             "ns0": "a",
             "ns3": "b",
-            "soap-env": "http://schemas.xmlsoap.org/soap/envelope/",
+            "soapenv": "http://schemas.xmlsoap.org/soap/envelope/",
             "xs": "http://www.w3.org/2001/XMLSchema",
         }
         self.assertEqual(expected, ns_map)

--- a/xsdata/models/enums.py
+++ b/xsdata/models/enums.py
@@ -30,7 +30,7 @@ class Namespace(Enum):
     XHTML = ("http://www.w3.org/1999/xhtml", "xhtml")
     SOAP11 = ("http://schemas.xmlsoap.org/wsdl/soap/", "soap")
     SOAP12 = ("http://schemas.xmlsoap.org/wsdl/soap12/", "soap12")
-    SOAP_ENV = ("http://schemas.xmlsoap.org/soap/envelope/", "soap-env")
+    SOAP_ENV = ("http://schemas.xmlsoap.org/soap/envelope/", "soapenv")
 
     def __init__(self, uri: str, prefix: str):
         self.uri = uri


### PR DESCRIPTION
Add config options for search and replace substitutions for class, field, package, module names based on `re.sub` and replaced the older aliases. The cli will auto migrate the aliases and emit a warning to verify output!

```xml
<?xml version="1.0" encoding="UTF-8"?>
<Config xmlns="http://pypi.org/project/xsdata" version="21.11">
  <Output maxLineLength="79">
    <Package>generated</Package>
    <Format repr="true" eq="true" order="false" unsafeHash="false" frozen="false" slots="false" kwOnly="false">dataclasses</Format>
    <Structure>filenames</Structure>
    <DocstringStyle>reStructuredText</DocstringStyle>
    <RelativeImports>false</RelativeImports>
    <CompoundFields>false</CompoundFields>
  </Output>
  <Conventions>
    <ClassName case="pascalCase" safePrefix="type"/>
    <FieldName case="snakeCase" safePrefix="value"/>
    <ConstantName case="screamingSnakeCase" safePrefix="value"/>
    <ModuleName case="snakeCase" safePrefix="mod"/>
    <PackageName case="snakeCase" safePrefix="pkg"/>
  </Conventions>
  <Substitutions>
    <Substitution type="class" search="Class" replace="Type"/>
    <Substitution type="package" search="http://www.w3.org/2001/XMLSchema" replace="xs"/>
  </Substitutions>
</Config>
```
  

