### PR TITLE
Sort sources before processing

### DIFF
--- a/xsdata/cli.py
+++ b/xsdata/cli.py
@@ -129,7 +129,8 @@ def generate(**kwargs: Any):
     config.output.update(**params)
 
     transformer = SchemaTransformer(config=config, print=stdout)
-    transformer.process(list(resolve_source(source, recursive=recursive)))
+    uris = sorted(resolve_source(source, recursive=recursive))
+    transformer.process(uris)
 
     handler.emit_warnings()
 


### PR DESCRIPTION
## 📒 Description

Path.glob relies on the os for ordering, this is causing inconsistent builds between operating systems

Resolves #xxxx

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue


## 💬 Comments

> A place to write any comments to the reviewer.
>

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
