### PR TITLE
Remove the internal prefix for value fields

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: pyupgrade
         args: [--py37-plus]
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v2.6.0
+    rev: v2.7.1
     hooks:
       - id: reorder-python-imports
   - repo: https://github.com/ambv/black

--- a/tests/codegen/handlers/test_class_extension.py
+++ b/tests/codegen/handlers/test_class_extension.py
@@ -444,7 +444,7 @@ class ClassExtensionHandlerTests(FactoryTestCase):
 
         ClassExtensionHandler.add_default_attribute(item, extension)
         expected = AttrFactory.create(
-            name="@value", default=None, types=[xs_string], tag=Tag.EXTENSION
+            name="value", default=None, types=[xs_string], tag=Tag.EXTENSION
         )
 
         self.assertEqual(2, len(item.attrs))

--- a/tests/codegen/test_utils.py
+++ b/tests/codegen/test_utils.py
@@ -179,23 +179,6 @@ class ClassUtilsTests(FactoryTestCase):
         self.assertEqual(target.module, target.inner[0].module)
         self.assertEqual(inner.qname, target.inner[0].qname)
 
-    def test_copy_inner_class_rename_simple_inner_type(self):
-        source = ClassFactory.create()
-        inner = ClassFactory.create(qname="{a}@value", module="b", package="c")
-        target = ClassFactory.create()
-        attr = AttrFactory.create(name="simple")
-        attr_type = AttrTypeFactory.create(forward=True, qname=inner.qname)
-
-        source.inner.append(inner)
-        ClassUtils.copy_inner_class(source, target, attr, attr_type)
-
-        self.assertEqual(1, len(target.inner))
-        self.assertIsNot(inner, target.inner[0])
-        self.assertEqual(target.package, target.inner[0].package)
-        self.assertEqual(target.module, target.inner[0].module)
-        self.assertEqual("{a}simple", target.inner[0].qname)
-        self.assertEqual("{a}simple", attr_type.qname)
-
     def test_copy_inner_class_skip_non_forward_reference(self):
         source = ClassFactory.create()
         target = ClassFactory.create()

--- a/tests/models/xsd/test_alternative.py
+++ b/tests/models/xsd/test_alternative.py
@@ -6,7 +6,7 @@ from xsdata.models.xsd import Alternative
 class AlternativeTests(TestCase):
     def test_property_real_name(self):
         obj = Alternative()
-        self.assertEqual("@value", obj.real_name)
+        self.assertEqual("value", obj.real_name)
 
         obj.id = "foo"
         self.assertEqual("foo", obj.real_name)

--- a/tests/models/xsd/test_list.py
+++ b/tests/models/xsd/test_list.py
@@ -10,7 +10,7 @@ class ListTests(TestCase):
 
     def test_real_name(self):
         obj = List()
-        self.assertEqual("@value", obj.real_name)
+        self.assertEqual("value", obj.real_name)
 
     def test_real_type(self):
         obj = List()

--- a/tests/models/xsd/test_restriction.py
+++ b/tests/models/xsd/test_restriction.py
@@ -34,7 +34,7 @@ class RestrictionTests(TestCase):
 
     def test_property_real_name(self):
         obj = Restriction()
-        self.assertEqual("@value", obj.real_name)
+        self.assertEqual("value", obj.real_name)
 
     def test_property_bases(self):
         obj = Restriction()

--- a/tests/models/xsd/test_simple_type.py
+++ b/tests/models/xsd/test_simple_type.py
@@ -11,7 +11,7 @@ from xsdata.models.xsd import Union
 class SimpleTypeTests(TestCase):
     def test_property_real_name(self):
         obj = SimpleType()
-        self.assertEqual("@value", obj.real_name)
+        self.assertEqual("value", obj.real_name)
 
         obj.name = "foo"
         self.assertEqual("foo", obj.real_name)

--- a/tests/models/xsd/test_union.py
+++ b/tests/models/xsd/test_union.py
@@ -25,7 +25,7 @@ class UnionTests(TestCase):
 
     def test_property_real_name(self):
         obj = Union()
-        self.assertEqual("@value", obj.real_name)
+        self.assertEqual("value", obj.real_name)
 
     def test_property_attr_types(self):
         obj = Union()

--- a/xsdata/codegen/handlers/class_extension.py
+++ b/xsdata/codegen/handlers/class_extension.py
@@ -11,6 +11,7 @@ from xsdata.logger import logger
 from xsdata.models.enums import DataType
 from xsdata.models.enums import NamespaceType
 from xsdata.models.enums import Tag
+from xsdata.utils.constants import DEFAULT_ATTR_NAME
 
 
 class ClassExtensionHandler(RelativeHandlerInterface):
@@ -268,7 +269,7 @@ class ClassExtensionHandler(RelativeHandlerInterface):
         type."""
         if extension.type.datatype != DataType.ANY_TYPE:
             tag = Tag.EXTENSION
-            name = "@value"
+            name = DEFAULT_ATTR_NAME
             namespace = None
         else:
             tag = Tag.ANY

--- a/xsdata/codegen/utils.py
+++ b/xsdata/codegen/utils.py
@@ -136,13 +136,6 @@ class ClassUtils:
             clone = inner.clone()
             clone.package = target.package
             clone.module = target.module
-
-            # Simple type, update the name
-            if clone.name == "@value":
-                namespace, _ = namespaces.split_qname(clone.qname)
-                qname = namespaces.build_qname(namespace, attr.name)
-                clone.qname = attr_type.qname = qname
-
             target.inner.append(clone)
 
     @classmethod

--- a/xsdata/models/xsd.py
+++ b/xsdata/models/xsd.py
@@ -24,13 +24,12 @@ from xsdata.models.mixins import element
 from xsdata.models.mixins import ElementBase
 from xsdata.utils import text
 from xsdata.utils.collections import unique_sequence
+from xsdata.utils.constants import DEFAULT_ATTR_NAME
 from xsdata.utils.namespaces import clean_uri
 
 docstring_serializer = XmlSerializer(
     config=SerializerConfig(pretty_print=True, xml_declaration=False)
 )
-
-DEFAULT_ATTR_NAME = "@value"
 
 
 @dataclass(frozen=True)

--- a/xsdata/utils/constants.py
+++ b/xsdata/utils/constants.py
@@ -10,6 +10,7 @@ EMPTY_TUPLE: Tuple = ()
 
 XML_FALSE = sys.intern("false")
 XML_TRUE = sys.intern("true")
+DEFAULT_ATTR_NAME = "value"
 
 
 def return_true(*_: Any) -> bool:


### PR DESCRIPTION
## 📒 Description

The originalCase convention performs no string transformations when used for field/classes/... names.
The generator is also using the field name `@value` for all infered text nodes.

These two don't work very well together.

Resolves #646 


## 🔗 What I've Done

In the past enumeration classes were allowed to be inner|nested. To resolve that issue I used the prefix @ for value fields in order to quickly identify these cases when the generator had to copy inner classes from one class to another.
    
It's being a while now that all enumeration classes are promoted to root classes, so that hack to identify these cases is no longer necessary so it's safe to remove that part of the code and also remove the @ prefix that is causing the issue #646


## 💬 Comments

Hopefully most of these hacks from the early days are long gone.


## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
