### PR TITLE
catch JSONDecodeError as raise IOError(URI)

### DIFF
--- a/xsdata/codegen/transformer.py
+++ b/xsdata/codegen/transformer.py
@@ -173,16 +173,20 @@ class SchemaTransformer:
         name = self.config.output.package.split(".")[-1]
         dirname = os.path.dirname(uris[0]) if uris else ""
 
-        for uri in uris:
-            input_stream = self.load_resource(uri)
-            if input_stream:
-                data = json.load(io.BytesIO(input_stream))
-                logger.info("Parsing document %s", uri)
-                if isinstance(data, dict):
-                    data = [data]
+        try:
+            for uri in uris:
+                input_stream = self.load_resource(uri)
+                if input_stream:
+                    data = json.load(io.BytesIO(input_stream))
+                    logger.info("Parsing document %s", uri)
+                    if isinstance(data, dict):
+                        data = [data]
 
-                for obj in data:
-                    classes.extend(DictMapper.map(obj, name, dirname))
+                    for obj in data:
+                        classes.extend(DictMapper.map(obj, name, dirname))
+        except json.decoder.JSONDecodeError as err:
+            raise IOError(f"JSON load failure: {uri}") from err
+
 
         self.classes.extend(ClassUtils.reduce_classes(classes))
 


### PR DESCRIPTION
## 📒 Description

> Write a brief description of your PR.
wrap the call to json.load in codegen.transform.process_json_documents in a try/catch

## 💬 Comments

I was calling xsdata generate recursively on a directory of json documents,
one of which was malformed.
This gives an immediate feedback of the problem file, 
instead of "failed on line X column Y" with no indication of the file.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
