### PR TITLE
Add cfg options to change/force compound field names

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,8 +12,8 @@ Resolves #xxxx
 
 ## 💬 Comments
 
-> A place to write any comments to the reviewer. 
-> 
+> A place to write any comments to the reviewer.
+>
 
 ## 🛫 Checklist
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: tests/fixtures
 
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.1
+    rev: v2.31.0
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
@@ -11,7 +11,7 @@ repos:
     hooks:
       - id: reorder-python-imports
   - repo: https://github.com/ambv/black
-    rev: 21.11b1
+    rev: 21.12b0
     hooks:
       - id: black
   - repo: https://gitlab.com/pycqa/flake8
@@ -26,7 +26,7 @@ repos:
         args: ["--suppress-none-returning"]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.1.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -37,7 +37,7 @@ repos:
       - id: docformatter
         args: ["--in-place", "--pre-summary-newline"]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.910-1
+    rev: v0.931
     hooks:
       - id: mypy
         additional_dependencies: [tokenize-rt, types-requests, types-Jinja2, types-click, types-docutils]

--- a/docs/api/codegen.rst
+++ b/docs/api/codegen.rst
@@ -34,6 +34,7 @@ like naming conventions and substitutions.
     GeneratorSubstitutions
     StructureStyle
     DocstringStyle
+    CompoundFields
     ObjectType
     GeneratorSubstitution
     NameConvention

--- a/tests/codegen/handlers/test_attribute_compound_choice.py
+++ b/tests/codegen/handlers/test_attribute_compound_choice.py
@@ -18,7 +18,7 @@ class AttributeCompoundChoiceHandlerTests(FactoryTestCase):
         super().setUp()
 
         self.config = GeneratorConfig()
-        self.config.output.compound_fields = True
+        self.config.output.compound_fields.enabled = True
         self.container = ClassContainer(config=self.config)
         self.processor = AttributeCompoundChoiceHandler(container=self.container)
 
@@ -116,6 +116,14 @@ class AttributeCompoundChoiceHandlerTests(FactoryTestCase):
         actual = self.processor.choose_name(target, ["a", "b", "c", "d"])
         self.assertEqual("choice_1", actual)
 
+        self.processor.config.default_name = "ThisOrThat"
+        actual = self.processor.choose_name(target, ["a", "b", "c", "d"])
+        self.assertEqual("ThisOrThat", actual)
+
+        self.processor.config.force_default_name = True
+        actual = self.processor.choose_name(target, ["a", "b", "c"])
+        self.assertEqual("ThisOrThat", actual)
+
     def test_build_attr_choice(self):
         attr = AttrFactory.create(
             name="a", namespace="xsdata", default="123", help="help", fixed=True
@@ -170,7 +178,7 @@ class AttributeCompoundChoiceHandlerTests(FactoryTestCase):
 
         attrs_clone = [attr.clone() for attr in target.attrs]
 
-        self.processor.compound_fields = False
+        self.processor.config.enabled = False
         self.processor.reset_sequential(target, 0)
         self.assertEqual(2, len_sequential(target))
 

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -33,7 +33,7 @@ class GeneratorConfigTests(TestCase):
             "    <Structure>filenames</Structure>\n"
             "    <DocstringStyle>reStructuredText</DocstringStyle>\n"
             "    <RelativeImports>false</RelativeImports>\n"
-            "    <CompoundFields>false</CompoundFields>\n"
+            '    <CompoundFields defaultName="choice" forceDefaultName="false">false</CompoundFields>\n'
             "  </Output>\n"
             "  <Conventions>\n"
             '    <ClassName case="pascalCase" safePrefix="type"/>\n'
@@ -88,7 +88,7 @@ class GeneratorConfigTests(TestCase):
             "    <Structure>filenames</Structure>\n"
             "    <DocstringStyle>reStructuredText</DocstringStyle>\n"
             "    <RelativeImports>false</RelativeImports>\n"
-            "    <CompoundFields>false</CompoundFields>\n"
+            '    <CompoundFields defaultName="choice" forceDefaultName="false">false</CompoundFields>\n'
             "  </Output>\n"
             "  <Conventions>\n"
             '    <ClassName case="pascalCase" safePrefix="type"/>\n'

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ commands =
 
 [testenv:docs]
 basepython = python3.8
-extras = docs,cli
+extras = docs,cli,lxml
 changedir = docs
 commands =
     sphinx-build -b html . _build

--- a/xsdata/codegen/handlers/attribute_compound_choice.py
+++ b/xsdata/codegen/handlers/attribute_compound_choice.py
@@ -18,15 +18,15 @@ class AttributeCompoundChoiceHandler(RelativeHandlerInterface):
     """Group attributes that belong in the same choice and replace them by
     compound fields."""
 
-    __slots__ = "compound_fields"
+    __slots__ = "config"
 
     def __init__(self, container: ContainerInterface):
         super().__init__(container)
 
-        self.compound_fields = container.config.output.compound_fields
+        self.config = container.config.output.compound_fields
 
     def process(self, target: Class):
-        if self.compound_fields:
+        if self.config.enabled:
             groups = group_by(target.attrs, get_restriction_choice)
             for choice, attrs in groups.items():
                 if choice and len(attrs) > 1 and any(attr.is_list for attr in attrs):
@@ -74,8 +74,12 @@ class AttributeCompoundChoiceHandler(RelativeHandlerInterface):
         reserved = set(map(get_slug, self.base_attrs(target)))
         reserved.update(map(get_slug, target.attrs))
 
-        if len(names) > 3 or len(names) != len(set(names)):
-            name = "choice"
+        if (
+            self.config.force_default_name
+            or len(names) > 3
+            or len(names) != len(set(names))
+        ):
+            name = self.config.default_name
         else:
             name = "_Or_".join(names)
 

--- a/xsdata/formats/dataclass/client.py
+++ b/xsdata/formats/dataclass/client.py
@@ -36,9 +36,13 @@ class Config(NamedTuple):
     @classmethod
     def from_service(cls, obj: Any, **kwargs: Any) -> "Config":
         """Instantiate from a generated service class."""
-        return cls(
-            **{key: kwargs.get(key) or getattr(obj, key, None) for key in cls._fields}
-        )
+
+        params = {
+            key: kwargs[key] if key in kwargs else getattr(obj, key, None)
+            for key in cls._fields
+        }
+
+        return cls(**params)
 
 
 class TransportTypes:

--- a/xsdata/formats/dataclass/parsers/handlers/__init__.py
+++ b/xsdata/formats/dataclass/parsers/handlers/__init__.py
@@ -9,7 +9,6 @@ try:
     def default_handler() -> Type[XmlHandler]:
         return LxmlEventHandler
 
-
 except ImportError:  # pragma: no cover
 
     def default_handler() -> Type[XmlHandler]:

--- a/xsdata/formats/dataclass/serializers/writers/__init__.py
+++ b/xsdata/formats/dataclass/serializers/writers/__init__.py
@@ -9,7 +9,6 @@ try:
     def default_writer() -> Type[XmlWriter]:
         return LxmlEventWriter
 
-
 except ImportError:  # pragma: no cover
 
     def default_writer() -> Type[XmlWriter]:

--- a/xsdata/models/config.py
+++ b/xsdata/models/config.py
@@ -1,7 +1,6 @@
 import sys
 import warnings
 from dataclasses import dataclass
-from dataclasses import field
 from enum import Enum
 from pathlib import Path
 from typing import Any
@@ -25,6 +24,7 @@ from xsdata.models.enums import Namespace
 from xsdata.models.mixins import array_element
 from xsdata.models.mixins import attribute
 from xsdata.models.mixins import element
+from xsdata.models.mixins import text_node
 from xsdata.utils import objects
 from xsdata.utils import text
 
@@ -165,7 +165,7 @@ class OutputFormat:
     :param kw_only: Enable keyword only arguments, default: false, python>=3.10 Only
     """
 
-    value: str = field(default="dataclasses")
+    value: str = text_node(default="dataclasses", cli="output")
     repr: bool = attribute(default=True)
     eq: bool = attribute(default=True)
     order: bool = attribute(default=False)
@@ -198,6 +198,23 @@ class OutputFormat:
 
 
 @dataclass
+class CompoundFields:
+    """
+    Compound fields options.
+
+    :param enabled: Use compound fields for repeatable elements, default: false
+    :param default_name: Default compound field name, default: choice
+    :param force_default_name: Always use the default compound field, otherwise
+        if the number of elements is less than 4 the generator will try to dynamically
+        create the field name eg. hat_or_dress_or_something.
+    """
+
+    enabled: bool = text_node(default=False, cli="compound-fields")
+    default_name: str = attribute(default="choice", cli=False)
+    force_default_name: bool = attribute(default=False, cli=False)
+
+
+@dataclass
 class GeneratorOutput:
     """
     Main generator output options.
@@ -218,7 +235,7 @@ class GeneratorOutput:
     )
     docstring_style: DocstringStyle = element(default=DocstringStyle.RST)
     relative_imports: bool = element(default=False)
-    compound_fields: bool = element(default=False)
+    compound_fields: CompoundFields = element(default_factory=CompoundFields)
     max_line_length: int = attribute(default=79)
 
     def update(self, **kwargs: Any):
@@ -350,9 +367,11 @@ class GeneratorConfig:
     Generator configuration binding model.
 
     :cvar version: xsdata version number the config was created/updated
-    :param output: output options
-    :param conventions: generator conventions
-    :param aliases: generator aliases
+    :param output: Output options
+    :param conventions: Generator conventions
+    :param aliases: Generator aliases, Deprecated since v21.12, use substitutions
+    :param substitutions: Generator search and replace substitutions for classes,
+        fields, packages and modules names.
     """
 
     class Meta:

--- a/xsdata/models/mixins.py
+++ b/xsdata/models/mixins.py
@@ -187,12 +187,18 @@ class ElementBase:
                 yield value
 
 
+def text_node(**kwargs: Any) -> Any:
+    """Shortcut method for text node fields."""
+    metadata = extract_metadata(kwargs, type=XmlType.TEXT)
+    add_default_value(kwargs, optional=False)
+
+    return field(metadata=metadata, **kwargs)
+
+
 def attribute(optional: bool = True, **kwargs: Any) -> Any:
     """Shortcut method for attribute fields."""
     metadata = extract_metadata(kwargs, type=XmlType.ATTRIBUTE)
-
-    if not has_default(kwargs) and optional:
-        kwargs["default"] = None
+    add_default_value(kwargs, optional=optional)
 
     return field(metadata=metadata, **kwargs)
 
@@ -200,11 +206,17 @@ def attribute(optional: bool = True, **kwargs: Any) -> Any:
 def element(optional: bool = True, **kwargs: Any) -> Any:
     """Shortcut method for element fields."""
     metadata = extract_metadata(kwargs, type=XmlType.ELEMENT)
-
-    if not has_default(kwargs) and optional:
-        kwargs["default"] = None
+    add_default_value(kwargs, optional=optional)
 
     return field(metadata=metadata, **kwargs)
+
+
+def add_default_value(params: Dict, optional: bool):
+    """Add default value to the params if it's missing and its marked as
+    optional."""
+
+    if optional and not ("default" in params or "default_factory" in params):
+        params["default"] = None
 
 
 def array_element(**kwargs: Any) -> Any:
@@ -229,11 +241,6 @@ def extract_metadata(params: Dict, **kwargs: Any) -> Dict:
     }
     metadata.update(kwargs)
     return metadata
-
-
-def has_default(params: Dict) -> bool:
-    """Chek if default value or factory exists in the given params."""
-    return "default" in params or "default_factory" in params
 
 
 FIELD_PARAMS = (

--- a/xsdata/utils/click.py
+++ b/xsdata/utils/click.py
@@ -38,6 +38,11 @@ def build_options(obj: Any, parent: str) -> Iterator[Callable[[FC], FC]]:
     for field in fields(obj):
         type_hint = type_hints[field.name]
         doc_hint = doc_hints[field.name]
+        name = field.metadata.get("cli", field.name)
+
+        if not name:
+            continue
+
         qname = f"{parent}.{field.name}".strip(".")
 
         if is_dataclass(type_hint):
@@ -45,19 +50,19 @@ def build_options(obj: Any, parent: str) -> Iterator[Callable[[FC], FC]]:
         else:
             is_flag = False
             opt_type = type_hint
-            if field.name == "value":
+            if name == "output":
                 opt_type = click.Choice(CodeWriter.generators.keys())
                 names = ["-o", "--output"]
             elif type_hint is bool:
                 is_flag = True
                 opt_type = None
-                name = text.kebab_case(field.name)
+                name = text.kebab_case(name)
                 names = [f"--{name}/--no-{name}"]
             else:
                 if issubclass(type_hint, enum.Enum):
                     opt_type = EnumChoice(type_hint)
 
-                parts = text.split_words(field.name)
+                parts = text.split_words(name)
                 name = "-".join(parts)
                 name_short = "".join(part[0] for part in parts)
                 names = [f"--{name}", f"-{name_short}"]


### PR DESCRIPTION
## 📒 Description

When a compound field consists of more than 3 elements, the field is named **choice** otherwise the generator tries to use a concatenation of the sub field names eg "hat_or_dress_or_shoes".

We need a config option to bypass that behavior to always use a fixed name and to be able to change the fixed name as well. 


Resolves #639

## 🔗 What I've Done

 - Added new configuration options compound fields: default name and force default name
 - Use the above options to alter the current behavior in the AttributeCompoundChoiceHandler


## 💬 Comments

The new options are only available through the custom project config `xsdata init-config`

```xml
<?xml version="1.0" encoding="UTF-8"?>
<Config xmlns="http://pypi.org/project/xsdata" version="21.12">
  <Output maxLineLength="79">
    <Package>generated</Package>
    <Format repr="true" eq="true" order="false" unsafeHash="false" frozen="false" slots="false" kwOnly="false">dataclasses</Format>
    <Structure>filenames</Structure>
    <DocstringStyle>reStructuredText</DocstringStyle>
    <RelativeImports>false</RelativeImports>
    <CompoundFields defaultName="choice" forceDefaultName="false">false</CompoundFields>
  </Output>
  <Conventions>
    <ClassName case="pascalCase" safePrefix="type"/>
    <FieldName case="snakeCase" safePrefix="value"/>
    <ConstantName case="screamingSnakeCase" safePrefix="value"/>
    <ModuleName case="snakeCase" safePrefix="mod"/>
    <PackageName case="snakeCase" safePrefix="pkg"/>
  </Conventions>
  <Substitutions>
    <Substitution type="package" search="http://www.w3.org/2001/XMLSchema" replace="xs"/>
    <Substitution type="class" search="Class" replace="Type"/>
  </Substitutions>
</Config>
```

## 🛫 Checklist

- [x] Updated docs
- [x] Added unit-tests
- [x] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [x] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
