### PR TITLE
PycodeSerializer should ignore init false fields

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
       - id: end-of-file-fixer
       - id: debug-statements
   - repo: https://github.com/myint/docformatter
-    rev: v1.4
+    rev: v1.5.0-rc1
     hooks:
       - id: docformatter
         args: ["--in-place", "--pre-summary-newline"]

--- a/docs/examples/pycode-serializer.rst
+++ b/docs/examples/pycode-serializer.rst
@@ -32,8 +32,7 @@ python representation code.
                 price=44.95,
                 pub_date=XmlDate(2000, 10, 1),
                 review="An amazing story of nothing.",
-                id="bk001",
-                lang="en"
+                id="bk001"
             ),
             BookForm(
                 author="Nagata, Suanne",
@@ -42,8 +41,7 @@ python representation code.
                 price=33.95,
                 pub_date=XmlDate(2001, 1, 10),
                 review="A masterpiece of the fine art of gossiping.",
-                id="bk002",
-                lang="en"
+                id="bk002"
             ),
         ]
     )

--- a/tests/formats/dataclass/serializers/test_code.py
+++ b/tests/formats/dataclass/serializers/test_code.py
@@ -27,8 +27,7 @@ class PycodeSerializerTests(TestCase):
             "            price=44.95,\n"
             "            pub_date=XmlDate(2000, 10, 1),\n"
             '            review="An amazing story of nothing.",\n'
-            '            id="bk001",\n'
-            '            lang="en"\n'
+            '            id="bk001"\n'
             "        ),\n"
             "        BookForm(\n"
             '            author="Nagata, Suanne",\n'
@@ -37,8 +36,7 @@ class PycodeSerializerTests(TestCase):
             "            price=33.95,\n"
             "            pub_date=XmlDate(2001, 1, 10),\n"
             '            review="A masterpiece of the fine art of gossiping.",\n'
-            '            id="bk002",\n'
-            '            lang="en"\n'
+            '            id="bk002"\n'
             "        ),\n"
             "    ]\n"
             ")\n"

--- a/tests/integration/test_docstrings.py
+++ b/tests/integration/test_docstrings.py
@@ -11,7 +11,6 @@ schema = fixtures_dir.joinpath("docstrings/schema.xsd")
 
 
 def test_generate_restructured_docstrings():
-
     package = "tests.fixtures.docstrings.rst"
     runner = CliRunner()
     runner.invoke(

--- a/xsdata/formats/dataclass/serializers/code.py
+++ b/xsdata/formats/dataclass/serializers/code.py
@@ -126,6 +126,9 @@ class PycodeSerializer(AbstractSerializer):
 
         next_level = level + 1
         for index, f in enumerate(self.context.class_type.get_fields(obj)):
+            if not f.init:
+                continue
+
             if index:
                 yield f",\n{spaces * next_level}{f.name}="
             else:

--- a/xsdata/formats/dataclass/typing.py
+++ b/xsdata/formats/dataclass/typing.py
@@ -13,7 +13,6 @@ EMPTY_ARGS = ()
 
 
 def get_origin(tp: Any) -> Any:
-
     if tp is Dict:
         return Dict
 

--- a/xsdata/utils/dates.py
+++ b/xsdata/utils/dates.py
@@ -93,7 +93,6 @@ def validate_date(year: int, month: int, day: int):
 
 
 def validate_time(hour: int, minute: int, second: int, franctional_second: int):
-
     if not 0 <= hour <= 24:
         raise ValueError("Hour must be in 0..24")
 

--- a/xsdata/utils/package.py
+++ b/xsdata/utils/package.py
@@ -17,7 +17,6 @@ def module_path(module: str) -> Path:
 
 @functools.lru_cache(maxsize=50)
 def module_name(source: str) -> str:
-
     module = source.split("/")[-1]
     name, extension = os.path.splitext(module)
     return name if extension in (".xsd", ".dtd", ".wsdl", ".xml", ".json") else module


### PR DESCRIPTION
## 📒 Description

Code serializer should ignore fields with `init=false`


Resolves #697 

## 🔗 What I've Done


## 💬 Comments


## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
