### PR TITLE
CodeGenerator should filter out unused types

### DIFF
--- a/tests/codegen/test_utils.py
+++ b/tests/codegen/test_utils.py
@@ -15,16 +15,13 @@ from xsdata.utils.testing import FactoryTestCase
 
 
 class ClassUtilsTests(FactoryTestCase):
-    @mock.patch.object(ClassUtils, "clean_inner_classes")
-    def test_remove_attribute(self, mock_clean_inner_classes):
+    def test_remove_attribute(self):
 
         target = ClassFactory.elements(1)
         attr = target.attrs[0]
 
         ClassUtils.remove_attribute(target, attr)
         self.assertEqual(0, len(target.attrs))
-
-        mock_clean_inner_classes.assert_called_once_with(target)
 
     @mock.patch.object(ClassUtils, "is_orphan_inner")
     def test_clean_inner_classes(self, mock_is_orphan_inner):

--- a/xsdata/codegen/handlers/attribute_compound_choice.py
+++ b/xsdata/codegen/handlers/attribute_compound_choice.py
@@ -47,7 +47,7 @@ class AttributeCompoundChoiceHandler(RelativeHandlerInterface):
         min_occurs = []
         max_occurs = []
         for attr in attrs:
-            target.attrs.remove(attr)
+            ClassUtils.remove_attribute(target, attr)
             names.append(attr.local_name)
             min_occurs.append(attr.restrictions.min_occurs or 0)
             max_occurs.append(attr.restrictions.max_occurs or 0)

--- a/xsdata/codegen/handlers/attribute_group.py
+++ b/xsdata/codegen/handlers/attribute_group.py
@@ -42,6 +42,6 @@ class AttributeGroupHandler(RelativeHandlerInterface):
             raise AnalyzerValueError(f"Group attribute not found: `{qname}`")
 
         if source is target:
-            target.attrs.remove(attr)
+            ClassUtils.remove_attribute(target, attr)
         else:
             ClassUtils.copy_group_attributes(source, target, attr)

--- a/xsdata/codegen/handlers/attribute_overrides.py
+++ b/xsdata/codegen/handlers/attribute_overrides.py
@@ -53,7 +53,12 @@ class AttributeOverridesHandler(RelativeHandlerInterface):
             and bool_eq(attr.restrictions.tokens, source_attr.restrictions.tokens)
             and bool_eq(attr.restrictions.nillable, source_attr.restrictions.nillable)
         ):
-            ClassUtils.remove_attribute(target, attr)
+            cls.remove_attribute(target, attr)
+
+    @classmethod
+    def remove_attribute(cls, target: Class, attr: Attr):
+        ClassUtils.remove_attribute(target, attr)
+        ClassUtils.clean_inner_classes(target)
 
     @classmethod
     def resolve_conflict(cls, attr: Attr, source_attr: Attr):

--- a/xsdata/codegen/handlers/attribute_type.py
+++ b/xsdata/codegen/handlers/attribute_type.py
@@ -143,7 +143,7 @@ class AttributeTypeHandler(RelativeHandlerInterface):
         elif source.is_element and source.abstract:
             # Substitution groups with abstract elements are used like
             # placeholders and shouldn't be added as standalone fields.
-            target.attrs.remove(attr)
+            ClassUtils.remove_attribute(target, attr)
         else:
             if source.nillable:
                 attr.restrictions.nillable = True

--- a/xsdata/codegen/utils.py
+++ b/xsdata/codegen/utils.py
@@ -23,11 +23,9 @@ class ClassUtils:
 
     @classmethod
     def remove_attribute(cls, target: Class, attr: Attr):
-        """Remove the given attr from the target class and clean inner
-        classes."""
-        target.attrs.remove(attr)
-
-        cls.clean_inner_classes(target)
+        """Safely remove the given attr from the target class by check obj
+        ids."""
+        target.attrs = [at for at in target.attrs if id(at) != id(attr)]
 
     @classmethod
     def clean_inner_classes(cls, target: Class):


### PR DESCRIPTION
The generator is taking a safe approach to what types to generate, basically that includes all global elements and complex types with no simple content plus all enumerations. This oftens results to a lot of unused classes and enumerations.

With this change the generator will  become more strict and only generate the models for global non abstract types and, complex types and enumerations that are referenced by at least one other generated model.

Closes #629 