### PR TITLE
Implement DTD code generator

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,3 +1,3 @@
 [bandit]
 exclude: tests/,docs/
-skips: B701
+skips: B701,B410

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,16 +2,16 @@ exclude: tests/fixtures
 
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.32.1
+    rev: v2.34.0
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.1.0
+    rev: v3.3.0
     hooks:
       - id: reorder-python-imports
   - repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 22.6.0
     hooks:
       - id: black
   - repo: https://gitlab.com/pycqa/flake8
@@ -26,7 +26,7 @@ repos:
         args: ["--suppress-none-returning"]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -37,7 +37,7 @@ repos:
       - id: docformatter
         args: ["--in-place", "--pre-summary-newline"]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.950
+    rev: v0.961
     hooks:
       - id: mypy
         additional_dependencies: [tokenize-rt, types-requests, types-Jinja2, types-click, types-docutils]
@@ -47,6 +47,6 @@ repos:
       - id: setup-cfg-fmt
         args: ["--max-py-version=3.11"]
   - repo: https://github.com/PyCQA/doc8
-    rev: 0.11.1
+    rev: 0.11.2
     hooks:
       - id: doc8

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Naive XML Bindings for python
 xsData is a complete data binding library for python allowing developers to access and
 use XML and JSON documents as simple objects rather than using DOM.
 
-It ships with a code generator for XML schemas, WSDL definitions, XML & JSON documents.
+The code generator supports XML schemas, DTD, WSDL definitions, XML & JSON documents.
 It produces simple dataclasses with type hints and simple binding metadata.
 
 The included XML and JSON parser/serializer are highly optimized and adaptable, with
@@ -76,6 +76,7 @@ Features
 
   - XML Schemas 1.0 & 1.1
   - WSDL 1.1 definitions with SOAP 1.1 bindings
+  - DTD external definitions
   - Directly from XML and JSON Documents
   - Extensive configuration to customize output
   - Pluggable code writer for custom output formats

--- a/docs/codegen.rst
+++ b/docs/codegen.rst
@@ -27,7 +27,7 @@ Generate Code
 
 
 .. code-block:: console
-    :caption: Scan directory for xsd, wsdl, xml files
+    :caption: Scan directory for xsd, dtd, wsdl, xml or json files
 
     $ xsdata amadeus/schemas --package amadeus.models
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -11,6 +11,7 @@ Code Generation
     examples/docstrings
     examples/xml-modeling
     examples/json-modeling
+    examples/dtd-modeling
     examples/compound-fields
     examples/dataclasses-features
 

--- a/docs/examples/dtd-modeling.rst
+++ b/docs/examples/dtd-modeling.rst
@@ -1,0 +1,20 @@
+============
+DTD Modeling
+============
+
+The code generator supports processing external document type definitions (DTD).
+
+.. code-block:: console
+
+    $ xsdata --package tests.fixtures.dtd.models tests/fixtures/dtd/complete_example.dtd
+
+
+.. tab:: DTD Definition
+
+    .. literalinclude:: /../tests/fixtures/dtd/complete_example.dtd
+       :language: dtd
+
+.. tab:: Output
+
+    .. literalinclude:: /../tests/fixtures/dtd/models/complete_example.py
+       :language: python

--- a/docs/faq/error-parsing-dtd.rst
+++ b/docs/faq/error-parsing-dtd.rst
@@ -1,0 +1,9 @@
+DTDParseError: error parsing DTD
+================================
+
+xsdata works only with **external** document type definitions
+and relies on `lxml <https://lxml.de/>`_ exclusively to parse
+the dtd tree.
+
+Try to remove the `DOCTYPE` wrapper if you are sure the rest of
+the definition is correct.

--- a/tests/codegen/mappers/test_dtd.py
+++ b/tests/codegen/mappers/test_dtd.py
@@ -1,0 +1,302 @@
+import sys
+from typing import Iterator
+from unittest import mock
+
+from xsdata.codegen.mappers.dtd import DtdMapper
+from xsdata.codegen.models import Class
+from xsdata.codegen.models import Restrictions
+from xsdata.models.dtd import DtdAttributeDefault
+from xsdata.models.dtd import DtdAttributeType
+from xsdata.models.dtd import DtdContentOccur
+from xsdata.models.dtd import DtdContentType
+from xsdata.models.dtd import DtdElementType
+from xsdata.models.enums import DataType
+from xsdata.models.enums import Namespace
+from xsdata.models.enums import Tag
+from xsdata.utils.testing import AttrFactory
+from xsdata.utils.testing import AttrTypeFactory
+from xsdata.utils.testing import ClassFactory
+from xsdata.utils.testing import DtdAttributeFactory
+from xsdata.utils.testing import DtdContentFactory
+from xsdata.utils.testing import DtdElementFactory
+from xsdata.utils.testing import DtdFactory
+from xsdata.utils.testing import FactoryTestCase
+
+
+class DtdMapperTests(FactoryTestCase):
+    def test_map(self):
+        dtd = DtdFactory.root(2)
+        result = DtdMapper.map(dtd)
+
+        self.assertIsInstance(result, Iterator)
+        for cls in result:
+            self.assertIsInstance(cls, Class)
+            self.assertEqual(cls.location, dtd.location)
+
+    @mock.patch.object(DtdMapper, "build_attributes")
+    @mock.patch.object(DtdMapper, "build_elements")
+    def test_build_class(self, mock_build_elements, mock_build_attributes):
+        location = "tests.dtd"
+        element = DtdElementFactory.create(
+            name="root", prefix="ns", ns_map={"ns": "xsdata"}
+        )
+        actual = DtdMapper.build_class(element, "tests.dtd")
+        expected = ClassFactory.create(
+            qname="{xsdata}root",
+            ns_map=element.ns_map,
+            tag=Tag.ELEMENT,
+            location=location,
+            module=None,
+        )
+
+        self.assertEqual(expected, actual)
+
+        mock_build_attributes.assert_called_once_with(actual, element)
+        mock_build_elements.assert_called_once_with(actual, element)
+
+    @mock.patch.object(DtdMapper, "build_attribute")
+    def test_build_attributes(self, mock_build_attribute):
+        attributes = DtdAttributeFactory.list(2)
+        element = DtdElementFactory.create(attributes=attributes)
+        target = ClassFactory.create()
+
+        DtdMapper.build_attributes(target, element)
+
+        mock_build_attribute.assert_has_calls(
+            [
+                mock.call(target, attributes[0]),
+                mock.call(target, attributes[1]),
+            ]
+        )
+
+    def test_build_attribute(self):
+        target = ClassFactory.create()
+        attribute = DtdAttributeFactory.create(name="lang", prefix="xml")
+        DtdMapper.build_attribute(target, attribute)
+
+        self.assertEqual(1, len(target.attrs))
+        attr = target.attrs[0]
+
+        self.assertEqual(0, attr.index)
+        self.assertEqual(attribute.name, attr.name)
+        self.assertEqual(Tag.ATTRIBUTE, attr.tag)
+        self.assertEqual(Namespace.XML.uri, attr.namespace)
+        self.assertEqual(1, len(attr.types))
+        self.assertEqual(AttrTypeFactory.native(DataType.STRING), attr.types[0])
+        self.assertEqual(1, attr.restrictions.max_occurs)
+        self.assertEqual(0, attr.restrictions.min_occurs)
+
+    def test_build_attribute_type_with_enumeration(self):
+        target = ClassFactory.create()
+        attribute = DtdAttributeFactory.create(
+            type=DtdAttributeType.ENUMERATION, values=["a", "b", "c"]
+        )
+        actual = DtdMapper.build_attribute_type(target, attribute)
+
+        self.assertTrue(actual.forward)
+        self.assertEqual(attribute.name, actual.qname)
+
+        self.assertEqual(1, len(target.inner))
+        self.assertTrue(target.inner[0].is_enumeration)
+
+        self.assertEqual(["a", "b", "c"], [x.name for x in target.inner[0].attrs])
+        self.assertEqual(["a", "b", "c"], [x.default for x in target.inner[0].attrs])
+
+        for attr in target.inner[0].attrs:
+            self.assertEqual(Tag.ENUMERATION, attr.tag)
+            self.assertTrue(attr.fixed)
+            self.assertEqual([AttrTypeFactory.native(DataType.STRING)], attr.types)
+
+    def test_build_attribute_restrictions_with_default_required(self):
+        attr = AttrFactory.create()
+        DtdMapper.build_attribute_restrictions(attr, DtdAttributeDefault.REQUIRED, "")
+        self.assertEqual(1, attr.restrictions.max_occurs)
+        self.assertEqual(1, attr.restrictions.min_occurs)
+        self.assertFalse(attr.fixed)
+        self.assertIsNone(attr.default)
+
+    def test_build_attribute_restrictions_with_default_implied(self):
+        attr = AttrFactory.create()
+        DtdMapper.build_attribute_restrictions(attr, DtdAttributeDefault.IMPLIED, "")
+        self.assertEqual(0, attr.restrictions.max_occurs)
+        self.assertEqual(1, attr.restrictions.min_occurs)
+        self.assertFalse(attr.fixed)
+        self.assertIsNone(attr.default)
+
+    def test_build_attribute_restrictions_with_default_fixed(self):
+        attr = AttrFactory.create()
+        DtdMapper.build_attribute_restrictions(attr, DtdAttributeDefault.FIXED, "abc")
+        self.assertEqual(1, attr.restrictions.max_occurs)
+        self.assertEqual(1, attr.restrictions.min_occurs)
+        self.assertTrue(attr.fixed)
+        self.assertEqual("abc", attr.default)
+
+    def test_build_attribute_restrictions_with_default_none_and_no_value(self):
+        attr = AttrFactory.create()
+        DtdMapper.build_attribute_restrictions(attr, DtdAttributeDefault.NONE, None)
+        self.assertEqual(1, attr.restrictions.max_occurs)
+        self.assertEqual(0, attr.restrictions.min_occurs)
+        self.assertFalse(attr.fixed)
+        self.assertIsNone(attr.default)
+
+    def test_build_attribute_restrictions_with_default_none_and_default_value(self):
+        attr = AttrFactory.create()
+        DtdMapper.build_attribute_restrictions(attr, DtdAttributeDefault.NONE, "abc")
+        self.assertEqual(1, attr.restrictions.max_occurs)
+        self.assertEqual(1, attr.restrictions.min_occurs)
+        self.assertFalse(attr.fixed)
+        self.assertEqual("abc", attr.default)
+
+    def test_build_elements_with_mixed_element_type(self):
+        target = ClassFactory.create()
+        element = DtdElementFactory.create(type=DtdElementType.MIXED)
+
+        DtdMapper.build_elements(target, element)
+        self.assertEqual(0, len(target.attrs))
+        self.assertEqual(0, len(target.extensions))
+        self.assertTrue(target.mixed)
+
+    def test_build_elements_with_any_element_type(self):
+        target = ClassFactory.create()
+        element = DtdElementFactory.create(type=DtdElementType.ANY)
+
+        DtdMapper.build_elements(target, element)
+        self.assertEqual(0, len(target.attrs))
+        self.assertEqual(1, len(target.extensions))
+
+        self.assertEqual(str(DataType.ANY_TYPE), target.extensions[0].type.qname)
+        self.assertTrue(target.extensions[0].type.native)
+
+        self.assertFalse(target.mixed)
+
+    def test_build_elements_with_undefined_element_type(self):
+        target = ClassFactory.create()
+        element = DtdElementFactory.create(type=DtdElementType.UNDEFINED)
+
+        DtdMapper.build_elements(target, element)
+        self.assertEqual(0, len(target.attrs))
+        self.assertEqual(0, len(target.extensions))
+        self.assertFalse(target.mixed)
+
+    def test_build_elements_with_empty_element_type(self):
+        target = ClassFactory.create()
+        element = DtdElementFactory.create(type=DtdElementType.EMPTY)
+
+        DtdMapper.build_elements(target, element)
+        self.assertEqual(0, len(target.attrs))
+        self.assertEqual(0, len(target.extensions))
+        self.assertFalse(target.mixed)
+
+    def test_build_elements_with_element_element_type(self):
+        target = ClassFactory.create()
+        element = DtdElementFactory.create(
+            type=DtdElementType.ELEMENT, content=DtdContentFactory.create(name="child")
+        )
+
+        DtdMapper.build_elements(target, element)
+        self.assertEqual(1, len(target.attrs))
+        self.assertEqual(0, len(target.extensions))
+        self.assertFalse(target.mixed)
+
+    def test_build_content_with_type_element(self):
+        content = DtdContentFactory.create(
+            type=DtdContentType.ELEMENT, occur=DtdContentOccur.ONCE
+        )
+        target = ClassFactory.create()
+        DtdMapper.build_content(target, content, nillable=True)
+        self.assertEqual(1, len(target.attrs))
+        self.assertEqual(content.name, target.attrs[0].name)
+        self.assertTrue(target.attrs[0].restrictions.nillable)
+        self.assertEqual(1, target.attrs[0].restrictions.max_occurs)
+        self.assertEqual(1, target.attrs[0].restrictions.min_occurs)
+
+    def test_build_content_type_seq(self):
+        content = DtdContentFactory.create(
+            type=DtdContentType.SEQ,
+            left=DtdContentFactory.create(type=DtdContentType.ELEMENT),
+            right=DtdContentFactory.create(type=DtdContentType.ELEMENT),
+        )
+        target = ClassFactory.create()
+        DtdMapper.build_content(target, content, nillable=True)
+        self.assertEqual(2, len(target.attrs))
+
+    def test_build_content_type_or(self):
+        content = DtdContentFactory.create(
+            type=DtdContentType.OR,
+            left=DtdContentFactory.create(type=DtdContentType.ELEMENT),
+            right=DtdContentFactory.create(type=DtdContentType.ELEMENT),
+        )
+        target = ClassFactory.create()
+        DtdMapper.build_content(target, content, nillable=True)
+        self.assertEqual(2, len(target.attrs))
+        for attr in target.attrs:
+            self.assertEqual(str(id(content)), attr.restrictions.choice)
+
+    def test_build_content_type_pcdata(self):
+        content = DtdContentFactory.create(
+            type=DtdContentType.PCDATA,
+        )
+        target = ClassFactory.create()
+        DtdMapper.build_content(target, content)
+        self.assertEqual(0, len(target.attrs))
+
+    @mock.patch.object(DtdMapper, "build_content")
+    def test_build_content_tree(self, mock_build_content):
+        center = DtdContentFactory.create()
+        target = ClassFactory.create()
+
+        DtdMapper.build_content_tree(target, center, nillable=True)
+
+        center.left = DtdContentFactory.create()
+        center.right = DtdContentFactory.create()
+        DtdMapper.build_content_tree(target, center, nillable=False)
+
+        mock_build_content.assert_has_calls(
+            [
+                mock.call(target, center.left, nillable=False),
+                mock.call(target, center.right, nillable=False),
+            ]
+        )
+
+    def test_build_restrictions(self):
+        result = DtdMapper.build_restrictions(DtdContentOccur.ONCE)
+        self.assertEqual(1, result.min_occurs)
+        self.assertEqual(1, result.max_occurs)
+
+        result = DtdMapper.build_restrictions(DtdContentOccur.OPT)
+        self.assertEqual(0, result.min_occurs)
+        self.assertEqual(1, result.max_occurs)
+
+        result = DtdMapper.build_restrictions(DtdContentOccur.MULT)
+        self.assertEqual(0, result.min_occurs)
+        self.assertEqual(sys.maxsize, result.max_occurs)
+
+        result = DtdMapper.build_restrictions(DtdContentOccur.PLUS)
+        self.assertEqual(1, result.min_occurs)
+        self.assertEqual(sys.maxsize, result.max_occurs)
+
+        result = DtdMapper.build_restrictions(DtdContentOccur.PLUS, nillable=True)
+        self.assertEqual(1, result.min_occurs)
+        self.assertEqual(sys.maxsize, result.max_occurs)
+        self.assertTrue(result.nillable)
+
+    def test_build_element(self):
+        target = ClassFactory.create()
+        restrictions = Restrictions()
+        names = ["firs", "second", "third"]
+
+        for name in names:
+            DtdMapper.build_element(target, name, restrictions)
+
+        self.assertEqual(len(names), len(target.attrs))
+
+        for index, attr in enumerate(target.attrs):
+            self.assertEqual(names[index], attr.name)
+            self.assertEqual(index, attr.index)
+            self.assertEqual(Tag.ELEMENT, attr.tag)
+            self.assertEqual(restrictions, attr.restrictions)
+            self.assertIsNot(restrictions, attr.restrictions)
+
+            self.assertEqual(1, len(attr.types))
+            self.assertFalse(attr.types[0].native)
+            self.assertEqual(names[index], attr.types[0].qname)

--- a/tests/codegen/mappers/test_dtd.py
+++ b/tests/codegen/mappers/test_dtd.py
@@ -25,7 +25,7 @@ from xsdata.utils.testing import FactoryTestCase
 
 class DtdMapperTests(FactoryTestCase):
     def test_map(self):
-        dtd = DtdFactory.root(2)
+        dtd = DtdFactory.root(2, location="tests.dtd")
         result = DtdMapper.map(dtd)
 
         self.assertIsInstance(result, Iterator)
@@ -71,7 +71,9 @@ class DtdMapperTests(FactoryTestCase):
 
     def test_build_attribute(self):
         target = ClassFactory.create()
-        attribute = DtdAttributeFactory.create(name="lang", prefix="xml")
+        attribute = DtdAttributeFactory.create(
+            name="lang", prefix="xml", default=DtdAttributeDefault.IMPLIED
+        )
         DtdMapper.build_attribute(target, attribute)
 
         self.assertEqual(1, len(target.attrs))

--- a/tests/codegen/mappers/test_dtd.py
+++ b/tests/codegen/mappers/test_dtd.py
@@ -148,13 +148,16 @@ class DtdMapperTests(FactoryTestCase):
         self.assertEqual("abc", attr.default)
 
     def test_build_elements_with_mixed_element_type(self):
-        target = ClassFactory.create()
+        target = ClassFactory.create(tag=Tag.ELEMENT)
         element = DtdElementFactory.create(type=DtdElementType.MIXED)
 
         DtdMapper.build_elements(target, element)
         self.assertEqual(0, len(target.attrs))
-        self.assertEqual(0, len(target.extensions))
-        self.assertTrue(target.mixed)
+        self.assertEqual(1, len(target.extensions))
+
+        self.assertEqual(Tag.COMPLEX_TYPE, target.tag)
+        self.assertEqual(str(DataType.STRING), target.extensions[0].type.qname)
+        self.assertTrue(target.extensions[0].type.native)
 
     def test_build_elements_with_any_element_type(self):
         target = ClassFactory.create()

--- a/tests/codegen/mappers/test_dtd.py
+++ b/tests/codegen/mappers/test_dtd.py
@@ -118,8 +118,8 @@ class DtdMapperTests(FactoryTestCase):
     def test_build_attribute_restrictions_with_default_implied(self):
         attr = AttrFactory.create()
         DtdMapper.build_attribute_restrictions(attr, DtdAttributeDefault.IMPLIED, "")
-        self.assertEqual(0, attr.restrictions.max_occurs)
-        self.assertEqual(1, attr.restrictions.min_occurs)
+        self.assertEqual(1, attr.restrictions.max_occurs)
+        self.assertEqual(0, attr.restrictions.min_occurs)
         self.assertFalse(attr.fixed)
         self.assertIsNone(attr.default)
 

--- a/tests/codegen/parsers/test_dtd.py
+++ b/tests/codegen/parsers/test_dtd.py
@@ -1,0 +1,164 @@
+from dataclasses import asdict
+from unittest import mock
+from unittest import TestCase
+
+from tests import fixtures_dir
+from xsdata.codegen.parsers.dtd import DtdParser
+from xsdata.exceptions import ParserError
+from xsdata.models.dtd import DtdAttributeDefault
+from xsdata.models.dtd import DtdAttributeType
+from xsdata.models.dtd import DtdContentOccur
+from xsdata.models.dtd import DtdContentType
+from xsdata.models.dtd import DtdElementType
+from xsdata.models.enums import Namespace
+
+
+class DtdParserTests(TestCase):
+    @classmethod
+    def parse(cls, file_name: str):
+        file_path = fixtures_dir.joinpath(file_name)
+        return DtdParser.parse(file_path.read_bytes(), str(file_path.resolve()))
+
+    @mock.patch("lxml.etree.DTD")
+    def test_parse_requires_lxml(self, mock_lxml):
+        mock_lxml.side_effect = ImportError()
+        with self.assertRaises(ParserError) as cm:
+            DtdParser.parse(b"", "/file/path/def.dtd")
+
+        self.assertEqual("DtdParser requires lxml to run.", str(cm.exception))
+
+    def test_build_element(self):
+        dtd = self.parse("dtd/complete_example.dtd")
+        self.assertEqual(6, len(dtd.elements))
+
+        element = dtd.elements[1]
+        self.assertEqual(4, len(element.attributes))
+        self.assertIsNotNone(element.content)
+        self.assertEqual(4, len(element.ns_map))
+
+        element.attributes = []
+        element.content = None
+        element.ns_map = {}
+
+        expected = {
+            "attributes": [],
+            "content": None,
+            "name": "Post",
+            "ns_map": {},
+            "prefix": None,
+            "type": DtdElementType.ELEMENT,
+        }
+
+        self.assertEqual(expected, asdict(dtd.elements[1]))
+
+    def test_build_content(self):
+        dtd = self.parse("dtd/complete_example.dtd")
+        post = next(el for el in dtd.elements if el.name == "Post")
+
+        actual = asdict(post.content)
+        expected = {
+            "name": None,
+            "occur": DtdContentOccur.ONCE,
+            "type": DtdContentType.SEQ,
+            "left": {
+                "left": None,
+                "name": "Title",
+                "occur": DtdContentOccur.ONCE,
+                "right": None,
+                "type": DtdContentType.ELEMENT,
+            },
+            "right": {
+                "left": {
+                    "left": None,
+                    "name": "Body",
+                    "occur": DtdContentOccur.ONCE,
+                    "right": None,
+                    "type": DtdContentType.ELEMENT,
+                },
+                "name": None,
+                "occur": DtdContentOccur.ONCE,
+                "type": DtdContentType.SEQ,
+                "right": {
+                    "left": None,
+                    "name": "Tags",
+                    "occur": DtdContentOccur.ONCE,
+                    "right": None,
+                    "type": DtdContentType.ELEMENT,
+                },
+            },
+        }
+        self.assertEqual(expected, actual)
+
+    def test_build_attribute(self):
+        dtd = self.parse("dtd/complete_example.dtd")
+        post = next(el for el in dtd.elements if el.name == "Post")
+
+        self.assertEqual(4, len(post.attributes))
+
+        # The order doesn't match the definition...
+        actual = {attr.name: asdict(attr) for attr in post.attributes}
+        expected = {
+            "author": {
+                "default": DtdAttributeDefault.REQUIRED,
+                "default_value": None,
+                "name": "author",
+                "prefix": None,
+                "type": DtdAttributeType.CDATA,
+                "values": [],
+            },
+            "created_at": {
+                "default": DtdAttributeDefault.REQUIRED,
+                "default_value": None,
+                "name": "created_at",
+                "prefix": None,
+                "type": DtdAttributeType.CDATA,
+                "values": [],
+            },
+            "lang": {
+                "default": DtdAttributeDefault.NONE,
+                "default_value": "en",
+                "name": "lang",
+                "prefix": "xml",
+                "type": DtdAttributeType.NMTOKEN,
+                "values": [],
+            },
+            "status": {
+                "default": DtdAttributeDefault.NONE,
+                "default_value": "draft",
+                "name": "status",
+                "prefix": None,
+                "type": DtdAttributeType.ENUMERATION,
+                "values": ["draft", "published"],
+            },
+        }
+        self.assertEqual(expected, actual)
+
+    def test_build_ns_map(self):
+        dtd = self.parse("dtd/complete_example.dtd")
+        expected = {ns.prefix: ns.uri for ns in Namespace.common()}
+        for element in dtd.elements:
+            self.assertEqual(expected, element.ns_map)
+
+    def test_with_prefix_namespace(self):
+        dtd = self.parse("dtd/prefix_namespace.dtd")
+
+        self.assertEqual(2, len(dtd.elements))
+
+        self.assertEqual("ns", dtd.elements[0].prefix)
+        self.assertEqual("ns", dtd.elements[1].prefix)
+
+        self.assertIn("ns", dtd.elements[0].ns_map)
+        self.assertEqual("http://www.example.com/", dtd.elements[0].ns_map["ns"])
+        self.assertNotIn("ns", dtd.elements[1].ns_map)
+
+    def test_with_default_namespace(self):
+        dtd = self.parse("dtd/default_namespace.dtd")
+
+        self.assertEqual(2, len(dtd.elements))
+
+        self.assertIsNone(dtd.elements[0].prefix)
+        self.assertIsNone(dtd.elements[1].prefix)
+
+        self.assertIn(None, dtd.elements[0].ns_map)
+        self.assertEqual("http://www.example.com/", dtd.elements[0].ns_map[None])
+        self.assertNotIn(None, dtd.elements[1].ns_map)

--- a/tests/fixtures/dtd/__init__.py
+++ b/tests/fixtures/dtd/__init__.py
@@ -1,0 +1,1 @@
+# nothing here

--- a/tests/fixtures/dtd/complete_example.dtd
+++ b/tests/fixtures/dtd/complete_example.dtd
@@ -1,0 +1,11 @@
+<!ELEMENT Blog (Post+)>
+<!ELEMENT Post (Title,Body,Tags)>
+<!ELEMENT Title (#PCDATA)>
+<!ELEMENT Body (#PCDATA)>
+<!ELEMENT Tags (Tag*)>
+<!ELEMENT Tag (#PCDATA)>
+
+<!ATTLIST Post status (draft|published) 'draft'>
+<!ATTLIST Post author CDATA #REQUIRED>
+<!ATTLIST Post created_at CDATA #REQUIRED>
+<!ATTLIST Post xml:lang NMTOKEN 'en'>

--- a/tests/fixtures/dtd/default_namespace.dtd
+++ b/tests/fixtures/dtd/default_namespace.dtd
@@ -1,0 +1,3 @@
+<!ELEMENT root (child1)>
+<!ATTLIST root xmlns CDATA #FIXED "http://www.example.com/">
+<!ELEMENT child1 (#PCDATA)>

--- a/tests/fixtures/dtd/models/__init__.py
+++ b/tests/fixtures/dtd/models/__init__.py
@@ -1,0 +1,13 @@
+from tests.fixtures.dtd.models.complete_example import (
+    Blog,
+    Post,
+    PostStatus,
+    Tags,
+)
+
+__all__ = [
+    "Blog",
+    "Post",
+    "PostStatus",
+    "Tags",
+]

--- a/tests/fixtures/dtd/models/complete_example.py
+++ b/tests/fixtures/dtd/models/complete_example.py
@@ -1,0 +1,88 @@
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import List, Optional
+
+
+class PostStatus(Enum):
+    DRAFT = "draft"
+    PUBLISHED = "published"
+
+
+@dataclass
+class Tags:
+    tag: List[str] = field(
+        default_factory=list,
+        metadata={
+            "name": "Tag",
+            "type": "Element",
+        }
+    )
+
+
+@dataclass
+class Post:
+    status: PostStatus = field(
+        default=PostStatus.DRAFT,
+        metadata={
+            "type": "Attribute",
+            "required": True,
+        }
+    )
+    lang: str = field(
+        default="en",
+        metadata={
+            "type": "Attribute",
+            "namespace": "http://www.w3.org/XML/1998/namespace",
+            "required": True,
+        }
+    )
+    created_at: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Attribute",
+            "required": True,
+        }
+    )
+    author: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Attribute",
+            "required": True,
+        }
+    )
+    title: Optional[str] = field(
+        default=None,
+        metadata={
+            "name": "Title",
+            "type": "Element",
+            "required": True,
+        }
+    )
+    body: Optional[str] = field(
+        default=None,
+        metadata={
+            "name": "Body",
+            "type": "Element",
+            "required": True,
+        }
+    )
+    tags: Optional[Tags] = field(
+        default=None,
+        metadata={
+            "name": "Tags",
+            "type": "Element",
+            "required": True,
+        }
+    )
+
+
+@dataclass
+class Blog:
+    post: List[Post] = field(
+        default_factory=list,
+        metadata={
+            "name": "Post",
+            "type": "Element",
+            "min_occurs": 1,
+        }
+    )

--- a/tests/fixtures/dtd/prefix_namespace.dtd
+++ b/tests/fixtures/dtd/prefix_namespace.dtd
@@ -1,0 +1,3 @@
+ <!ELEMENT ns:root (ns:child1)>
+ <!ATTLIST ns:root xmlns:ns CDATA #FIXED "http://www.example.com/">
+ <!ELEMENT ns:child1 (#PCDATA)>

--- a/tests/integration/test_dtd.py
+++ b/tests/integration/test_dtd.py
@@ -1,0 +1,29 @@
+import os
+
+from click.testing import CliRunner
+
+from tests import fixtures_dir
+from tests import root
+from xsdata.cli import cli
+from xsdata.utils.testing import load_class
+
+os.chdir(root)
+
+
+def test_dtd_documents():
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            str(fixtures_dir.joinpath("dtd/complete_example.dtd")),
+            "--package",
+            "tests.fixtures.dtd.models",
+        ],
+    )
+
+    if result.exception:
+        raise result.exception
+
+    clazz = load_class(result.output, "Post")
+
+    assert clazz is not None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -157,4 +157,4 @@ class CliTests(TestCase):
         self.assertEqual(3, len(list(resolve_source(str(def_xml_path), False))))
 
         actual = list(resolve_source(str(fixtures_dir), True))
-        self.assertEqual(36, len(actual))
+        self.assertEqual(39, len(actual))

--- a/xsdata/cli.py
+++ b/xsdata/cli.py
@@ -141,7 +141,7 @@ def resolve_source(source: str, recursive: bool) -> Iterator[str]:
         path = Path(source).resolve()
         match = "**/*" if recursive else "*"
         if path.is_dir():
-            for ext in ["wsdl", "xsd", "xml", "json"]:
+            for ext in ["wsdl", "xsd", "dtd", "xml", "json"]:
                 yield from (x.as_uri() for x in path.glob(f"{match}.{ext}"))
         else:  # is file
             yield path.as_uri()

--- a/xsdata/codegen/mappers/dtd.py
+++ b/xsdata/codegen/mappers/dtd.py
@@ -139,7 +139,7 @@ class DtdMapper:
         elif occur == DtdContentOccur.MULT:
             restrictions.min_occurs = 0
             restrictions.max_occurs = sys.maxsize
-        elif occur == DtdContentOccur.PLUS:
+        else:  # occur == DtdContentOccur.PLUS:
             restrictions.min_occurs = 1
             restrictions.max_occurs = sys.maxsize
 

--- a/xsdata/codegen/mappers/dtd.py
+++ b/xsdata/codegen/mappers/dtd.py
@@ -1,6 +1,7 @@
 import sys
 from typing import Any
 from typing import Iterator
+from typing import List
 from typing import Optional
 
 from xsdata.codegen.models import Attr
@@ -154,7 +155,7 @@ class DtdMapper:
         target.attrs.append(attr)
 
     @classmethod
-    def build_enumeration(cls, target: Class, name: str, values: list[str]):
+    def build_enumeration(cls, target: Class, name: str, values: List[str]):
         inner = Class(qname=name, tag=Tag.SIMPLE_TYPE, location=target.location)
         attr_type = AttrType(qname=str(DataType.STRING), native=True)
 

--- a/xsdata/codegen/mappers/dtd.py
+++ b/xsdata/codegen/mappers/dtd.py
@@ -96,13 +96,16 @@ class DtdMapper:
         if element.type == DtdElementType.ELEMENT and element.content:
             cls.build_content(target, element.content)
         elif element.type == DtdElementType.MIXED:
-            target.mixed = True
+            target.tag = Tag.COMPLEX_TYPE
+            cls.build_extension(target, DataType.STRING)
         elif element.type == DtdElementType.ANY:
-            datatype = DataType.ANY_TYPE
-            ext_type = AttrType(qname=str(datatype), native=True)
-            restrictions = Restrictions()
-            extension = Extension(type=ext_type, restrictions=restrictions)
-            target.extensions.append(extension)
+            cls.build_extension(target, DataType.ANY_TYPE)
+
+    @classmethod
+    def build_extension(cls, target: Class, data_type: DataType):
+        ext_type = AttrType(qname=str(data_type), native=True)
+        extension = Extension(type=ext_type, restrictions=Restrictions())
+        target.extensions.append(extension)
 
     @classmethod
     def build_content(cls, target: Class, content: DtdContent, **kwargs: Any):

--- a/xsdata/codegen/mappers/dtd.py
+++ b/xsdata/codegen/mappers/dtd.py
@@ -1,0 +1,169 @@
+import sys
+from typing import Any
+from typing import Iterator
+from typing import Optional
+
+from xsdata.codegen.models import Attr
+from xsdata.codegen.models import AttrType
+from xsdata.codegen.models import Class
+from xsdata.codegen.models import Extension
+from xsdata.codegen.models import Restrictions
+from xsdata.models.dtd import Dtd
+from xsdata.models.dtd import DtdAttribute
+from xsdata.models.dtd import DtdAttributeDefault
+from xsdata.models.dtd import DtdAttributeType
+from xsdata.models.dtd import DtdContent
+from xsdata.models.dtd import DtdContentOccur
+from xsdata.models.dtd import DtdContentType
+from xsdata.models.dtd import DtdElement
+from xsdata.models.dtd import DtdElementType
+from xsdata.models.enums import DataType
+from xsdata.models.enums import Tag
+
+
+class DtdMapper:
+    @classmethod
+    def map(cls, dtd: Dtd) -> Iterator[Class]:
+        for element in dtd.elements:
+            yield cls.build_class(element, dtd.location)
+
+    @classmethod
+    def build_class(cls, element: DtdElement, location: str) -> Class:
+        target = Class(
+            qname=element.qname,
+            ns_map=element.ns_map,
+            tag=Tag.ELEMENT,
+            location=location,
+        )
+
+        cls.build_attributes(target, element)
+        cls.build_elements(target, element)
+
+        return target
+
+    @classmethod
+    def build_attributes(cls, target: Class, element: DtdElement):
+        for attribute in element.attributes:
+            cls.build_attribute(target, attribute)
+
+    @classmethod
+    def build_attribute(cls, target: Class, attribute: DtdAttribute):
+        attr_type = cls.build_attribute_type(target, attribute)
+        attr = Attr(
+            name=attribute.name,
+            namespace=target.ns_map.get(attribute.prefix),
+            tag=Tag.ATTRIBUTE,
+            types=[attr_type],
+        )
+
+        cls.build_attribute_restrictions(
+            attr, attribute.default, attribute.default_value
+        )
+
+        attr.index = len(target.attrs)
+        target.attrs.append(attr)
+
+    @classmethod
+    def build_attribute_restrictions(
+        cls, attr: Attr, default: DtdAttributeDefault, default_value: Optional[str]
+    ):
+        attr.restrictions.max_occurs = 1
+        if default == DtdAttributeDefault.REQUIRED:
+            attr.restrictions.min_occurs = 1
+        elif default == DtdAttributeDefault.IMPLIED:
+            attr.restrictions.min_occurs = 0
+        elif default == DtdAttributeDefault.FIXED:
+            attr.fixed = True
+            attr.restrictions.min_occurs = 1
+            attr.default = default_value
+        elif default_value is not None:
+            attr.restrictions.min_occurs = 1
+            attr.default = default_value
+        else:
+            attr.restrictions.min_occurs = 0
+
+    @classmethod
+    def build_attribute_type(cls, target: Class, attribute: DtdAttribute) -> AttrType:
+        if attribute.type == DtdAttributeType.ENUMERATION:
+            cls.build_enumeration(target, attribute.name, attribute.values)
+            return AttrType(qname=attribute.name, forward=True)
+
+        return AttrType(qname=str(attribute.data_type), native=True)
+
+    @classmethod
+    def build_elements(cls, target: Class, element: DtdElement):
+        # "undefined", "empty", "any", "mixed", or "element";
+        if element.type == DtdElementType.ELEMENT and element.content:
+            cls.build_content(target, element.content)
+        elif element.type == DtdElementType.MIXED:
+            target.mixed = True
+        elif element.type == DtdElementType.ANY:
+            datatype = DataType.ANY_TYPE
+            ext_type = AttrType(qname=str(datatype), native=True)
+            restrictions = Restrictions()
+            extension = Extension(type=ext_type, restrictions=restrictions)
+            target.extensions.append(extension)
+
+    @classmethod
+    def build_content(cls, target: Class, content: DtdContent, **kwargs: Any):
+        content_type = content.type
+        if content_type == DtdContentType.ELEMENT:
+            restrictions = cls.build_restrictions(content.occur, **kwargs)
+            cls.build_element(target, content.name, restrictions)
+        elif content_type == DtdContentType.SEQ:
+            cls.build_content_tree(target, content)
+        elif content_type == DtdContentType.OR:
+            cls.build_content_tree(target, content, choice=str(id(content)))
+
+    @classmethod
+    def build_content_tree(cls, target: Class, content: DtdContent, **kwargs: Any):
+        if content.left:
+            cls.build_content(target, content.left, **kwargs)
+
+        if content.right:
+            cls.build_content(target, content.right, **kwargs)
+
+    @classmethod
+    def build_restrictions(cls, occur: DtdContentOccur, **kwargs: Any) -> Restrictions:
+        restrictions = Restrictions(**kwargs)
+        if occur == DtdContentOccur.ONCE:
+            restrictions.min_occurs = 1
+            restrictions.max_occurs = 1
+        elif occur == DtdContentOccur.OPT:
+            restrictions.min_occurs = 0
+            restrictions.max_occurs = 1
+        elif occur == DtdContentOccur.MULT:
+            restrictions.min_occurs = 0
+            restrictions.max_occurs = sys.maxsize
+        elif occur == DtdContentOccur.PLUS:
+            restrictions.min_occurs = 1
+            restrictions.max_occurs = sys.maxsize
+
+        return restrictions
+
+    @classmethod
+    def build_element(cls, target: Class, name: str, restrictions: Restrictions):
+        types = AttrType(qname=name, native=False)
+        attr = Attr(
+            name=name, tag=Tag.ELEMENT, types=[types], restrictions=restrictions.clone()
+        )
+        attr.index = len(target.attrs)
+        target.attrs.append(attr)
+
+    @classmethod
+    def build_enumeration(cls, target: Class, name: str, values: list[str]):
+        inner = Class(qname=name, tag=Tag.SIMPLE_TYPE, location=target.location)
+        attr_type = AttrType(qname=str(DataType.STRING), native=True)
+
+        for value in values:
+            inner.attrs.append(
+                Attr(
+                    fixed=True,
+                    default=value,
+                    name=value,
+                    tag=Tag.ENUMERATION,
+                    types=[attr_type.clone()],
+                )
+            )
+
+        target.inner.append(inner)

--- a/xsdata/codegen/parsers/dtd.py
+++ b/xsdata/codegen/parsers/dtd.py
@@ -1,0 +1,86 @@
+import io
+from typing import Any
+from typing import List
+from typing import Optional
+
+from xsdata.exceptions import ParserError
+from xsdata.models.dtd import Dtd
+from xsdata.models.dtd import DtdAttribute
+from xsdata.models.dtd import DtdAttributeDefault
+from xsdata.models.dtd import DtdAttributeType
+from xsdata.models.dtd import DtdContent
+from xsdata.models.dtd import DtdContentOccur
+from xsdata.models.dtd import DtdContentType
+from xsdata.models.dtd import DtdElement
+from xsdata.models.dtd import DtdElementType
+from xsdata.models.enums import Namespace
+
+
+class DtdParser:
+    @classmethod
+    def parse(cls, source: Any, location: str) -> Dtd:
+        try:
+            from lxml import etree
+
+            dtd = etree.DTD(io.BytesIO(source))
+        except ImportError:
+            raise ParserError("DtdParser requires lxml to run.")
+
+        elements = list(map(cls.build_element, dtd.iterelements()))
+        return Dtd(elements=elements, location=location)
+
+    @classmethod
+    def build_element(cls, element: Any) -> DtdElement:
+        content = cls.build_content(element.content)
+        attributes = list(map(cls.build_attribute, element.iterattributes()))
+        ns_map = cls.build_ns_map(element.prefix, attributes)
+        return DtdElement(
+            name=element.name,
+            prefix=element.prefix,
+            type=DtdElementType(element.type),
+            content=content,
+            attributes=attributes,
+            ns_map=ns_map,
+        )
+
+    @classmethod
+    def build_content(cls, content: Any) -> Optional[DtdContent]:
+        if not content:
+            return None
+
+        return DtdContent(
+            name=content.name,
+            occur=DtdContentOccur(content.occur),
+            type=DtdContentType(content.type),
+            left=cls.build_content(content.left),
+            right=cls.build_content(content.right),
+        )
+
+    @classmethod
+    def build_attribute(cls, attribute: Any) -> DtdAttribute:
+        return DtdAttribute(
+            prefix=attribute.prefix,
+            name=attribute.name,
+            type=DtdAttributeType(attribute.type),
+            default=DtdAttributeDefault(attribute.default),
+            default_value=attribute.default_value,
+            values=attribute.values(),
+        )
+
+    @classmethod
+    def build_ns_map(cls, prefix: str, attributes: List[DtdAttribute]) -> dict:
+        ns_map = {ns.prefix: ns.uri for ns in Namespace.common()}
+
+        for attribute in list(attributes):
+
+            if not attribute.default_value:
+                continue
+
+            if attribute.prefix == "xmlns":
+                ns_map[attribute.name] = attribute.default_value
+                attributes.remove(attribute)
+            elif attribute.name == "xmlns":
+                ns_map[prefix] = attribute.default_value
+                attributes.remove(attribute)
+
+        return ns_map

--- a/xsdata/codegen/parsers/schema.py
+++ b/xsdata/codegen/parsers/schema.py
@@ -241,9 +241,12 @@ class SchemaParser(UserXmlParser):
                 )
 
             ns_list = obj.ns_map.values()
-            ns_common = (Namespace.XS, Namespace.XSI, Namespace.XML, Namespace.XLINK)
             obj.ns_map.update(
-                {ns.prefix: ns.uri for ns in ns_common if ns.uri not in ns_list}
+                {
+                    ns.prefix: ns.uri
+                    for ns in Namespace.common()
+                    if ns.uri not in ns_list
+                }
             )
 
     @classmethod

--- a/xsdata/models/dtd.py
+++ b/xsdata/models/dtd.py
@@ -1,0 +1,94 @@
+import enum
+from dataclasses import dataclass
+from typing import Dict
+from typing import List
+from typing import Optional
+
+from xsdata.models.enums import DataType
+from xsdata.utils.namespaces import build_qname
+
+
+class DtdElementType(enum.Enum):
+    UNDEFINED = "undefined"
+    EMPTY = "empty"
+    ANY = "any"
+    MIXED = "mixed"
+    ELEMENT = "element"
+
+
+class DtdAttributeDefault(enum.Enum):
+    REQUIRED = "required"
+    IMPLIED = "implied"
+    FIXED = "fixed"
+    NONE = "none"
+
+
+class DtdAttributeType(enum.Enum):
+    CDATA = "cdata"
+    ID = "id"
+    IDREF = "idref"
+    IDREFS = "idrefs"
+    ENTITY = "entity"
+    ENTITIES = "entities"
+    NMTOKEN = "nmtoken"
+    NMTOKENS = "nmtokens"
+    ENUMERATION = "enumeration"
+    NOTATION = "notation"
+
+
+class DtdContentType(enum.Enum):
+    PCDATA = "pcdata"
+    ELEMENT = "element"
+    SEQ = "seq"
+    OR = "or"
+
+
+class DtdContentOccur(enum.Enum):
+    ONCE = "once"
+    OPT = "opt"
+    MULT = "mult"
+    PLUS = "plus"
+
+
+@dataclass
+class DtdAttribute:
+    name: str
+    prefix: Optional[str]
+    type: DtdAttributeType
+    default: DtdAttributeDefault
+    default_value: Optional[str]
+    values: List[str]
+
+    @property
+    def data_type(self) -> DataType:
+        return DataType.from_code(self.type.value.lower())
+
+
+@dataclass
+class DtdContent:
+    name: str
+    type: DtdContentType
+    occur: DtdContentOccur
+    left: Optional["DtdContent"]
+    right: Optional["DtdContent"]
+
+
+@dataclass
+class DtdElement:
+    name: str
+    type: DtdElementType
+    prefix: Optional[str]
+    content: Optional[DtdContent]
+    attributes: List[DtdAttribute]
+    ns_map: Dict
+
+    @property
+    def qname(self) -> str:
+        namespace = self.ns_map.get(self.prefix)
+        return build_qname(namespace, self.name)
+
+
+@dataclass
+class Dtd:
+    location: str
+    elements: List[DtdElement]

--- a/xsdata/models/enums.py
+++ b/xsdata/models/enums.py
@@ -6,6 +6,7 @@ from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import Optional
+from typing import Tuple
 from typing import Type
 from xml.etree.ElementTree import QName
 
@@ -44,6 +45,10 @@ class Namespace(Enum):
     @classmethod
     def get_enum(cls, uri: Optional[str]) -> Optional["Namespace"]:
         return __STANDARD_NAMESPACES__.get(uri) if uri else None
+
+    @classmethod
+    def common(cls) -> Tuple["Namespace", ...]:
+        return Namespace.XS, Namespace.XSI, Namespace.XML, Namespace.XLINK
 
 
 __STANDARD_NAMESPACES__ = {ns.uri: ns for ns in Namespace}
@@ -191,6 +196,10 @@ class DataType(Enum):
     def from_qname(cls, qname: str) -> Optional["DataType"]:
         return __DataTypeQNameIndex__.get(qname)
 
+    @classmethod
+    def from_code(cls, code: str) -> "DataType":
+        return __DataTypeCodeIndex__.get(code, DataType.STRING)
+
 
 def period_datatype(value: XmlPeriod) -> DataType:
     if value.year is not None:
@@ -238,6 +247,7 @@ __DataTypeInferIndex__: Dict[Type, Callable] = {
     XmlPeriod: period_datatype,
 }
 __DataTypeQNameIndex__ = {str(dt): dt for dt in DataType}
+__DataTypeCodeIndex__ = {dt.code.lower(): dt for dt in DataType}
 
 
 class EventType:

--- a/xsdata/utils/package.py
+++ b/xsdata/utils/package.py
@@ -20,4 +20,4 @@ def module_name(source: str) -> str:
 
     module = source.split("/")[-1]
     name, extension = os.path.splitext(module)
-    return name if extension in (".xsd", ".wsdl", ".xml", ".json") else module
+    return name if extension in (".xsd", ".dtd", ".wsdl", ".xml", ".json") else module

--- a/xsdata/utils/testing.py
+++ b/xsdata/utils/testing.py
@@ -23,6 +23,15 @@ from xsdata.codegen.models import Status
 from xsdata.formats.dataclass.models.elements import XmlMeta
 from xsdata.formats.dataclass.models.elements import XmlType
 from xsdata.formats.dataclass.models.elements import XmlVar
+from xsdata.models.dtd import Dtd
+from xsdata.models.dtd import DtdAttribute
+from xsdata.models.dtd import DtdAttributeDefault
+from xsdata.models.dtd import DtdAttributeType
+from xsdata.models.dtd import DtdContent
+from xsdata.models.dtd import DtdContentOccur
+from xsdata.models.dtd import DtdContentType
+from xsdata.models.dtd import DtdElement
+from xsdata.models.dtd import DtdElementType
 from xsdata.models.enums import DataType
 from xsdata.models.enums import Namespace
 from xsdata.models.enums import Tag
@@ -64,6 +73,10 @@ class FactoryTestCase(unittest.TestCase):
         PackageFactory.reset()
         XmlVarFactory.reset()
         XmlMetaFactory.reset()
+        DtdElementFactory.reset()
+        DtdAttributeFactory.reset()
+        DtdContentFactory.reset()
+        DtdFactory.reset()
 
 
 class Factory(abc.ABC):
@@ -464,3 +477,130 @@ class XmlMetaFactory(Factory):
             attributes=attributes,
             any_attributes=any_attributes,
         )
+
+
+class DtdAttributeFactory(Factory):
+    counter = 65
+
+    @classmethod
+    def create(
+        cls,
+        name: Optional[str] = None,
+        prefix: Optional[str] = None,
+        type: Optional[DtdAttributeType] = None,
+        default: Optional[DtdAttributeDefault] = None,
+        default_value: Optional[str] = None,
+        values: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> DtdAttribute:
+
+        if name is None:
+            name = f"attribute_{cls.next_letter()}"
+
+        if type is None:
+            type = DtdAttributeType.CDATA
+
+        if default is None:
+            default = DtdAttributeDefault.NONE
+
+        if values is None:
+            values = []
+
+        return DtdAttribute(
+            name=name,
+            prefix=prefix,
+            type=type,
+            default=default,
+            default_value=default_value,
+            values=values,
+        )
+
+
+class DtdContentFactory(Factory):
+    counter = 65
+
+    @classmethod
+    def create(
+        cls,
+        name: Optional[str] = None,
+        type: Optional[DtdContentType] = None,
+        occur: Optional[DtdContentOccur] = None,
+        left: Optional[DtdContent] = None,
+        right: Optional[DtdContent] = None,
+        **kwargs: Any,
+    ) -> DtdContent:
+        if name is None:
+            name = f"content_{cls.next_letter()}"
+
+        if type is None:
+            type = DtdContentType.ELEMENT
+
+        if occur is None:
+            occur = DtdContentOccur.ONCE
+
+        return DtdContent(
+            name=name,
+            type=type,
+            occur=occur,
+            left=left,
+            right=right,
+        )
+
+
+class DtdElementFactory(Factory):
+    counter = 65
+
+    @classmethod
+    def create(
+        cls,
+        name: Optional[str] = None,
+        prefix: Optional[str] = None,
+        type: Optional[DtdElementType] = None,
+        content: Optional[DtdContent] = None,
+        attributes: Optional[List[DtdAttribute]] = None,
+        ns_map: Optional[Dict] = None,
+        **kwargs: Any,
+    ) -> DtdElement:
+
+        if name is None:
+            name = f"element_{cls.next_letter()}"
+
+        if type is None:
+            type = DtdElementType.ELEMENT
+
+        if attributes is None:
+            attributes = []
+
+        if ns_map is None:
+            ns_map = {}
+
+        return DtdElement(
+            name=name,
+            prefix=prefix,
+            type=type,
+            content=content,
+            attributes=attributes,
+            ns_map=ns_map,
+        )
+
+
+class DtdFactory(Factory):
+    @classmethod
+    def create(
+        cls,
+        elements: Optional[List[DtdElement]] = None,
+        location: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Dtd:
+        if elements is None:
+            elements = []
+
+        if location is None:
+            location = "test.dtd"
+
+        return Dtd(elements=elements, location=location)
+
+    @classmethod
+    def root(cls, number: int, **kwargs: Any) -> Dtd:
+        elements = DtdElementFactory.list(number)
+        return cls.create(elements=elements, **kwargs)


### PR DESCRIPTION
## 📒 Description

Add Support for Document type definitions (DTD)

Resolves #685 

## 🔗 What I've Done

- Used lxml dtd parser
- Added dtd parse models
- Added mapper to convert dtd models to codegen objects
- Namespaces support is very experimental as I didn't have many samples


## 💬 Comments

## 🛫 Checklist

- [x] Updated docs
- [x] Added unit-tests
- [x] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [x] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
