### PR TITLE
Exclude abstract elements from class fields

### DIFF
--- a/tests/codegen/handlers/test_attribute_type.py
+++ b/tests/codegen/handlers/test_attribute_type.py
@@ -189,6 +189,22 @@ class AttributeTypeHandlerTests(FactoryTestCase):
         self.processor.process_dependency_type(target, attr, attr_type)
         self.assertTrue(attr.restrictions.nillable)
 
+    @mock.patch.object(AttributeTypeHandler, "find_dependency")
+    def test_process_dependency_type_with_abstract_type_type(
+        self, mock_find_dependency
+    ):
+        complex_type = ClassFactory.create(tag=Tag.ELEMENT, abstract=True)
+        mock_find_dependency.return_value = complex_type
+
+        attr = AttrFactory.create()
+        attr_type = attr.types[0]
+        target = ClassFactory.create()
+        target.attrs.append(attr)
+
+        self.assertEqual(1, len(target.attrs))
+        self.processor.process_dependency_type(target, attr, attr_type)
+        self.assertEqual(0, len(target.attrs))
+
     @mock.patch.object(AttributeTypeHandler, "update_restrictions")
     @mock.patch.object(AttributeTypeHandler, "copy_attribute_properties")
     def test_process_inner_type_with_simple_type(

--- a/xsdata/codegen/handlers/attribute_type.py
+++ b/xsdata/codegen/handlers/attribute_type.py
@@ -140,6 +140,10 @@ class AttributeTypeHandler(RelativeHandlerInterface):
                 x.restrictions.format for x in source.attrs if x.restrictions.format
             )
             attr_type.reference = id(source)
+        elif source.is_element and source.abstract:
+            # Substitution groups with abstract elements are used like
+            # placeholders and shouldn't be added as standalone fields.
+            target.attrs.remove(attr)
         else:
             if source.nillable:
                 attr.restrictions.nillable = True


### PR DESCRIPTION
Let's test the theory that abstract elements can't appear on the final xml document #625 