### PR TITLE
fix max_occurs restriction merge that badly turn elements into lists

### DIFF
--- a/xsdata/codegen/handlers/attribute_merge.py
+++ b/xsdata/codegen/handlers/attribute_merge.py
@@ -40,7 +40,7 @@ class AttributeMergeHandler(HandlerInterface):
                 attr_max_occurs = a_res.max_occurs or 1
 
                 e_res.min_occurs = min(min_occurs, attr_min_occurs)
-                e_res.max_occurs = max_occurs + attr_max_occurs
+                e_res.max_occurs = min(max_occurs, attr_max_occurs)
                 e_res.sequential = a_res.sequential or e_res.sequential
                 existing.fixed = False
                 existing.types.extend(attr.types)


### PR DESCRIPTION
Resolves #666

## 🔗 What I've Done

As I explained in #666 one cannot set bot max_occurs=1 for missing max_occurs in the attribute and in the restriction and simply add them.

I should say I'm not entirely sure what is the best solution. Here I simply take the min of both max_occurs so both max_occurs will be enforced. 
Alternatives could be:
* take the max of both max_occurs. But is this correct (see next paragraph)?
* add the max_occurs but unless they were both undefined.

Also, are you sure what is done for min_occurs is correct? I don't know if it is specified but eventually I would think about taking the max of both min_occurs so both min_occurs are enforced. That would follow the same logic as I did for max_occurs here.


## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
