### PR TITLE
Introduce codegen filter strategy: referred globals

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
       - id: end-of-file-fixer
       - id: debug-statements
   - repo: https://github.com/myint/docformatter
-    rev: v1.5.0-rc1
+    rev: v1.5.0
     hooks:
       - id: docformatter
         args: ["--in-place", "--pre-summary-newline"]

--- a/tests/codegen/handlers/test_filter_classes.py
+++ b/tests/codegen/handlers/test_filter_classes.py
@@ -1,0 +1,73 @@
+from unittest import mock
+
+from xsdata.codegen.container import ClassContainer
+from xsdata.codegen.handlers import FilterClasses
+from xsdata.models.config import ClassFilterStrategy
+from xsdata.models.config import GeneratorConfig
+from xsdata.models.enums import Tag
+from xsdata.utils.testing import AttrFactory
+from xsdata.utils.testing import ClassFactory
+from xsdata.utils.testing import FactoryTestCase
+
+
+class FilterClassesTests(FactoryTestCase):
+    maxDiff = None
+
+    def setUp(self):
+        super().setUp()
+
+        self.container = ClassContainer(config=GeneratorConfig())
+        self.handler = FilterClasses(self.container)
+
+    def test_filter_all_globals(self):
+        complex_type = ClassFactory.elements(1)
+        enum_1 = ClassFactory.enumeration(2)
+        complex_type.attrs[0].types[0].reference = enum_1.ref
+
+        simple_type = ClassFactory.simple_type()
+        enum_2 = ClassFactory.enumeration(3)
+        simple_type.attrs[0].types[0].reference = enum_2.ref
+
+        element = ClassFactory.create(tag=Tag.ELEMENT, abstract=True)
+
+        expected = [complex_type, enum_1]
+        self.container.extend([complex_type, enum_1, simple_type, enum_2, element])
+        self.handler.run()
+        self.assertEqual(expected, list(self.container))
+
+    def test_filter_referred_globals(self):
+        self.container.config.output.filter_strategy = (
+            ClassFilterStrategy.REFERRED_GLOBALS
+        )
+
+        element_1 = ClassFactory.create(tag=Tag.ELEMENT, attrs=AttrFactory.list(2))
+        element_2 = ClassFactory.create(tag=Tag.ELEMENT, attrs=AttrFactory.list(2))
+        enum_1 = ClassFactory.enumeration(2)
+        element_2.attrs[0].types[0].reference = enum_1.ref
+
+        expected = [element_2, enum_1]
+        self.container.extend([element_1, element_2, enum_1])
+        self.handler.run()
+        self.assertEqual(expected, list(self.container))
+
+    def test_filter_all(self):
+        simple_type = ClassFactory.simple_type()
+        enumeration = ClassFactory.enumeration(2)
+        complex_type = ClassFactory.elements(2)
+        self.container.extend([simple_type, enumeration, complex_type])
+        self.container.config.output.filter_strategy = ClassFilterStrategy.ALL
+
+        self.handler.run()
+        self.assertEqual(3, len(list(self.container)))
+
+    @mock.patch("xsdata.codegen.handlers.filter_classes.logger.warning")
+    def test_run_with_strategy_not_all_with_no_classes(self, mock_warning):
+        classes = [ClassFactory.enumeration(2), ClassFactory.simple_type()]
+        self.container.extend(classes)
+        self.handler.run()
+        self.assertEqual(classes, list(self.container))
+
+        mock_warning.assert_called_once_with(
+            "The filter strategy '%s' returned no classes, will generate all types.",
+            "allGlobals",
+        )

--- a/tests/codegen/test_container.py
+++ b/tests/codegen/test_container.py
@@ -7,7 +7,6 @@ from xsdata.codegen.models import Status
 from xsdata.models.config import GeneratorConfig
 from xsdata.models.enums import Tag
 from xsdata.utils.testing import AttrFactory
-from xsdata.utils.testing import AttrTypeFactory
 from xsdata.utils.testing import ClassFactory
 from xsdata.utils.testing import FactoryTestCase
 
@@ -144,11 +143,3 @@ class ClassContainerTests(FactoryTestCase):
         expected = [complex_type, enum_1]
         container.filter_classes()
         self.assertEqual(expected, list(container))
-
-    def test_filter_classes_with_only_simple_types(self):
-        classes = [ClassFactory.enumeration(2), ClassFactory.simple_type()]
-        container = ClassContainer(config=GeneratorConfig())
-        container.extend(classes)
-        container.filter_classes()
-
-        self.assertEqual(classes, list(container))

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -33,6 +33,7 @@ class GeneratorConfigTests(TestCase):
             '    <Format repr="true" eq="true" order="false" unsafeHash="false" frozen="false" slots="false" kwOnly="false">dataclasses</Format>\n'
             "    <Structure>filenames</Structure>\n"
             "    <DocstringStyle>reStructuredText</DocstringStyle>\n"
+            "    <FilterStrategy>allGlobals</FilterStrategy>\n"
             "    <RelativeImports>false</RelativeImports>\n"
             '    <CompoundFields defaultName="choice" forceDefaultName="false">false</CompoundFields>\n'
             "    <PostponedAnnotations>false</PostponedAnnotations>\n"
@@ -90,6 +91,7 @@ class GeneratorConfigTests(TestCase):
             ' frozen="false" slots="false" kwOnly="false">dataclasses</Format>\n'
             "    <Structure>filenames</Structure>\n"
             "    <DocstringStyle>reStructuredText</DocstringStyle>\n"
+            "    <FilterStrategy>allGlobals</FilterStrategy>\n"
             "    <RelativeImports>false</RelativeImports>\n"
             '    <CompoundFields defaultName="choice" forceDefaultName="false">false</CompoundFields>\n'
             "    <PostponedAnnotations>false</PostponedAnnotations>\n"

--- a/xsdata/codegen/handlers/__init__.py
+++ b/xsdata/codegen/handlers/__init__.py
@@ -1,6 +1,7 @@
 from .add_attribute_substitutions import AddAttributeSubstitutions
 from .create_compound_fields import CreateCompoundFields
 from .designate_class_packages import DesignateClassPackages
+from .filter_classes import FilterClasses
 from .flatten_attribute_groups import FlattenAttributeGroups
 from .flatten_class_extensions import FlattenClassExtensions
 from .merge_attributes import MergeAttributes
@@ -19,6 +20,7 @@ __all__ = [
     "AddAttributeSubstitutions",
     "CreateCompoundFields",
     "DesignateClassPackages",
+    "FilterClasses",
     "FlattenAttributeGroups",
     "FlattenClassExtensions",
     "MergeAttributes",

--- a/xsdata/codegen/handlers/filter_classes.py
+++ b/xsdata/codegen/handlers/filter_classes.py
@@ -1,0 +1,52 @@
+from typing import List
+
+from xsdata.codegen.mixins import ContainerHandlerInterface
+from xsdata.codegen.models import Class
+from xsdata.logger import logger
+from xsdata.models.config import ClassFilterStrategy
+
+
+class FilterClasses(ContainerHandlerInterface):
+    """Filter classes for code generation based on the configuration output
+    filter strategy."""
+
+    __slots__ = ()
+
+    def run(self):
+        classes = []
+        filter_strategy = self.container.config.output.filter_strategy
+        if filter_strategy == ClassFilterStrategy.ALL_GLOBALS:
+            classes = self.filter_all_globals()
+        elif filter_strategy == ClassFilterStrategy.REFERRED_GLOBALS:
+            classes = self.filter_referred_globals()
+
+        if classes:
+            self.container.set(classes)
+        elif filter_strategy != ClassFilterStrategy.ALL:
+            logger.warning(
+                "The filter strategy '%s' returned no classes,"
+                " will generate all types.",
+                filter_strategy.value,
+            )
+
+    def filter_all_globals(self) -> List[Class]:
+        """Filter all globals and any referenced types."""
+        occurs = set()
+        for obj in self.container:
+            if obj.is_global_type:
+                occurs.add(obj.ref)
+                occurs.update(obj.references)
+
+        return [obj for obj in self.container if obj.ref in occurs]
+
+    def filter_referred_globals(self) -> List[Class]:
+        """Filter globals with any references."""
+        occurs = set()
+        for obj in self.container:
+            if obj.is_global_type:
+                references = list(obj.references)
+                occurs.update(references)
+                if references:
+                    occurs.add(obj.ref)
+
+        return [obj for obj in self.container if obj.ref in occurs]

--- a/xsdata/codegen/mixins.py
+++ b/xsdata/codegen/mixins.py
@@ -44,11 +44,15 @@ class ContainerInterface(abc.ABC):
 
     @abc.abstractmethod
     def extend(self, items: List[Class]):
-        """Add a list of classes the container."""
+        """Add a list of classes to the container."""
 
     @abc.abstractmethod
     def reset(self, item: Class, qname: str):
         """Update the given class qualified name."""
+
+    @abc.abstractmethod
+    def set(self, items: List[Class]):
+        """Set the list of classes to the container."""
 
 
 class HandlerInterface(abc.ABC):
@@ -62,7 +66,7 @@ class HandlerInterface(abc.ABC):
 
 
 class RelativeHandlerInterface(HandlerInterface, metaclass=ABCMeta):
-    """Class handler interface with access to the complete classes
+    """Class handler interface with access to the complete classes'
     container."""
 
     __slots__ = "container"

--- a/xsdata/models/config.py
+++ b/xsdata/models/config.py
@@ -134,6 +134,21 @@ class DocstringStyle(Enum):
     BLANK = "Blank"
 
 
+class ClassFilterStrategy(Enum):
+    """
+    Class filter strategy.
+
+    :cvar ALL: all: Generate all types, discouraged!!!
+    :cvar ALL_GLOBALS: allGlobals: Generate all global types
+    :cvar REFERRED_GLOBALS: referredGlobals: Generate all global types
+        with at least one reference.
+    """
+
+    ALL = "all"
+    ALL_GLOBALS = "allGlobals"
+    REFERRED_GLOBALS = "referredGlobals"
+
+
 class ObjectType(Enum):
     """
     Object type enumeration.
@@ -223,6 +238,7 @@ class GeneratorOutput:
     :param format: Output format
     :param structure_style: Output structure style, default: filenames
     :param docstring_style: Docstring style, default: reStructuredText
+    :param filter_strategy: Class filter strategy, default: globals
     :param relative_imports: Use relative imports, default: false
     :param compound_fields: Use compound fields for repeatable elements, default: false
     :param max_line_length: Adjust the maximum line length, default: 79
@@ -237,6 +253,9 @@ class GeneratorOutput:
         default=StructureStyle.FILENAMES, name="Structure"
     )
     docstring_style: DocstringStyle = element(default=DocstringStyle.RST)
+    filter_strategy: ClassFilterStrategy = element(
+        default=ClassFilterStrategy.ALL_GLOBALS
+    )
     relative_imports: bool = element(default=False)
     compound_fields: CompoundFields = element(default_factory=CompoundFields)
     max_line_length: int = attribute(default=79)


### PR DESCRIPTION
## 📒 Description

Add a new filter strategy for generated classes in order to filter out global types that are not referenced anywhere.

This new strategy will accommodate certain schemas where simple types are defined as global elements and since xsdata default behavior is to generate all global types these dummy type elements with no usages make it to the final output.


Example

```xml
<?xml version="1.0" encoding="utf-8"?>
    ...
    <xs:element name="Name" type="xs:string" />
</xs:schema>
```

Resolves #691 

## 🔗 What I've Done

- Moved the filtering from the container into its own handler so we can add/update things easier.
- Added the new strategy
- Added the fallback strategy all: if the selected strategy filters out all types.

## 💬 Comments

- The default strategy is the highly suggested solution for most use cases and all wsdl!!!

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
