### PR TITLE
feat: Allow config substitutions to specify re replace strings

### DIFF
--- a/tests/formats/dataclass/test_filters.py
+++ b/tests/formats/dataclass/test_filters.py
@@ -111,6 +111,12 @@ class FiltersTests(FactoryTestCase):
         attr = AttrFactory.create(types=[AttrTypeFactory.create(alias="alias")])
         self.assertEqual("Alias", self.filters.constant_value(attr))
 
+    def test_apply_substitutions_with_regexes(self):
+        self.filters.substitutions[ObjectType.CLASS]["(.*)Class"] = "\\1Type"
+
+        actual = self.filters.apply_substitutions("FooClass", ObjectType.CLASS)
+        self.assertEqual("FooType", actual)
+
     @mock.patch.object(Filters, "field_default_value")
     def test_field_definition(self, mock_field_default_value):
         mock_field_default_value.side_effect = [1, False]

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -58,7 +58,7 @@ class GeneratorConfigTests(TestCase):
             '    <Substitution type="package" search="http://schemas.xmlsoap.org/wsdl/soap/" replace="soap"/>\n'
             '    <Substitution type="package" search="http://schemas.xmlsoap.org/wsdl/soap12/" replace="soap12"/>\n'
             '    <Substitution type="package" search="http://schemas.xmlsoap.org/soap/envelope/" replace="soapenv"/>\n'
-            '    <Substitution type="class" search="Class" replace="Type"/>\n'
+            '    <Substitution type="class" search="(.*)Class$" replace="\\1Type"/>\n'
             "  </Substitutions>\n"
             "</Config>\n"
         )

--- a/xsdata/formats/dataclass/filters.py
+++ b/xsdata/formats/dataclass/filters.py
@@ -147,7 +147,7 @@ class Filters:
 
     def apply_substitutions(self, name: str, obj_type: ObjectType) -> str:
         for search, replace in self.substitutions[obj_type].items():
-            name = re.sub(search, replace, name)
+            name = re.sub(rf"{search}", rf"{replace}", name)
 
         return name
 

--- a/xsdata/models/config.py
+++ b/xsdata/models/config.py
@@ -443,7 +443,9 @@ class GeneratorConfig:
             )
 
         obj.substitutions.substitution.append(
-            GeneratorSubstitution(type=ObjectType.CLASS, search="Class", replace="Type")
+            GeneratorSubstitution(
+                type=ObjectType.CLASS, search="(.*)Class$", replace="\\1Type"
+            )
         )
 
         return obj


### PR DESCRIPTION
## 📒 Description

The default search/replace example for class names doesn't demonstrate that this feature is using `re.sub`

Update the apply method to allow replacement string to specify match group numbers `\1 \2 \3`


Resolves #742

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue


## 💬 Comments

> A place to write any comments to the reviewer.
>

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
