### PR TITLE
Fix min occurs for choice content types

### DIFF
--- a/tests/codegen/parsers/test_dtd.py
+++ b/tests/codegen/parsers/test_dtd.py
@@ -29,7 +29,7 @@ class DtdParserTests(TestCase):
 
     def test_build_element(self):
         dtd = self.parse("dtd/complete_example.dtd")
-        self.assertEqual(6, len(dtd.elements))
+        self.assertEqual(8, len(dtd.elements))
 
         element = dtd.elements[1]
         self.assertEqual(4, len(element.attributes))
@@ -57,35 +57,59 @@ class DtdParserTests(TestCase):
 
         actual = asdict(post.content)
         expected = {
-            "name": None,
-            "occur": DtdContentOccur.ONCE,
-            "type": DtdContentType.SEQ,
             "left": {
-                "left": None,
-                "name": "Title",
-                "occur": DtdContentOccur.ONCE,
-                "right": None,
-                "type": DtdContentType.ELEMENT,
-            },
-            "right": {
                 "left": {
                     "left": None,
-                    "name": "Body",
+                    "name": "Origin",
                     "occur": DtdContentOccur.ONCE,
                     "right": None,
                     "type": DtdContentType.ELEMENT,
                 },
                 "name": None,
                 "occur": DtdContentOccur.ONCE,
-                "type": DtdContentType.SEQ,
                 "right": {
                     "left": None,
-                    "name": "Tags",
+                    "name": "Source",
                     "occur": DtdContentOccur.ONCE,
                     "right": None,
                     "type": DtdContentType.ELEMENT,
                 },
+                "type": DtdContentType.OR,
             },
+            "name": None,
+            "occur": DtdContentOccur.ONCE,
+            "right": {
+                "left": {
+                    "left": None,
+                    "name": "Title",
+                    "occur": DtdContentOccur.ONCE,
+                    "right": None,
+                    "type": DtdContentType.ELEMENT,
+                },
+                "name": None,
+                "occur": DtdContentOccur.ONCE,
+                "right": {
+                    "left": {
+                        "left": None,
+                        "name": "Body",
+                        "occur": DtdContentOccur.ONCE,
+                        "right": None,
+                        "type": DtdContentType.ELEMENT,
+                    },
+                    "name": None,
+                    "occur": DtdContentOccur.ONCE,
+                    "right": {
+                        "left": None,
+                        "name": "Tags",
+                        "occur": DtdContentOccur.ONCE,
+                        "right": None,
+                        "type": DtdContentType.ELEMENT,
+                    },
+                    "type": DtdContentType.SEQ,
+                },
+                "type": DtdContentType.SEQ,
+            },
+            "type": DtdContentType.SEQ,
         }
         self.assertEqual(expected, actual)
 

--- a/tests/fixtures/dtd/complete_example.dtd
+++ b/tests/fixtures/dtd/complete_example.dtd
@@ -1,10 +1,11 @@
 <!ELEMENT Blog (Post+)>
-<!ELEMENT Post (Title,Body,Tags)>
+<!ELEMENT Post ((Origin|Source),Title,Body,Tags)>
+<!ELEMENT Origin (#PCDATA)>
+<!ELEMENT Source (#PCDATA)>
 <!ELEMENT Title (#PCDATA)>
 <!ELEMENT Body (#PCDATA)>
 <!ELEMENT Tags (Tag*)>
 <!ELEMENT Tag (#PCDATA)>
-
 <!ATTLIST Post status (draft|published) 'draft'>
 <!ATTLIST Post author CDATA #REQUIRED>
 <!ATTLIST Post created_at CDATA #REQUIRED>

--- a/tests/fixtures/dtd/models/complete_example.py
+++ b/tests/fixtures/dtd/models/complete_example.py
@@ -50,6 +50,20 @@ class Post:
             "required": True,
         }
     )
+    origin: Optional[str] = field(
+        default=None,
+        metadata={
+            "name": "Origin",
+            "type": "Element",
+        }
+    )
+    source: Optional[str] = field(
+        default=None,
+        metadata={
+            "name": "Source",
+            "type": "Element",
+        }
+    )
     title: Optional[str] = field(
         default=None,
         metadata={

--- a/xsdata/codegen/mappers/dtd.py
+++ b/xsdata/codegen/mappers/dtd.py
@@ -1,5 +1,6 @@
 import sys
 from typing import Any
+from typing import Dict
 from typing import Iterator
 from typing import List
 from typing import Optional
@@ -115,9 +116,11 @@ class DtdMapper:
             restrictions = cls.build_restrictions(content.occur, **kwargs)
             cls.build_element(target, content.name, restrictions)
         elif content_type == DtdContentType.SEQ:
-            cls.build_content_tree(target, content)
+            cls.build_content_tree(target, content, **kwargs)
         elif content_type == DtdContentType.OR:
-            cls.build_content_tree(target, content, choice=str(id(content)))
+            params = {"min_occurs": 0, "choice": str(id(content))}
+            params.update(kwargs)
+            cls.build_content_tree(target, content, **params)
 
     @classmethod
     def build_content_tree(cls, target: Class, content: DtdContent, **kwargs: Any):
@@ -129,21 +132,26 @@ class DtdMapper:
 
     @classmethod
     def build_restrictions(cls, occur: DtdContentOccur, **kwargs: Any) -> Restrictions:
-        restrictions = Restrictions(**kwargs)
         if occur == DtdContentOccur.ONCE:
-            restrictions.min_occurs = 1
-            restrictions.max_occurs = 1
+            min_occurs = 1
+            max_occurs = 1
         elif occur == DtdContentOccur.OPT:
-            restrictions.min_occurs = 0
-            restrictions.max_occurs = 1
+            min_occurs = 0
+            max_occurs = 1
         elif occur == DtdContentOccur.MULT:
-            restrictions.min_occurs = 0
-            restrictions.max_occurs = sys.maxsize
+            min_occurs = 0
+            max_occurs = sys.maxsize
         else:  # occur == DtdContentOccur.PLUS:
-            restrictions.min_occurs = 1
-            restrictions.max_occurs = sys.maxsize
+            min_occurs = 1
+            max_occurs = sys.maxsize
 
-        return restrictions
+        params: Dict[str, Any] = {
+            "min_occurs": min_occurs,
+            "max_occurs": max_occurs,
+        }
+        params.update(kwargs)
+
+        return Restrictions(**params)
 
     @classmethod
     def build_element(cls, target: Class, name: str, restrictions: Restrictions):


### PR DESCRIPTION
## 📒 Description

The dtd mapper is not setting the min_occurs restriction correctly for choice elements.


Resolves #703 

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue


## 💬 Comments

This is still not perfect for cases like this, where elements appear in both choices, the attribute merger will set these fields as list which technically it's not really correct.

```xml
<!ELEMENT PaymentRequestDetail (
(PaymentDocumentID , PaymentSequenceNo? , PaymentDates? , 
(
    FinancialInstitutionDetail|
    (OriginatingFinancialInstitution , ReceivingFISpecificID)|
    (OriginatingFISpecificID , (ReceivingFinancialInstitution|ReceivingFISpecificID))|
    CardInfo
) 

```


## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
