### PR TITLE
Preserve substitution groups on duplicate global types

### DIFF
--- a/tests/codegen/handlers/test_attribute_substitution.py
+++ b/tests/codegen/handlers/test_attribute_substitution.py
@@ -4,6 +4,7 @@ from xsdata.codegen.container import ClassContainer
 from xsdata.codegen.handlers import AttributeSubstitutionHandler
 from xsdata.codegen.models import AttrType
 from xsdata.models.config import GeneratorConfig
+from xsdata.models.enums import Tag
 from xsdata.utils.namespaces import build_qname
 from xsdata.utils.testing import AttrFactory
 from xsdata.utils.testing import AttrTypeFactory
@@ -116,7 +117,7 @@ class AttributeSubstitutionHandlerTests(FactoryTestCase):
             name=item.name,
             default=None,
             types=[AttrType(qname=build_qname("foo", "bar"))],
-            tag=item.tag,
+            tag=Tag.ELEMENT,
         )
 
         self.assertEqual(expected, actual)

--- a/tests/codegen/test_validator.py
+++ b/tests/codegen/test_validator.py
@@ -93,8 +93,14 @@ class ClassValidatorTests(FactoryTestCase):
         )
 
     def test_merge_global_types(self):
-        one = ClassFactory.create(qname="foo", tag=Tag.ELEMENT, namespace="a", help="b")
-        two = ClassFactory.create(qname="foo", tag=Tag.COMPLEX_TYPE)
+        one = ClassFactory.create(
+            qname="foo",
+            tag=Tag.ELEMENT,
+            namespace="a",
+            help="b",
+            substitutions=["a", "b"],
+        )
+        two = ClassFactory.create(qname="foo", tag=Tag.COMPLEX_TYPE, substitutions=[])
         three = ClassFactory.create(qname="foo", tag=Tag.SIMPLE_TYPE)
 
         classes = [one, two, three]
@@ -128,6 +134,8 @@ class ClassValidatorTests(FactoryTestCase):
         self.assertIn(three, classes)
         self.assertEqual(one.namespace, two.namespace)
         self.assertEqual(one.help, two.help)
+        self.assertEqual(one.substitutions, two.substitutions)
+        self.assertEqual(2, len(one.substitutions))
 
     @mock.patch.object(ClassUtils, "copy_extensions")
     @mock.patch.object(ClassUtils, "copy_attributes")

--- a/xsdata/codegen/handlers/attribute_substitution.py
+++ b/xsdata/codegen/handlers/attribute_substitution.py
@@ -9,6 +9,7 @@ from xsdata.codegen.models import Attr
 from xsdata.codegen.models import AttrType
 from xsdata.codegen.models import Class
 from xsdata.codegen.utils import ClassUtils
+from xsdata.models.enums import Tag
 from xsdata.utils import collections
 
 
@@ -82,6 +83,6 @@ class AttributeSubstitutionHandler(RelativeHandlerInterface):
         return Attr(
             name=source.name,
             types=[AttrType(qname=source.qname)],
-            tag=source.tag,
+            tag=Tag.ELEMENT,
             namespace=source.namespace,
         )

--- a/xsdata/codegen/validator.py
+++ b/xsdata/codegen/validator.py
@@ -156,4 +156,5 @@ class ClassValidator:
 
         ct.namespace = el.namespace or ct.namespace
         ct.help = el.help or ct.help
+        ct.substitutions = el.substitutions
         classes.remove(el)


### PR DESCRIPTION
## 📒 Description

In xsd it's allowed to have one complexType and one element with the same name like this 

```xml
<complexType name="foo">

</complexType>

<element name="foo" type="foo" />
```

The generator in this case will merge these two types together in order to produce a single class.
In the scenario that the element also substitutes another element, that reference is lost during the above merge

Resolves #648

## 🔗 What I've Done

- Maintain the subsitutions list when we merge a complex type with an element
- Be explicit in AttributeSubstitutionHandler that all substitutions come from elements


## 💬 Comments

Cool issue


## 🛫 Checklist

- [ ] Updated docs
- [x] Added unit-tests
- [x] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [x] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
