### PR TITLE
Support recursive glob for cli dir source

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -149,9 +149,12 @@ class CliTests(TestCase):
         file = hello_path.joinpath("hello.xsd")
         url = "http://www.xsdata/schema.xsd"
 
-        self.assertEqual([file.as_uri()], list(resolve_source(str(file))))
-        self.assertEqual([url], list(resolve_source(url)))
-        self.assertEqual(5, len(list(resolve_source(str(hello_path)))))
+        self.assertEqual([file.as_uri()], list(resolve_source(str(file), False)))
+        self.assertEqual([url], list(resolve_source(url, False)))
+        self.assertEqual(5, len(list(resolve_source(str(hello_path), False))))
 
         def_xml_path = fixtures_dir.joinpath("calculator")
-        self.assertEqual(3, len(list(resolve_source(str(def_xml_path)))))
+        self.assertEqual(3, len(list(resolve_source(str(def_xml_path), False))))
+
+        actual = list(resolve_source(str(fixtures_dir), True))
+        self.assertEqual(32, len(actual))


### PR DESCRIPTION
## 📒 Description

The cli generate command with a directory an input source expects at least one of the target source files (xsd, wsdl, xml json) to be in the root directory.

Resolves #643

## 🔗 What I've Done

 - Support recursive glob for cli dir sources, in order to find all sources in all sub levels
 - Add cli flag --recursive to enable it


## 💬 Comments


## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
