### PR TITLE
Add option to use union operator and subscriptable types for type annotations

### DIFF
--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -30,7 +30,7 @@ class GeneratorConfigTests(TestCase):
             f'<Config xmlns="http://pypi.org/project/xsdata" version="{__version__}">\n'
             '  <Output maxLineLength="79">\n'
             "    <Package>generated</Package>\n"
-            '    <Format repr="true" eq="true" order="false" unsafeHash="false" frozen="false" slots="false" kwOnly="false">dataclasses</Format>\n'
+            '    <Format repr="true" eq="true" order="false" unsafeHash="false" frozen="false" slots="false" kwOnly="false" unionOp="false">dataclasses</Format>\n'
             "    <Structure>filenames</Structure>\n"
             "    <DocstringStyle>reStructuredText</DocstringStyle>\n"
             "    <RelativeImports>false</RelativeImports>\n"
@@ -87,7 +87,7 @@ class GeneratorConfigTests(TestCase):
             '  <Output maxLineLength="79">\n'
             "    <Package>foo.bar</Package>\n"
             '    <Format repr="true" eq="true" order="false" unsafeHash="false"'
-            ' frozen="false" slots="false" kwOnly="false">dataclasses</Format>\n'
+            ' frozen="false" slots="false" kwOnly="false" unionOp="false">dataclasses</Format>\n'
             "    <Structure>filenames</Structure>\n"
             "    <DocstringStyle>reStructuredText</DocstringStyle>\n"
             "    <RelativeImports>false</RelativeImports>\n"
@@ -152,6 +152,20 @@ class GeneratorConfigTests(TestCase):
 
             self.assertEqual(
                 "kw_only requires python >= 3.10, reverting...", str(w[-1].message)
+            )
+
+        else:
+            self.assertIsNotNone(OutputFormat(kw_only=True))
+
+    def test_format_union_op_requires_310(self):
+        if sys.version_info < (3, 10):
+            self.assertTrue(OutputFormat(union_op=True, value="attrs").union_op)
+
+            with warnings.catch_warnings(record=True) as w:
+                self.assertFalse(OutputFormat(union_op=True).union_op)
+
+            self.assertEqual(
+                "union_op requires python >= 3.10, reverting...", str(w[-1].message)
             )
 
         else:

--- a/xsdata/models/config.py
+++ b/xsdata/models/config.py
@@ -163,6 +163,8 @@ class OutputFormat:
     :param frozen: Enable read only properties, default false
     :param slots: Enable __slots__, default: false, python>=3.10 Only
     :param kw_only: Enable keyword only arguments, default: false, python>=3.10 Only
+    :param union_op: Enable union operator and subscriptable types,
+                     default: false, python>=3.10 Only
     """
 
     value: str = text_node(default="dataclasses", cli="output")
@@ -173,6 +175,7 @@ class OutputFormat:
     frozen: bool = attribute(default=False)
     slots: bool = attribute(default=False)
     kw_only: bool = attribute(default=False)
+    union_op: bool = attribute(default=False)
 
     def __post_init__(self):
         self.validate()
@@ -193,6 +196,13 @@ class OutputFormat:
                 self.kw_only = False
                 warnings.warn(
                     "kw_only requires python >= 3.10, reverting...",
+                    CodeGenerationWarning,
+                )
+
+            if self.union_op:
+                self.union_op = False
+                warnings.warn(
+                    "union_op requires python >= 3.10, reverting...",
                     CodeGenerationWarning,
                 )
 


### PR DESCRIPTION
## 📒 Description

Add CLI option `--union-op` to enable python 3.10 style union operator.
Example:
`Foo | Bar` instead of `typing.Union[Foo, Bar]`
`FooBar | None` instead of `typing.Optional[FooBar]`
`dict[str, FooBar]` instead of `typing.Dict[str, FooBar]`
`list[FooBar]` instead of `typing.List[FooBar]`
`tuple[FooBar, ...]` instead of `typing.Tuple[FooBar, ...]`

## 🔗 What I've Done

I added the `union_op` CLI option in `xsdata/models/config.py`
I adapted `Filters.field_type()`, `Filtes.choice_type()` and `Filters.build_type_patterns()`


## 💬 Comments

> A place to write any comments to the reviewer.
>

## 🛫 Checklist

- [ ] Updated docs
- [x] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
