### PR TITLE
Prevent empty xs:list from being discarded

### DIFF
--- a/tests/formats/dataclass/serializers/test_xml.py
+++ b/tests/formats/dataclass/serializers/test_xml.py
@@ -135,9 +135,14 @@ class XmlSerializerTests(TestCase):
             xml_type=XmlType.ELEMENT, qname="a", tokens_factory=list
         )
 
+        expected = [
+            (XmlWriterEvent.START, "a"),
+            (XmlWriterEvent.DATA, []),
+            (XmlWriterEvent.END, "a"),
+        ]
         result = self.serializer.write_value([], var, "xsdata")
         self.assertIsInstance(result, Generator)
-        self.assertEqual(0, len(list(result)))
+        self.assertListEqual(expected, list(result))
 
         expected = [
             (XmlWriterEvent.START, "a"),

--- a/tests/formats/dataclass/serializers/test_xml.py
+++ b/tests/formats/dataclass/serializers/test_xml.py
@@ -135,6 +135,10 @@ class XmlSerializerTests(TestCase):
             xml_type=XmlType.ELEMENT, qname="a", tokens_factory=list
         )
 
+        result = self.serializer.write_value(None, var, "xsdata")
+        self.assertIsInstance(result, Generator)
+        self.assertListEqual([], list(result))
+
         expected = [
             (XmlWriterEvent.START, "a"),
             (XmlWriterEvent.DATA, []),

--- a/xsdata/formats/dataclass/serializers/xml.py
+++ b/xsdata/formats/dataclass/serializers/xml.py
@@ -160,7 +160,7 @@ class XmlSerializer(AbstractSerializer):
     def write_tokens(self, value: Any, var: XmlVar, namespace: NoneStr) -> Generator:
         """Produce an events stream for the given tokens list or list of tokens
         lists."""
-        if value or var.nillable:
+        if value is not None or var.nillable:
             if value and collections.is_array(value[0]):
                 for val in value:
                     yield from self.write_element(val, var, namespace)


### PR DESCRIPTION
## 📒 Description

Empty lists were treated as None values, which discarded them from
serialization. This resulted in XML serializations which were not compliant 
with the provided schema.

Resolves #686 

## 🔗 What I've Done

This commit fixes this issue by explicitly checking for None values, 
rather than relying on implicit boolean conversion.

## 💬 Comments


## 🛫 Checklist

- [ ] Updated docs
- [x] *Updated* unit-tests
- [x] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [x] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
