### PR TITLE
Add ImportAnnotations configuration option

### DIFF
--- a/docs/faq/why-i-get-a-typeerror-requires-a-single-type.rst
+++ b/docs/faq/why-i-get-a-typeerror-requires-a-single-type.rst
@@ -1,5 +1,5 @@
-Why I get a TypeError: requires a single type
-=============================================
+Why do I get a TypeError: requires a single type
+================================================
 
 The full error message looks something like this:
 
@@ -7,22 +7,9 @@ The full error message looks something like this:
 
     TypeError: typing.Optional requires a single type. Got Field(name=None,type=None,default=<dataclasses._MISSING_TYPE object at 0x7f79f4b0d700>,default_facto.
 
-The error means the dataclass wrapper can't build the typing annotations for a model
-because the field type is ambiguous. If you are using the code generator make sure you
-are not using the same convention for both field and class names.
+This error means the typing annotations for a model are ambiguous because they collide with a class field. You can set :code:`ImportAnnotations` to :code:`true` in the :ref:`GeneratorOutput` section of the :ref:`generator config <Generator Config>` to solve this issue. This will enable Postponed Evaluations of Annotations (`PEP 563 <https://www.python.org/dev/peps/pep-0563/>`_) and the generated bindings will be able to be imported without errors.
 
 **Example**
 
-.. code-block:: python
-
-    @dataclass
-    class unit:
-        pass
-
-
-    @dataclass
-    class element:
-        unit: Optional[unit] = field()
-
-
-Read :ref:`more <Generator Config>`
+.. literalinclude:: /../tests/fixtures/annotations/model.py
+   :language: python

--- a/docs/faq/why-i-get-a-typeerror-requires-a-single-type.rst
+++ b/docs/faq/why-i-get-a-typeerror-requires-a-single-type.rst
@@ -7,7 +7,7 @@ The full error message looks something like this:
 
     TypeError: typing.Optional requires a single type. Got Field(name=None,type=None,default=<dataclasses._MISSING_TYPE object at 0x7f79f4b0d700>,default_facto.
 
-This error means the typing annotations for a model are ambiguous because they collide with a class field. If you use Python 3.7 or later, you can set :code:`ImportAnnotations` to :code:`true` in the :ref:`GeneratorOutput` section of the :ref:`generator config <Generator Config>` to solve this issue. This will enable Postponed Evaluations of Annotations (`PEP 563 <https://www.python.org/dev/peps/pep-0563/>`_) and the generated bindings will be able to be imported without errors. This feature is not available for Python 3.6 because :code:`annotations` were added to the :code:`__future__` module in Python 3.7.0b1.
+This error means the typing annotations for a model are ambiguous because they collide with a class field. If you use Python 3.7 or later, you can set :code:`PostponedAnnotations` to :code:`true` in the :ref:`GeneratorOutput` section of the :ref:`generator config <Generator Config>` to solve this issue. This will enable Postponed Evaluations of Annotations (`PEP 563 <https://www.python.org/dev/peps/pep-0563/>`_) and the generated bindings will be able to be imported without errors. This feature is not available for Python 3.6 because :code:`annotations` were added to the :code:`__future__` module in Python 3.7.0b1.
 
 **Example**
 

--- a/docs/faq/why-i-get-a-typeerror-requires-a-single-type.rst
+++ b/docs/faq/why-i-get-a-typeerror-requires-a-single-type.rst
@@ -7,7 +7,7 @@ The full error message looks something like this:
 
     TypeError: typing.Optional requires a single type. Got Field(name=None,type=None,default=<dataclasses._MISSING_TYPE object at 0x7f79f4b0d700>,default_facto.
 
-This error means the typing annotations for a model are ambiguous because they collide with a class field. You can set :code:`ImportAnnotations` to :code:`true` in the :ref:`GeneratorOutput` section of the :ref:`generator config <Generator Config>` to solve this issue. This will enable Postponed Evaluations of Annotations (`PEP 563 <https://www.python.org/dev/peps/pep-0563/>`_) and the generated bindings will be able to be imported without errors.
+This error means the typing annotations for a model are ambiguous because they collide with a class field. If you use Python 3.7 or later, you can set :code:`ImportAnnotations` to :code:`true` in the :ref:`GeneratorOutput` section of the :ref:`generator config <Generator Config>` to solve this issue. This will enable Postponed Evaluations of Annotations (`PEP 563 <https://www.python.org/dev/peps/pep-0563/>`_) and the generated bindings will be able to be imported without errors. This feature is not available for Python 3.6 because :code:`annotations` were added to the :code:`__future__` module in Python 3.7.0b1.
 
 **Example**
 

--- a/tests/fixtures/annotations/__init__.py
+++ b/tests/fixtures/annotations/__init__.py
@@ -1,0 +1,11 @@
+from tests.fixtures.annotations.model import (
+    Measurement,
+    Weight,
+)
+from tests.fixtures.annotations.units import unit
+
+__all__ = [
+    "Measurement",
+    "Weight",
+    "unit",
+]

--- a/tests/fixtures/annotations/model.py
+++ b/tests/fixtures/annotations/model.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Optional
+from tests.fixtures.annotations.units import unit
+
+__NAMESPACE__ = "http://domain.org/schema/model"
+
+
+@dataclass
+class Measurement:
+    value: Optional[float] = field(
+        default=None,
+        metadata={
+            "required": True,
+        }
+    )
+    unit: Optional[unit] = field(
+        default=None,
+        metadata={
+            "type": "Attribute",
+        }
+    )
+
+
+@dataclass
+class Weight(Measurement):
+    class Meta:
+        namespace = "http://domain.org/schema/model"

--- a/tests/fixtures/annotations/model.xsd
+++ b/tests/fixtures/annotations/model.xsd
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xs:schema targetNamespace="http://domain.org/schema/model"
+  xmlns="http://domain.org/schema/model"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:utd="http://domain.org/schema/model/units">
+
+  <xs:import schemaLocation="./units.xsd"/>
+
+  <xs:complexType name="Measurement">
+    <xs:simpleContent>
+      <xs:extension base="xs:double">
+        <xs:attribute name="unit" type="utd:unit"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="Weight" type="Measurement"/>
+</xs:schema>

--- a/tests/fixtures/annotations/sample.xml
+++ b/tests/fixtures/annotations/sample.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Weight unit="kg">2.0</Weight>

--- a/tests/fixtures/annotations/units.py
+++ b/tests/fixtures/annotations/units.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+from enum import Enum
+
+__NAMESPACE__ = "http://domain.org/schema/model/units"
+
+
+class unit(Enum):
+    M = "m"
+    KG = "kg"
+    VALUE = "%"
+    NA = "NA"

--- a/tests/fixtures/annotations/units.xsd
+++ b/tests/fixtures/annotations/units.xsd
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xs:schema targetNamespace="http://domain.org/schema/model/units"
+	xmlns="http://domain.org/schema/model/units"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+	<xs:simpleType name="stdUnit">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="m"/>
+			<xs:enumeration value="kg"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="miscUnit">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="%"/>
+			<xs:enumeration value="NA"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="unit">
+		<xs:union memberTypes="stdUnit miscUnit"/>
+	</xs:simpleType>
+</xs:schema>

--- a/tests/fixtures/annotations/xsdata.xml
+++ b/tests/fixtures/annotations/xsdata.xml
@@ -7,7 +7,7 @@
     <DocstringStyle>reStructuredText</DocstringStyle>
     <RelativeImports>false</RelativeImports>
     <CompoundFields defaultName="choice" forceDefaultName="false">true</CompoundFields>
-    <ImportAnnotations>true</ImportAnnotations>
+    <PostponedAnnotations>true</PostponedAnnotations>
   </Output>
   <Conventions>
     <ClassName case="originalCase" safePrefix="type"/>

--- a/tests/fixtures/annotations/xsdata.xml
+++ b/tests/fixtures/annotations/xsdata.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Config xmlns="http://pypi.org/project/xsdata" version="22.1">
+  <Output maxLineLength="79">
+    <Package>tests.fixtures.annotations</Package>
+    <Format repr="true" eq="true" order="false" unsafeHash="false" frozen="false" slots="false" kwOnly="false">dataclasses</Format>
+    <Structure>filenames</Structure>
+    <DocstringStyle>reStructuredText</DocstringStyle>
+    <RelativeImports>false</RelativeImports>
+    <CompoundFields defaultName="choice" forceDefaultName="false">true</CompoundFields>
+    <ImportAnnotations>true</ImportAnnotations>
+  </Output>
+  <Conventions>
+    <ClassName case="originalCase" safePrefix="type"/>
+    <FieldName case="originalCase" safePrefix="value"/>
+    <ConstantName case="screamingSnakeCase" safePrefix="value"/>
+    <ModuleName case="snakeCase" safePrefix="mod"/>
+    <PackageName case="originalCase" safePrefix="pkg"/>
+  </Conventions>
+  <Substitutions/>
+</Config>

--- a/tests/formats/dataclass/test_filters.py
+++ b/tests/formats/dataclass/test_filters.py
@@ -676,7 +676,7 @@ class FiltersTests(FactoryTestCase):
 
     def test_default_imports_with_annotations(self):
         config = GeneratorConfig()
-        config.output.import_annotations = True
+        config.output.postponed_annotations = True
         filters = Filters(config)
 
         expected = "from __future__ import annotations"

--- a/tests/formats/dataclass/test_filters.py
+++ b/tests/formats/dataclass/test_filters.py
@@ -674,6 +674,14 @@ class FiltersTests(FactoryTestCase):
         expected = "import attrs"
         self.assertEqual(expected, self.filters.default_imports(output))
 
+    def test_default_imports_with_annotations(self):
+        config = GeneratorConfig()
+        config.output.import_annotations = True
+        filters = Filters(config)
+
+        expected = "from __future__ import annotations"
+        self.assertEqual(expected, filters.default_imports(""))
+
     def test_format_metadata(self):
         data = dict(
             num=1,

--- a/tests/integration/test_annotations.py
+++ b/tests/integration/test_annotations.py
@@ -1,7 +1,8 @@
 import os
+import sys
 
+import pytest
 from click.testing import CliRunner
-from pytest import fail
 
 from tests import fixtures_dir
 from tests import root
@@ -13,6 +14,7 @@ from xsdata.utils.testing import load_class
 os.chdir(root)
 
 
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="PEP563 introduced in 3.7")
 def test_annotations():
     filepath = fixtures_dir.joinpath("annotations")
     schema = filepath.joinpath("model.xsd")
@@ -28,7 +30,7 @@ def test_annotations():
         Measurement = load_class(result.output, "Measurement")
         unit = load_class(result.output, "unit")
     except Exception:
-        fail("Could not load class with member having the same name as type")
+        pytest.fail("Could not load class with member having the same name as type")
 
     filename = str(filepath.joinpath("sample.xml"))
     parser = XmlParser(context=XmlContext())

--- a/tests/integration/test_annotations.py
+++ b/tests/integration/test_annotations.py
@@ -1,0 +1,37 @@
+import os
+
+from click.testing import CliRunner
+from pytest import fail
+
+from tests import fixtures_dir
+from tests import root
+from xsdata.cli import cli
+from xsdata.formats.dataclass.context import XmlContext
+from xsdata.formats.dataclass.parsers.xml import XmlParser
+from xsdata.utils.testing import load_class
+
+os.chdir(root)
+
+
+def test_annotations():
+    filepath = fixtures_dir.joinpath("annotations")
+    schema = filepath.joinpath("model.xsd")
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, [str(schema), f"--config={str(filepath.joinpath('xsdata.xml'))}"]
+    )
+
+    if result.exception:
+        raise result.exception
+
+    try:
+        Measurement = load_class(result.output, "Measurement")
+        unit = load_class(result.output, "unit")
+    except Exception:
+        fail("Could not load class with member having the same name as type")
+
+    filename = str(filepath.joinpath("sample.xml"))
+    parser = XmlParser(context=XmlContext())
+    measurement = parser.parse(filename, Measurement)
+    assert measurement.value == 2.0
+    assert measurement.unit == unit.KG

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -156,7 +156,12 @@ class GeneratorConfigTests(TestCase):
             self.assertIsNotNone(OutputFormat(kw_only=True))
 
     def test_postponed_annotations_requires_37(self):
-        if sys.version_info < (3, 7):
+        # We need to confuse pyupgrade into not discarding Python version checks,
+        # which are needed to know when the warning is triggered or not
+        # Extracting the version in a local variable before performing the check is
+        # sufficient for that purpose.
+        v = sys.version_info
+        if v < (3, 7):
             with warnings.catch_warnings(record=True) as w:
                 self.assertFalse(
                     GeneratorOutput(postponed_annotations=True).postponed_annotations
@@ -166,9 +171,10 @@ class GeneratorConfigTests(TestCase):
                     str(w[-1].message),
                 )
 
-        # Using an else statement makes pyupgrade want to rewrite the test by
-        # discarding the previous block
-        self.assertIsNotNone(GeneratorOutput(postponed_annotations=True))
+        if v >= (3, 7):
+            self.assertTrue(
+                GeneratorOutput(postponed_annotations=True).postponed_annotations
+            )
 
     def test_init_config_with_aliases(self):
         config = GeneratorConfig(

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -34,7 +34,7 @@ class GeneratorConfigTests(TestCase):
             "    <DocstringStyle>reStructuredText</DocstringStyle>\n"
             "    <RelativeImports>false</RelativeImports>\n"
             '    <CompoundFields defaultName="choice" forceDefaultName="false">false</CompoundFields>\n'
-            "    <ImportAnnotations>false</ImportAnnotations>\n"
+            "    <PostponedAnnotations>false</PostponedAnnotations>\n"
             "  </Output>\n"
             "  <Conventions>\n"
             '    <ClassName case="pascalCase" safePrefix="type"/>\n'
@@ -90,7 +90,7 @@ class GeneratorConfigTests(TestCase):
             "    <DocstringStyle>reStructuredText</DocstringStyle>\n"
             "    <RelativeImports>false</RelativeImports>\n"
             '    <CompoundFields defaultName="choice" forceDefaultName="false">false</CompoundFields>\n'
-            "    <ImportAnnotations>false</ImportAnnotations>\n"
+            "    <PostponedAnnotations>false</PostponedAnnotations>\n"
             "  </Output>\n"
             "  <Conventions>\n"
             '    <ClassName case="pascalCase" safePrefix="type"/>\n'

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -10,6 +10,7 @@ from xsdata.exceptions import ParserError
 from xsdata.models.config import GeneratorAlias
 from xsdata.models.config import GeneratorAliases
 from xsdata.models.config import GeneratorConfig
+from xsdata.models.config import GeneratorOutput
 from xsdata.models.config import ObjectType
 from xsdata.models.config import OutputFormat
 
@@ -153,6 +154,21 @@ class GeneratorConfigTests(TestCase):
 
         else:
             self.assertIsNotNone(OutputFormat(kw_only=True))
+
+    def test_postponed_annotations_requires_37(self):
+        if sys.version_info < (3, 7):
+            with warnings.catch_warnings(record=True) as w:
+                self.assertFalse(
+                    GeneratorOutput(postponed_annotations=True).postponed_annotations
+                )
+                self.assertEqual(
+                    "postponed annotations requires python >= 3.7, reverting...",
+                    str(w[-1].message),
+                )
+
+        # Using an else statement makes pyupgrade want to rewrite the test by
+        # discarding the previous block
+        self.assertIsNotNone(GeneratorOutput(postponed_annotations=True))
 
     def test_init_config_with_aliases(self):
         config = GeneratorConfig(

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -34,6 +34,7 @@ class GeneratorConfigTests(TestCase):
             "    <DocstringStyle>reStructuredText</DocstringStyle>\n"
             "    <RelativeImports>false</RelativeImports>\n"
             '    <CompoundFields defaultName="choice" forceDefaultName="false">false</CompoundFields>\n'
+            "    <ImportAnnotations>false</ImportAnnotations>\n"
             "  </Output>\n"
             "  <Conventions>\n"
             '    <ClassName case="pascalCase" safePrefix="type"/>\n'
@@ -89,6 +90,7 @@ class GeneratorConfigTests(TestCase):
             "    <DocstringStyle>reStructuredText</DocstringStyle>\n"
             "    <RelativeImports>false</RelativeImports>\n"
             '    <CompoundFields defaultName="choice" forceDefaultName="false">false</CompoundFields>\n'
+            "    <ImportAnnotations>false</ImportAnnotations>\n"
             "  </Output>\n"
             "  <Conventions>\n"
             '    <ClassName case="pascalCase" safePrefix="type"/>\n'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -157,4 +157,4 @@ class CliTests(TestCase):
         self.assertEqual(3, len(list(resolve_source(str(def_xml_path), False))))
 
         actual = list(resolve_source(str(fixtures_dir), True))
-        self.assertEqual(32, len(actual))
+        self.assertEqual(36, len(actual))

--- a/xsdata/formats/dataclass/filters.py
+++ b/xsdata/formats/dataclass/filters.py
@@ -50,7 +50,7 @@ class Filters:
         "docstring_style",
         "max_line_length",
         "relative_imports",
-        "import_annotations",
+        "postponed_annotations",
         "format",
         "import_patterns",
     )
@@ -73,7 +73,7 @@ class Filters:
         self.docstring_style: DocstringStyle = config.output.docstring_style
         self.max_line_length: int = config.output.max_line_length
         self.relative_imports: bool = config.output.relative_imports
-        self.import_annotations: bool = config.output.import_annotations
+        self.postponed_annotations: bool = config.output.postponed_annotations
         self.format = config.output.format
 
         # Build things
@@ -679,7 +679,7 @@ class Filters:
         """Generate the default imports for the given package output."""
         result = []
 
-        if self.import_annotations:
+        if self.postponed_annotations:
             result.append("from __future__ import annotations")
 
         for library, types in self.import_patterns.items():

--- a/xsdata/formats/dataclass/filters.py
+++ b/xsdata/formats/dataclass/filters.py
@@ -50,6 +50,7 @@ class Filters:
         "docstring_style",
         "max_line_length",
         "relative_imports",
+        "import_annotations",
         "format",
         "import_patterns",
     )
@@ -72,6 +73,7 @@ class Filters:
         self.docstring_style: DocstringStyle = config.output.docstring_style
         self.max_line_length: int = config.output.max_line_length
         self.relative_imports: bool = config.output.relative_imports
+        self.import_annotations: bool = config.output.import_annotations
         self.format = config.output.format
 
         # Build things
@@ -676,6 +678,10 @@ class Filters:
     def default_imports(self, output: str) -> str:
         """Generate the default imports for the given package output."""
         result = []
+
+        if self.import_annotations:
+            result.append("from __future__ import annotations")
+
         for library, types in self.import_patterns.items():
             names = [
                 name

--- a/xsdata/models/config.py
+++ b/xsdata/models/config.py
@@ -226,6 +226,8 @@ class GeneratorOutput:
     :param relative_imports: Use relative imports, default: false
     :param compound_fields: Use compound fields for repeatable elements, default: false
     :param max_line_length: Adjust the maximum line length, default: 79
+    :param import_annotations: Import annotations from :obj:`__future__` in generated
+        modules, default: false
     """
 
     package: str = element(default="generated")
@@ -237,6 +239,7 @@ class GeneratorOutput:
     relative_imports: bool = element(default=False)
     compound_fields: CompoundFields = element(default_factory=CompoundFields)
     max_line_length: int = attribute(default=79)
+    import_annotations: bool = element(default=False)
 
     def update(self, **kwargs: Any):
         objects.update(self, **kwargs)

--- a/xsdata/models/config.py
+++ b/xsdata/models/config.py
@@ -226,8 +226,8 @@ class GeneratorOutput:
     :param relative_imports: Use relative imports, default: false
     :param compound_fields: Use compound fields for repeatable elements, default: false
     :param max_line_length: Adjust the maximum line length, default: 79
-    :param import_annotations: Import annotations from :obj:`__future__` in generated
-        modules, default: false
+    :param postponed_annotations: Enable postponed evaluation of annotations,
+        default: false
     """
 
     package: str = element(default="generated")
@@ -239,7 +239,7 @@ class GeneratorOutput:
     relative_imports: bool = element(default=False)
     compound_fields: CompoundFields = element(default_factory=CompoundFields)
     max_line_length: int = attribute(default=79)
-    import_annotations: bool = element(default=False)
+    postponed_annotations: bool = element(default=False)
 
     def update(self, **kwargs: Any):
         objects.update(self, **kwargs)

--- a/xsdata/models/config.py
+++ b/xsdata/models/config.py
@@ -241,6 +241,17 @@ class GeneratorOutput:
     max_line_length: int = attribute(default=79)
     postponed_annotations: bool = element(default=False)
 
+    def __post_init__(self):
+        self.validate()
+
+    def validate(self):
+        if self.postponed_annotations and sys.version_info < (3, 7):
+            self.postponed_annotations = False
+            warnings.warn(
+                "postponed annotations requires python >= 3.7, reverting...",
+                CodeGenerationWarning,
+            )
+
     def update(self, **kwargs: Any):
         objects.update(self, **kwargs)
         self.format.validate()

--- a/xsdata/models/config.py
+++ b/xsdata/models/config.py
@@ -227,7 +227,7 @@ class GeneratorOutput:
     :param compound_fields: Use compound fields for repeatable elements, default: false
     :param max_line_length: Adjust the maximum line length, default: 79
     :param postponed_annotations: Enable postponed evaluation of annotations,
-        default: false
+        default: false, python>=3.7 Only
     """
 
     package: str = element(default="generated")


### PR DESCRIPTION
## 📒 Description

This PR adds a new element `ImportAnnotations` to the `Output` section of the configuration file.  The goal of this configuration option is to allow schemas introducing collisions between a class member name and its type in the generated bindings to be imported without errors.

Resolves #646 

## 🔗 What I've Done

As discussed in the second part of #646, name collisions originally raised a TypeError because type annotations could not be resolved. However, [PEP 563](https://www.python.org/dev/peps/pep-0563/) discusses a way to postpone the evaluation of type hints in such a way that name collisions are acceptable. This behavior  is optional in Python `3.7.0b1`, and will be mandatory in Python `3.10` (see [Future statement definitions](https://docs.python.org/3/library/__future__.html)).
This configuration option is disabled by default, and enabling it will add the following import at the top of all generated modules.

```python
from __future__ import annotations
```
This is done by simply prepending the import statement to the `default_imports` filter used in the `module` Jinja template. 

## 💬 Comments

Thank you for this library and the effort you're putting towards code quality. Let me know if more tests should be added for this feature.

## 🛫 Checklist

- [x] Updated docs
- [x] Added unit-tests
- [x] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [x] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
