### PR TITLE
use docformatter>=1.5.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ console_scripts =
 cli =
     click>=5.0
     click-default-group>=1.2
-    docformatter==1.5.0
+    docformatter>=1.5.1
     jinja2>=2.10
     toposort>=1.5
 docs =

--- a/xsdata/formats/dataclass/filters.py
+++ b/xsdata/formats/dataclass/filters.py
@@ -11,7 +11,8 @@ from typing import Optional
 from typing import Tuple
 from typing import Type
 
-from docformatter import configuration, format
+from docformatter import configuration
+from docformatter import format
 from jinja2 import Environment
 
 from xsdata.codegen.models import Attr
@@ -504,11 +505,15 @@ class Filters:
         content += ' """' if content.endswith('"') else '"""'
 
         max_length = self.max_line_length - level * 4
-        configurator = configuration.Configurater([
-            "--wrap-summaries", str(max_length),
-            "--wrap-descriptions", str(max_length - 7),
-            "--make-summary-multi-line",
-        ])
+        configurator = configuration.Configurater(
+            [
+                "--wrap-summaries",
+                str(max_length),
+                "--wrap-descriptions",
+                str(max_length - 7),
+                "--make-summary-multi-line",
+            ]
+        )
         configurator.do_parse_arguments()
         formatter = format.Formatter(
             configurator.args,

--- a/xsdata/formats/dataclass/filters.py
+++ b/xsdata/formats/dataclass/filters.py
@@ -1,4 +1,5 @@
 import re
+import sys
 import textwrap
 from collections import defaultdict
 from typing import Any
@@ -10,7 +11,7 @@ from typing import Optional
 from typing import Tuple
 from typing import Type
 
-from docformatter import format_code
+from docformatter import configuration, format
 from jinja2 import Environment
 
 from xsdata.codegen.models import Attr
@@ -503,12 +504,19 @@ class Filters:
         content += ' """' if content.endswith('"') else '"""'
 
         max_length = self.max_line_length - level * 4
-        content = format_code(
-            content,
-            summary_wrap_length=max_length,
-            description_wrap_length=max_length - 7,
-            make_summary_multi_line=True,
+        configurator = configuration.Configurater([
+            "--wrap-summaries", str(max_length),
+            "--wrap-descriptions", str(max_length - 7),
+            "--make-summary-multi-line",
+        ])
+        configurator.do_parse_arguments()
+        formatter = format.Formatter(
+            configurator.args,
+            sys.stderr,
+            sys.stdin,
+            sys.stdout,
         )
+        content = formatter._do_format_code(content)
 
         if params:
             # Remove trailing triple quotes


### PR DESCRIPTION
## 📒 Description

Make xsdata compatible with docformatter 1.5.1.

## 🔗 What I've Done

Copy what docformatter's `__main__.py` does.

## 💬 Comments

Since docformatter has no official API there's no guarantee this will continue to work. Maybe it would make sense to ask them to provide one.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
