### PR TITLE
Avoid using DerivedElement with known elements for mixed wildcards

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -11,10 +11,19 @@ Code Generation
     examples/docstrings
     examples/xml-modeling
     examples/json-modeling
-    examples/pycode-serializer
     examples/dtd-modeling
     examples/compound-fields
     examples/dataclasses-features
+
+
+Data Binding
+============
+
+.. toctree::
+    :maxdepth: 1
+
+    examples/pycode-serializer
+    examples/working-with-wildcards
 
 
 Advance Topics

--- a/docs/examples/working-with-wildcards.rst
+++ b/docs/examples/working-with-wildcards.rst
@@ -1,5 +1,7 @@
-How to work with wildcard fields?
-==================================
+======================
+Working with wildcards
+======================
+
 
 One of the xml schema traits is to support any extensions with wildcards.
 
@@ -38,6 +40,9 @@ The generator will roughly create this class for you.
     ...          }
     ...      )
 
+
+Generics
+========
 
 xsdata comes with two generic models that are used during parsing and you can also use
 to generate any custom xml element.
@@ -86,4 +91,64 @@ to generate any custom xml element.
         <third xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" c="3" xsi:type="MetadataType"/>
       </bar>
     </MetadataType>
+    <BLANKLINE>
+
+
+Mixed content
+=============
+
+For mixed content with known choices you can skip wrapping your instances with a
+generic model. During data binding xsdata will try first to match one of the qualified
+choices.
+
+.. doctest::
+
+    >>> @dataclass
+    ... class Beta:
+    ...     class Meta:
+    ...         name = "beta"
+    ...
+    >>> @dataclass
+    ... class Alpha:
+    ...     class Meta:
+    ...         name = "alpha"
+    ...
+    >>> @dataclass
+    ... class Doc:
+    ...     class Meta:
+    ...         name = "doc"
+    ...
+    ...     content: List[object] = field(
+    ...         default_factory=list,
+    ...         metadata={
+    ...             "type": "Wildcard",
+    ...             "namespace": "##any",
+    ...             "mixed": True,
+    ...             "choices": (
+    ...                 {
+    ...                     "name": "a",
+    ...                     "type": Alpha,
+    ...                     "namespace": "",
+    ...                 },
+    ...                 {
+    ...                     "name": "b",
+    ...                     "type": Beta,
+    ...                     "namespace": "",
+    ...                 },
+    ...             ),
+    ...         }
+    ...     )
+    ...
+    >>> obj = Doc(
+    ...     content=[
+    ...         Alpha(),
+    ...         Beta(),
+    ...     ]
+    ... )
+    ...
+    >>> print(serializer.render(obj))
+    <doc>
+      <a/>
+      <b/>
+    </doc>
     <BLANKLINE>

--- a/tests/fixtures/models.py
+++ b/tests/fixtures/models.py
@@ -166,7 +166,14 @@ class Paragraph:
 
     content: List[object] = field(
         default_factory=list,
-        metadata=dict(type="Wildcard", namespace="##any", mixed=True),
+        metadata=dict(
+            type="Wildcard",
+            namespace="##any",
+            mixed=True,
+            choices=(
+                dict(name="span", type=Span),
+            ),
+        )
     )
 
 

--- a/tests/formats/dataclass/parsers/nodes/test_element.py
+++ b/tests/formats/dataclass/parsers/nodes/test_element.py
@@ -266,26 +266,38 @@ class ElementNodeTests(FactoryTestCase):
         self.assertEqual(expected, params)
 
     def test_prepare_generic_value(self):
-        actual = self.node.prepare_generic_value(None, 1)
+        var = XmlVarFactory.create(
+            index=2,
+            xml_type=XmlType.WILDCARD,
+            qname="a",
+            types=(object,),
+            elements={"known": XmlVarFactory.create()},
+        )
+
+        actual = self.node.prepare_generic_value(None, 1, var)
         self.assertEqual(1, actual)
 
-        actual = self.node.prepare_generic_value("a", 1)
+        actual = self.node.prepare_generic_value("a", 1, var)
         expected = AnyElement(qname="a", text="1")
         self.assertEqual(expected, actual)
 
-        actual = self.node.prepare_generic_value("a", "foo")
+        actual = self.node.prepare_generic_value("a", "foo", var)
         expected = AnyElement(qname="a", text="foo")
         self.assertEqual(expected, actual)
 
         fixture = make_dataclass("Fixture", [("content", str)])
-        actual = self.node.prepare_generic_value("a", fixture("foo"))
+        actual = self.node.prepare_generic_value("a", fixture("foo"), var)
         expected = DerivedElement(qname="a", value=fixture("foo"), type="Fixture")
         self.assertEqual(expected, actual)
 
-        actual = self.node.prepare_generic_value("a", expected)
+        fixture = make_dataclass("Fixture", [("content", str)])
+        actual = self.node.prepare_generic_value("known", fixture("foo"), var)
+        self.assertEqual(fixture("foo"), actual)
+
+        actual = self.node.prepare_generic_value("a", expected, var)
         self.assertIs(expected, actual)
 
-        actual = self.node.prepare_generic_value("Fixture", fixture("foo"))
+        actual = self.node.prepare_generic_value("Fixture", fixture("foo"), var)
         expected = DerivedElement(qname="Fixture", value=fixture("foo"))
         self.assertEqual(expected, actual)
 

--- a/xsdata/formats/dataclass/serializers/xml.py
+++ b/xsdata/formats/dataclass/serializers/xml.py
@@ -118,11 +118,15 @@ class XmlSerializer(AbstractSerializer):
         yield XmlWriterEvent.END, qname
 
     def write_xsi_type(self, value: Any, var: XmlVar, namespace: NoneStr) -> Generator:
-        """Produce an events stream from a dataclass for the given var with
-        with xsi abstract type check for non wildcards."""
+        """Produce an events stream from a dataclass for the given var with xsi
+        abstract type check for non wildcards."""
 
         if var.is_wildcard:
-            yield from self.write_dataclass(value, namespace)
+            choice = var.find_value_choice(value, True)
+            if choice:
+                yield from self.write_value(value, choice, namespace)
+            else:
+                yield from self.write_dataclass(value, namespace)
         else:
             xsi_type = self.xsi_type(var, value, namespace)
             yield from self.write_dataclass(


### PR DESCRIPTION
## 📒 Description

xsdata is always wrapping data models with the DerivedElement generic during data binding. 

There were multiple limitations with the generator and the resolve all qualified names.

I am not sure when but these issues are currently resolved so it's time to drop the mandatory wrapping to only when it's necessary.

Resolves #693 and #437 

## 🔗 What I've Done

- Update parsing to check mixed elements for a known qname
- Update serializer to check for a known qname for mixed objects

## 💬 Comments

This breaks backwards compatibility. People will need to check object instance type and not assume it will always be a DerivedElement

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
