### PR TITLE
Resolve group and attrGroup name collisions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     hooks:
       - id: reorder-python-imports
   - repo: https://github.com/ambv/black
-    rev: 22.6.0
+    rev: 22.8.0
     hooks:
       - id: black
   - repo: https://gitlab.com/pycqa/flake8

--- a/tests/codegen/handlers/test_flatten_attribute_groups.py
+++ b/tests/codegen/handlers/test_flatten_attribute_groups.py
@@ -47,7 +47,7 @@ class FlattenAttributeGroupsTests(FactoryTestCase):
     @mock.patch.object(ClassUtils, "copy_group_attributes")
     def test_process_attribute_with_group(self, mock_copy_group_attributes):
         complex_bar = ClassFactory.create(qname="bar", tag=Tag.COMPLEX_TYPE)
-        group_bar = ClassFactory.create(qname="bar", tag=Tag.GROUP)
+        group_bar = ClassFactory.create(qname="bar", tag=Tag.ATTRIBUTE_GROUP)
         group_attr = AttrFactory.attribute_group(name="bar")
         target = ClassFactory.create()
         target.attrs.append(group_attr)
@@ -80,7 +80,7 @@ class FlattenAttributeGroupsTests(FactoryTestCase):
 
     def test_process_attribute_with_circular_reference(self):
         group_attr = AttrFactory.attribute_group(name="bar")
-        target = ClassFactory.create(qname="bar", tag=Tag.GROUP)
+        target = ClassFactory.create(qname="bar", tag=Tag.ATTRIBUTE_GROUP)
         target.attrs.append(group_attr)
 
         target.status = Status.FLATTENING

--- a/xsdata/codegen/handlers/flatten_attribute_groups.py
+++ b/xsdata/codegen/handlers/flatten_attribute_groups.py
@@ -1,13 +1,12 @@
 from xsdata.codegen.mixins import RelativeHandlerInterface
 from xsdata.codegen.models import Attr
 from xsdata.codegen.models import Class
-from xsdata.codegen.models import is_group
 from xsdata.codegen.utils import ClassUtils
 from xsdata.exceptions import AnalyzerValueError
 
 
 class FlattenAttributeGroups(RelativeHandlerInterface):
-    """Replace attribute groups with the source class attributes."""
+    """Replace groups and attGroups with the source class attributes."""
 
     __slots__ = ()
 
@@ -36,7 +35,7 @@ class FlattenAttributeGroups(RelativeHandlerInterface):
         :raises AnalyzerValueError: if source class is not found.
         """
         qname = attr.types[0].qname  # group attributes have one type only.
-        source = self.container.find(qname, condition=is_group)
+        source = self.container.find(qname, condition=lambda x: x.tag == attr.tag)
 
         if not source:
             raise AnalyzerValueError(f"Group attribute not found: `{qname}`")


### PR DESCRIPTION
## 📒 Description

Group elements and attrGroup attributes can have the same name.
The handler that flattens both of them doesn't resolve them by tag which causes the output model to have the wrong fields in the end.

Resolves #701

## 🔗 What I've Done

- Add condition in FlattenAttributeGroups to match the attr tag to the source class tag.

## 💬 Comments

Really tricky case,  I have zero cases of this issue in my samples...

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
