### PR TITLE
Resolve circular imports error

### DIFF
--- a/tests/codegen/handlers/test_vacuum_inner_classes.py
+++ b/tests/codegen/handlers/test_vacuum_inner_classes.py
@@ -14,6 +14,26 @@ class VacuumInnerClassesTests(FactoryTestCase):
         super().setUp()
         self.processor = VacuumInnerClasses()
 
+    def test_remove_duplicate_inners(self):
+        target = ClassFactory.elements(3)
+
+        inner_1 = ClassFactory.elements(2)
+        inner_2 = inner_1.clone()
+
+        target.inner.extend([inner_1, inner_2])
+
+        target.attrs[1].types[0].qname = inner_1.qname
+        target.attrs[1].types[0].forward = True
+        target.attrs[1].types[0].reference = 4
+
+        target.attrs[2].types[0].qname = inner_2.qname
+        target.attrs[2].types[0].forward = True
+        target.attrs[2].types[0].circular = True
+        target.attrs[2].types[0].reference = 5
+
+        self.processor.process(target)
+        self.assertEqual(1, len(target.inner))
+
     def test_remove_inner(self):
         target = ClassFactory.elements(3)
 

--- a/tests/codegen/test_utils.py
+++ b/tests/codegen/test_utils.py
@@ -3,6 +3,7 @@ from typing import Generator
 from unittest import mock
 
 from xsdata.codegen.models import Restrictions
+from xsdata.codegen.models import Status
 from xsdata.codegen.utils import ClassUtils
 from xsdata.exceptions import CodeGenerationError
 from xsdata.models.enums import DataType
@@ -179,7 +180,9 @@ class ClassUtilsTests(FactoryTestCase):
 
     def test_copy_inner_class(self):
         source = ClassFactory.create()
-        inner = ClassFactory.create(qname="a", module="b", package="c")
+        inner = ClassFactory.create(
+            qname="a", module="b", package="c", status=Status.FLATTENED
+        )
         target = ClassFactory.create()
         attr = AttrFactory.create()
         attr_type = AttrTypeFactory.create(forward=True, qname=inner.qname)
@@ -192,16 +195,8 @@ class ClassUtilsTests(FactoryTestCase):
         self.assertEqual(target.package, target.inner[0].package)
         self.assertEqual(target.module, target.inner[0].module)
         self.assertEqual(inner.qname, target.inner[0].qname)
-
-    def test_copy_inner_class_skip_non_forward_reference(self):
-        source = ClassFactory.create()
-        target = ClassFactory.create()
-        attr = AttrFactory.create()
-        attr_type = AttrTypeFactory.create()
-        ClassUtils.copy_inner_class(source, target, attr, attr_type)
-
-        self.assertFalse(attr_type.circular)
-        self.assertEqual(0, len(target.inner))
+        self.assertIs(Status.RAW, target.inner[0].status)
+        self.assertIs(Status.FLATTENED, inner.status)
 
     def test_copy_inner_class_check_circular_reference(self):
         source = ClassFactory.create()

--- a/xsdata/codegen/handlers/vacuum_inner_classes.py
+++ b/xsdata/codegen/handlers/vacuum_inner_classes.py
@@ -4,6 +4,7 @@ from xsdata.codegen.mixins import HandlerInterface
 from xsdata.codegen.models import AttrType
 from xsdata.codegen.models import Class
 from xsdata.models.enums import DataType
+from xsdata.utils import collections
 from xsdata.utils.namespaces import build_qname
 
 
@@ -15,16 +16,18 @@ class VacuumInnerClasses(HandlerInterface):
     rename inner classes that have the same name as the outer/parent class.
 
     Cases:
-        1. Removing identical overriding fields can some times leave a class
+        1. Filter duplicate inner classes
+        2. Removing identical overriding fields can some times leave a class
            bare with just an extension. For inner classes we can safely
            replace the forward reference with the inner extension reference.
-        2. Empty nested complexContent with no restrictions or extensions,
+        3. Empty nested complexContent with no restrictions or extensions,
            we can replace these references with xs:anySimpleType
     """
 
     __slots__ = ()
 
     def process(self, target: Class):
+        target.inner = collections.unique_sequence(target.inner, key="qname")
         for inner in list(target.inner):
             if not inner.attrs and len(inner.extensions) < 2:
                 self.remove_inner(target, inner)

--- a/xsdata/codegen/models.py
+++ b/xsdata/codegen/models.py
@@ -462,6 +462,10 @@ class Class:
         return namespaces.local_name(self.qname)
 
     @property
+    def slug(self) -> str:
+        return text.alnum(self.name)
+
+    @property
     def ref(self) -> int:
         return id(self)
 
@@ -607,14 +611,23 @@ class Import:
     """
     Model representation of a python import statement.
 
-    :param name:
+    :param qname:
     :param source:
     :param alias:
     """
 
-    name: str
+    qname: str
     source: str
     alias: Optional[str] = field(default=None)
+
+    @property
+    def name(self) -> str:
+        """Shortcut for qname local name."""
+        return namespaces.local_name(self.qname)
+
+    @property
+    def slug(self) -> str:
+        return text.alnum(self.name)
 
 
 # Getters used all over the codegen process

--- a/xsdata/codegen/utils.py
+++ b/xsdata/codegen/utils.py
@@ -11,6 +11,7 @@ from xsdata.codegen.models import Extension
 from xsdata.codegen.models import get_qname
 from xsdata.codegen.models import get_slug
 from xsdata.codegen.models import Restrictions
+from xsdata.codegen.models import Status
 from xsdata.exceptions import CodeGenerationError
 from xsdata.models.enums import DataType
 from xsdata.utils import collections
@@ -140,15 +141,15 @@ class ClassUtils:
         if not attr_type.forward:
             return
 
-        # This will fail if no inner class is found, too strict???
         inner = ClassUtils.find_inner(source, attr_type.qname)
-
         if inner is target:
             attr_type.circular = True
         else:
+            # In extreme cases this adds duplicate inner classes
             clone = inner.clone()
             clone.package = target.package
             clone.module = target.module
+            clone.status = Status.RAW
             target.inner.append(clone)
 
     @classmethod

--- a/xsdata/utils/testing.py
+++ b/xsdata/utils/testing.py
@@ -347,12 +347,12 @@ class PackageFactory(Factory):
     @classmethod
     def create(
         cls,
-        name: str = "package",
-        source: str = "target",
+        qname: str = "{xsdata}Root",
+        source: str = "generated.models",
         alias: Optional[str] = None,
         **kwargs: Any,
     ) -> Import:
-        return Import(name=name, source=source, alias=alias)
+        return Import(qname=qname, source=source, alias=alias)
 
 
 class XmlVarFactory(Factory):


### PR DESCRIPTION
## 📒 Description

The crossref suite and especially the MathML one are very interested and revealed an issue during flattening that results in circular imports error.

Resolves #694

## 🔗 What I've Done

- During copy of inner classes, reset the status flag so the whole process can finish succesfully when dealing with circular dependencies.
- Vaccum duplicate inner classes
- Resolve naming conflict with imports


## 💬 Comments

This issue took a lot out of me to troubleshoot it, the crossref suite is going in the samples repo

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
