### PR TITLE
feat: Add option to ignore xml pattern restrictions

### DIFF
--- a/tests/codegen/handlers/test_process_attributes_types.py
+++ b/tests/codegen/handlers/test_process_attributes_types.py
@@ -54,6 +54,15 @@ class ProcessAttributeTypesTests(FactoryTestCase):
 
         self.assertEqual(types[:-1], attr.types)
 
+    def test_process_types_with_ignore_patterns(self):
+        target = ClassFactory.create()
+        attr = AttrFactory.native(DataType.DECIMAL)
+        attr.restrictions.pattern = r"\d{2}.\d{2}"
+
+        self.processor.container.config.output.ignore_patterns = True
+        self.processor.process_types(target, attr)
+        self.assertEqual(DataType.DECIMAL, attr.types[0].datatype)
+
     def test_cascade_properties(self):
         target = ClassFactory.create(default="2", fixed=True, nillable=True)
         attr = AttrFactory.native(DataType.STRING, tag=Tag.EXTENSION)

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -38,6 +38,7 @@ class GeneratorConfigTests(TestCase):
             '    <CompoundFields defaultName="choice" forceDefaultName="false">false</CompoundFields>\n'
             "    <PostponedAnnotations>false</PostponedAnnotations>\n"
             "    <UnnestClasses>false</UnnestClasses>\n"
+            "    <IgnorePatterns>false</IgnorePatterns>\n"
             "  </Output>\n"
             "  <Conventions>\n"
             '    <ClassName case="pascalCase" safePrefix="type"/>\n'
@@ -97,6 +98,7 @@ class GeneratorConfigTests(TestCase):
             '    <CompoundFields defaultName="choice" forceDefaultName="false">false</CompoundFields>\n'
             "    <PostponedAnnotations>false</PostponedAnnotations>\n"
             "    <UnnestClasses>false</UnnestClasses>\n"
+            "    <IgnorePatterns>false</IgnorePatterns>\n"
             "  </Output>\n"
             "  <Conventions>\n"
             '    <ClassName case="pascalCase" safePrefix="type"/>\n'

--- a/xsdata/codegen/handlers/process_attributes_types.py
+++ b/xsdata/codegen/handlers/process_attributes_types.py
@@ -34,6 +34,9 @@ class ProcessAttributeTypes(RelativeHandlerInterface):
 
     def process_types(self, target: Class, attr: Attr):
         """Process every attr type and filter out duplicates."""
+        if self.container.config.output.ignore_patterns:
+            attr.restrictions.pattern = None
+
         for attr_type in list(attr.types):
             self.process_type(target, attr, attr_type)
 

--- a/xsdata/models/config.py
+++ b/xsdata/models/config.py
@@ -245,6 +245,7 @@ class GeneratorOutput:
     :param postponed_annotations: Enable postponed evaluation of annotations,
         default: false, python>=3.7 Only
     :param unnest_classes: Move inner classes to upper level, default: false
+    :param ignore_patterns: Ignore pattern restrictions, default: false
     """
 
     package: str = element(default="generated")
@@ -261,6 +262,7 @@ class GeneratorOutput:
     max_line_length: int = attribute(default=79)
     postponed_annotations: bool = element(default=False)
     unnest_classes: bool = element(default=False)
+    ignore_patterns: bool = element(default=False)
 
     def update(self, **kwargs: Any):
         objects.update(self, **kwargs)


### PR DESCRIPTION
## 📒 Description

xsdata is generating xsd pattern restrictions, but the binding module still can't handle them, they are there just for reference.

The generator also will reset the datatype to simple string, in order to avoid parsing/converting certain values like decimals incorrectly eg `\d{2}.\d{1}`.


Resolves #720

## 🔗 What I've Done

This pr adds an option to ignore-patterns.
They won't be generated and the processor won't try to reset the attr type.

## 💬 Comments

> A place to write any comments to the reviewer.
>

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
