### PR TITLE
Support subclasses with different namespaces

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -83,3 +83,4 @@ addopts = --color=yes --benchmark-skip
 [coverage:run]
 omit =
     xsdata/__main__.py
+    xsdata/utils/debug.py

--- a/tests/fixtures/models.py
+++ b/tests/fixtures/models.py
@@ -173,3 +173,20 @@ class Parent:
     @dataclass
     class Inner:
         pass
+
+
+@dataclass
+class TypeNS2:
+
+    class Meta:
+        namespace = "ns2"
+
+    x1: int = field(metadata=dict(type="Element"))
+
+@dataclass
+class TypeNS1(TypeNS2):
+
+    class Meta:
+        namespace = "ns1"
+
+    x2: int = field(metadata=dict(type="Element"))

--- a/xsdata/utils/debug.py
+++ b/xsdata/utils/debug.py
@@ -1,0 +1,31 @@
+import json
+from pathlib import Path
+from typing import Any
+
+
+def dump(obj: Any):
+    """
+    Write any object into a dump json file.
+
+    For internal troubleshooting purposes only!!!
+    """
+
+    with Path.cwd().joinpath("xsdata_dump.json").open("w+") as f:
+        json.dump(convert(obj), f, indent=4)
+
+
+def convert(obj: Any) -> Any:
+    """Dump any obj into a readable dictionary."""
+    if not obj:
+        return obj
+
+    if isinstance(obj, list):
+        return list(map(convert, obj))
+
+    if isinstance(obj, dict):
+        return {key: convert(value) for key, value in obj.items()}
+
+    if hasattr(obj, "__slots__") and obj.__slots__:
+        return {name: convert(getattr(obj, name)) for name in obj.__slots__}
+
+    return str(obj)


### PR DESCRIPTION
## 📒 Description

When a subclass has an explicit and different namespace than the parent class the parser fails to resolve the correct namespace for the inheritted fields.


Resolves #654

## 🔗 What I've Done

- Use the namespace from the class the field was declared when building a model context cache.
- Added debug utils to easily dump the xml context cache


## 💬 Comments

Super interesting suite https://www.omg.org/spec/BPMN/2.0.2/ it will definitely go to the samples repo, I can't believe I didn't have such example in almost 20k tests/samples

## 🛫 Checklist

- [x] Updated docs
- [x] Added unit-tests
- [x] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [x] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
