### PR TITLE
Fix restricting simple/complex content with enumeration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,7 @@ jobs:
           - {name: Python 3.8, python: '3.8', os: ubuntu}
           - {name: Python 3.9, python: '3.9', os: ubuntu}
           - {name: Python 3.10, python: '3.10', os: ubuntu}
+          - {name: Python 3.11, python: '3.11-dev', os: ubuntu}
           - {name: Windows py37, python: '3.7', os: windows}
           - {name: MacOS py37, python: '3.7', os: macos}
     steps:
@@ -30,7 +31,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install libxml2
-        if: startsWith(matrix.python, 'pypy')
+        if: startsWith(matrix.python, 'pypy') || startsWith(matrix.python, '3.11-dev')
         run: |
           sudo apt-get install libxml2-dev libxslt-dev
       - name: Install dependencies
@@ -50,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [3.7, 3.8, 3.9]
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11-dev']
         mode: [xsd, json, xml]
     steps:
       - uses: actions/checkout@v2
@@ -64,6 +65,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
+      - name: Install libxml2
+        if: startsWith(matrix.python, '3.11-dev')
+        run: |
+          sudo apt-get install libxml2-dev libxslt-dev
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools pytest pytest-xdist xmlschema

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
     rev: v1.20.0
     hooks:
       - id: setup-cfg-fmt
-        args: ["--max-py-version=3.10"]
+        args: ["--max-py-version=3.11"]
   - repo: https://github.com/PyCQA/doc8
     rev: 0.10.1
     hooks:

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Software Development :: Code Generators

--- a/tests/codegen/handlers/test_class_extension.py
+++ b/tests/codegen/handlers/test_class_extension.py
@@ -126,7 +126,7 @@ class ClassExtensionHandlerTests(FactoryTestCase):
             AttrTypeFactory.native(DataType.FLOAT),
             AttrTypeFactory.native(DataType.DECIMAL),
         ]
-        source = ClassFactory.elements(1)
+        source = ClassFactory.simple_type()
         source.attrs[0].types = [
             AttrTypeFactory.native(DataType.INT),
             AttrTypeFactory.create(base.qname),
@@ -147,49 +147,48 @@ class ClassExtensionHandlerTests(FactoryTestCase):
             ["float", "decimal"], [tp.name for tp in target.attrs[0].types]
         )
         self.assertEqual(["string", "int"], [tp.name for tp in target.attrs[1].types])
+        self.processor.merge_enumeration_types(target, source, None)
 
-    def test_process_enum_extension_with_complex_source(self):
+    def test_process_enum_extension_with_complex_content_and_single_member(self):
+        target = ClassFactory.enumeration(1)
+        target.attrs[0].default = "foo"
         source = ClassFactory.create(
             tag=Tag.COMPLEX_TYPE,
-            attrs=[
-                AttrFactory.create(tag=Tag.ATTRIBUTE),
-                AttrFactory.create(tag=Tag.RESTRICTION),
-            ],
-            extensions=ExtensionFactory.list(2),
-            status=Status.FLATTENED,
+            attrs=[AttrFactory.attribute(), AttrFactory.extension()],
         )
-        target = ClassFactory.enumeration(1)
-        target.attrs[0].default = "Yes"
-        extension = ExtensionFactory.reference(source.qname)
-        target.extensions.append(extension)
-        expected = target.clone()
+        ext = ExtensionFactory.reference(source.qname)
+        target.extensions.append(ext)
 
-        self.processor.container.add(source)
         self.processor.container.add(target)
-        self.processor.process_dependency_extension(target, extension)
+        self.processor.container.add(source)
 
-        expected.attrs = [attr.clone() for attr in source.attrs]
-        expected.extensions = [ext.clone() for ext in source.extensions]
-        expected.attrs[1].default = "Yes"
-        expected.attrs[1].fixed = True
+        self.processor.process_extension(target, ext)
 
-        self.assertEqual(expected, target)
+        expected = source.attrs[1].clone()
+        self.assertTrue(target.attrs[0].fixed)
+        self.assertEqual("foo", target.attrs[0].default)
+        self.assertEqual(expected.name, target.attrs[0].name)
+        self.assertEqual(1, len(target.extensions))
 
-        self.assertIsNone(target.attrs[0].default)
-        self.assertFalse(target.attrs[0].fixed)
-        self.assertEqual("Yes", target.attrs[1].default)
-        self.assertTrue(target.attrs[1].fixed)
-
-    def test_process_enum_extension_raises_exception(self):
-        source = ClassFactory.elements(2)
+    def test_process_enum_extension_with_complex_content(self):
         target = ClassFactory.enumeration(2)
-        extension = ExtensionFactory.reference(source.qname)
-        target.extensions.append(extension)
-        self.processor.container.add(source)
-        self.processor.container.add(target)
+        source = ClassFactory.create(
+            tag=Tag.COMPLEX_TYPE,
+            attrs=[AttrFactory.attribute(), AttrFactory.extension()],
+        )
+        ext = ExtensionFactory.reference(source.qname)
+        target.extensions.append(ext)
 
-        with self.assertRaises(CodeGenerationError):
-            self.processor.process_dependency_extension(target, extension)
+        self.processor.container.add(target)
+        self.processor.container.add(source)
+
+        self.processor.process_extension(target, ext)
+
+        expected = source.attrs[1].clone()
+        self.assertEqual(1, len(target.extensions))
+        self.assertEqual(expected.name, target.attrs[0].name)
+        self.assertTrue(target.attrs[0].types[0].forward)
+        self.assertEqual("{xsdata}attr_E", target.attrs[0].types[0].qname)
 
     @mock.patch.object(ClassExtensionHandler, "process_complex_extension")
     @mock.patch.object(ClassExtensionHandler, "process_simple_extension")

--- a/tests/codegen/test_utils.py
+++ b/tests/codegen/test_utils.py
@@ -15,8 +15,22 @@ from xsdata.utils.testing import FactoryTestCase
 
 
 class ClassUtilsTests(FactoryTestCase):
-    def test_remove_attribute(self):
+    def test_find_value_attr(self):
+        target = ClassFactory.create()
+        with self.assertRaises(CodeGenerationError) as cm:
+            ClassUtils.find_value_attr(target)
 
+        self.assertEqual("Class has no value attr {xsdata}class_B", str(cm.exception))
+
+        target.attrs.append(AttrFactory.element())
+        with self.assertRaises(CodeGenerationError) as cm:
+            ClassUtils.find_value_attr(target)
+
+        target.attrs.append(AttrFactory.extension())
+        actual = ClassUtils.find_value_attr(target)
+        self.assertEqual(target.attrs[1], actual)
+
+    def test_remove_attribute(self):
         target = ClassFactory.elements(1)
         attr = target.attrs[0]
 

--- a/xsdata/codegen/utils.py
+++ b/xsdata/codegen/utils.py
@@ -22,6 +22,19 @@ class ClassUtils:
     """General reusable utils methods that didn't fit anywhere else."""
 
     @classmethod
+    def find_value_attr(cls, target: Class) -> Attr:
+        """
+        Find the text attribute of the class.
+
+        :raise CodeGenerationError: If no text node/attribute exists
+        """
+        for attr in target.attrs:
+            if not attr.xml_type:
+                return attr
+
+        raise CodeGenerationError(f"Class has no value attr {target.qname}")
+
+    @classmethod
     def remove_attribute(cls, target: Class, attr: Attr):
         """Safely remove the given attr from the target class by check obj
         ids."""


### PR DESCRIPTION
## 📒 Description

Restricting classes with enumerations has a few issues:

 - Only works if the enumeration has a single member
 - It doesn't work if the base class has multiple attr/fields


Resolves #659

## 🔗 What I've Done

- If the target enumeration has a single member, copy the value/text field from the base class and set the default/fixed value from the enumeration value.
- If the target enumeration has multple members, copy the value/text field from the base class and set its type from the target enumeration values. (convert to inner first)


## 💬 Comments

> A place to write any comments to the reviewer.
>

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
