### PR TITLE
chore: Pin docformatter version 1.5.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ console_scripts =
 cli =
     click>=5.0
     click-default-group>=1.2
-    docformatter
+    docformatter==1.5.0
     jinja2>=2.10
     toposort>=1.5
 docs =


### PR DESCRIPTION
## 📒 Description

Version 1.5.1 removed the simple entry point to format docstings programmatically, till I figure this one let's pin the dep to previous version. The new one doesn't add anything to xsdata anyway.




Resolves #728 

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue


## 💬 Comments

> A place to write any comments to the reviewer.
>

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
