### PR TITLE
Calculate required restriction from xml/json documents

### DIFF
--- a/tests/codegen/mappers/test_dict.py
+++ b/tests/codegen/mappers/test_dict.py
@@ -71,7 +71,7 @@ class DictMapperTests(FactoryTestCase):
                 AttrTypeFactory.native(DataType.FLOAT, tag=Tag.ELEMENT),
             ],
         )
-        restrictions = Restrictions(min_occurs=0, max_occurs=sys.maxsize)
+        restrictions = Restrictions(min_occurs=1, max_occurs=sys.maxsize)
         self.assertEqual(expected, target.attrs[0])
         self.assertEqual(restrictions, target.attrs[0].restrictions)
 
@@ -88,7 +88,7 @@ class DictMapperTests(FactoryTestCase):
                 AttrTypeFactory.native(DataType.ANY_SIMPLE_TYPE, tag=Tag.ELEMENT),
             ],
         )
-        restrictions = Restrictions(min_occurs=0, max_occurs=sys.maxsize)
+        restrictions = Restrictions(min_occurs=1, max_occurs=sys.maxsize)
         self.assertEqual(expected, target.attrs[0])
         self.assertEqual(restrictions, target.attrs[0].restrictions)
 

--- a/tests/codegen/mappers/test_element.py
+++ b/tests/codegen/mappers/test_element.py
@@ -72,6 +72,9 @@ class ElementMapperTests(FactoryTestCase):
             ],
         )
         self.assertEqual(expected, actual)
+        for attr in actual.attrs:
+            self.assertEqual(1, attr.restrictions.min_occurs)
+            self.assertEqual(1, attr.restrictions.max_occurs)
 
     def test_build_class_complex_type(self):
         element = AnyElement(

--- a/tests/codegen/test_utils.py
+++ b/tests/codegen/test_utils.py
@@ -277,23 +277,23 @@ class ClassUtilsTests(FactoryTestCase):
         self.assertEqual(["attr_E", "attr_F"], [x.name for x in result[1].attrs])
 
     def test_reduce_attributes(self):
-        attrs = AttrFactory.list(5, prefix="")
+        restrictions = Restrictions(min_occurs=1, max_occurs=1)
+        attr_a = AttrFactory.create(name="a", restrictions=restrictions.clone())
+        attr_b = AttrFactory.create(name="b", restrictions=restrictions.clone())
+        attr_c = AttrFactory.create(name="c", restrictions=restrictions.clone())
+        attr_d = AttrFactory.create(name="d", restrictions=restrictions.clone())
 
-        class_a = ClassFactory.create()
-        class_a.attrs = [x.clone() for x in attrs[:2]]
+        first = ClassFactory.create(qname="alphabet", attrs=[attr_b, attr_c, attr_d])
+        second = ClassFactory.create(qname="alphabet", attrs=[attr_a, attr_b])
 
-        class_b = ClassFactory.create()
-        class_b.attrs = [x.clone() for x in attrs[2:4]]
+        result = ClassUtils.reduce_attributes([first, second])
+        expected_names = ["a", "b", "c", "d"]
+        self.assertEqual(expected_names, [x.name for x in result])
 
-        class_c = ClassFactory.create()
-        class_c.attrs = [x.clone() for x in attrs[3:]]
-
-        class_d = ClassFactory.create()
-        class_d.attrs.append(attrs[0].clone())
-        class_d.attrs.append(attrs[4].clone())
-
-        result = ClassUtils.reduce_attributes([class_a, class_b, class_c, class_d])
-        self.assertEqual(["B", "C", "D", "E", "F"], [x.name for x in result])
+        self.assertEqual(0, result[0].restrictions.min_occurs)
+        self.assertEqual(1, result[1].restrictions.min_occurs)
+        self.assertEqual(0, result[2].restrictions.min_occurs)
+        self.assertEqual(0, result[3].restrictions.min_occurs)
 
     def test_merge_attributes(self):
         a = AttrFactory.native(DataType.INT, name="a")

--- a/tests/fixtures/artists/metadata.py
+++ b/tests/fixtures/artists/metadata.py
@@ -22,6 +22,7 @@ class Alias:
         metadata={
             "name": "sort-name",
             "type": "Attribute",
+            "required": True,
         }
     )
     type: Optional[str] = field(
@@ -44,7 +45,10 @@ class Alias:
         }
     )
     value: str = field(
-        default=""
+        default="",
+        metadata={
+            "required": True,
+        }
     )
 
 
@@ -58,12 +62,14 @@ class BeginArea:
         default=None,
         metadata={
             "type": "Attribute",
+            "required": True,
         }
     )
     name: Optional[str] = field(
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     sort_name: Optional[str] = field(
@@ -71,6 +77,7 @@ class BeginArea:
         metadata={
             "name": "sort-name",
             "type": "Element",
+            "required": True,
         }
     )
 
@@ -85,10 +92,14 @@ class Gender:
         default=None,
         metadata={
             "type": "Attribute",
+            "required": True,
         }
     )
     value: str = field(
-        default=""
+        default="",
+        metadata={
+            "required": True,
+        }
     )
 
 
@@ -102,6 +113,7 @@ class IpiList:
         default_factory=list,
         metadata={
             "type": "Element",
+            "min_occurs": 1,
         }
     )
 
@@ -116,6 +128,7 @@ class IsniList:
         default_factory=list,
         metadata={
             "type": "Element",
+            "min_occurs": 1,
         }
     )
 
@@ -131,6 +144,7 @@ class Iso31661CodeList:
         metadata={
             "name": "iso-3166-1-code",
             "type": "Element",
+            "required": True,
         }
     )
 
@@ -146,6 +160,7 @@ class Iso31662CodeList:
         metadata={
             "name": "iso-3166-2-code",
             "type": "Element",
+            "required": True,
         }
     )
 
@@ -160,6 +175,7 @@ class LifeSpan:
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     end: Optional[XmlDate] = field(
@@ -186,12 +202,14 @@ class AliasList:
         default=None,
         metadata={
             "type": "Attribute",
+            "required": True,
         }
     )
     alias: List[Alias] = field(
         default_factory=list,
         metadata={
             "type": "Element",
+            "min_occurs": 1,
         }
     )
 
@@ -206,12 +224,14 @@ class Area:
         default=None,
         metadata={
             "type": "Attribute",
+            "required": True,
         }
     )
     name: Optional[str] = field(
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     sort_name: Optional[str] = field(
@@ -219,6 +239,7 @@ class Area:
         metadata={
             "name": "sort-name",
             "type": "Element",
+            "required": True,
         }
     )
     iso_3166_1_code_list: Optional[Iso31661CodeList] = field(
@@ -226,6 +247,7 @@ class Area:
         metadata={
             "name": "iso-3166-1-code-list",
             "type": "Element",
+            "required": True,
         }
     )
 
@@ -240,12 +262,14 @@ class EndArea:
         default=None,
         metadata={
             "type": "Attribute",
+            "required": True,
         }
     )
     name: Optional[str] = field(
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     sort_name: Optional[str] = field(
@@ -253,6 +277,7 @@ class EndArea:
         metadata={
             "name": "sort-name",
             "type": "Element",
+            "required": True,
         }
     )
     iso_3166_2_code_list: Optional[Iso31662CodeList] = field(
@@ -260,6 +285,7 @@ class EndArea:
         metadata={
             "name": "iso-3166-2-code-list",
             "type": "Element",
+            "required": True,
         }
     )
 
@@ -274,12 +300,14 @@ class Artist:
         default=None,
         metadata={
             "type": "Attribute",
+            "required": True,
         }
     )
     type: Optional[str] = field(
         default=None,
         metadata={
             "type": "Attribute",
+            "required": True,
         }
     )
     type_id: Optional[str] = field(
@@ -287,12 +315,14 @@ class Artist:
         metadata={
             "name": "type-id",
             "type": "Attribute",
+            "required": True,
         }
     )
     name: Optional[str] = field(
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     sort_name: Optional[str] = field(
@@ -300,6 +330,7 @@ class Artist:
         metadata={
             "name": "sort-name",
             "type": "Element",
+            "required": True,
         }
     )
     disambiguation: Optional[str] = field(
@@ -326,6 +357,7 @@ class Artist:
         metadata={
             "name": "isni-list",
             "type": "Element",
+            "required": True,
         }
     )
     gender: Optional[Gender] = field(
@@ -338,12 +370,14 @@ class Artist:
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     area: Optional[Area] = field(
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     begin_area: Optional[BeginArea] = field(
@@ -351,6 +385,7 @@ class Artist:
         metadata={
             "name": "begin-area",
             "type": "Element",
+            "required": True,
         }
     )
     end_area: Optional[EndArea] = field(
@@ -365,6 +400,7 @@ class Artist:
         metadata={
             "name": "life-span",
             "type": "Element",
+            "required": True,
         }
     )
     alias_list: Optional[AliasList] = field(
@@ -372,6 +408,7 @@ class Artist:
         metadata={
             "name": "alias-list",
             "type": "Element",
+            "required": True,
         }
     )
 
@@ -386,5 +423,6 @@ class Metadata:
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )

--- a/tests/fixtures/series/series.py
+++ b/tests/fixtures/series/series.py
@@ -12,12 +12,14 @@ class Country:
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     code: Optional[str] = field(
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     timezone: Optional[str] = field(
@@ -37,6 +39,7 @@ class Externals:
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     thetvdb: Optional[int] = field(
@@ -49,6 +52,7 @@ class Externals:
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
 
@@ -62,12 +66,14 @@ class Image:
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     original: Optional[str] = field(
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
 
@@ -81,6 +87,7 @@ class Previousepisode:
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
 
@@ -94,6 +101,7 @@ class Rating:
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
 
@@ -107,12 +115,14 @@ class Schedule:
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     days: List[str] = field(
         default_factory=list,
         metadata={
             "type": "Element",
+            "min_occurs": 1,
         }
     )
 
@@ -126,6 +136,7 @@ class Self:
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
 
@@ -140,12 +151,14 @@ class Links:
         metadata={
             "name": "self",
             "type": "Element",
+            "required": True,
         }
     )
     previousepisode: Optional[Previousepisode] = field(
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
 
@@ -165,12 +178,14 @@ class Network:
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     country: Optional[Country] = field(
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
 
@@ -184,6 +199,7 @@ class Series:
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     url: Optional[str] = field(
@@ -196,42 +212,49 @@ class Series:
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     type: Optional[str] = field(
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     language: Optional[str] = field(
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     genres: List[str] = field(
         default_factory=list,
         metadata={
             "type": "Element",
+            "min_occurs": 1,
         }
     )
     status: Optional[str] = field(
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     runtime: Optional[int] = field(
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     premiered: Optional[XmlDate] = field(
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     official_site: Optional[str] = field(
@@ -239,18 +262,21 @@ class Series:
         metadata={
             "name": "officialSite",
             "type": "Element",
+            "required": True,
         }
     )
     schedule: Optional[Schedule] = field(
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     rating: Optional[Rating] = field(
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     weight: Optional[int] = field(
@@ -263,6 +289,7 @@ class Series:
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     web_channel: Optional[object] = field(
@@ -276,6 +303,7 @@ class Series:
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     image: Optional[Image] = field(
@@ -288,12 +316,14 @@ class Series:
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     updated: Optional[int] = field(
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     links: Optional[Links] = field(

--- a/tests/fixtures/stripe/models/balance.py
+++ b/tests/fixtures/stripe/models/balance.py
@@ -11,12 +11,14 @@ class ConnectReserved:
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     currency: Optional[str] = field(
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
 
@@ -30,12 +32,14 @@ class SourceTypes:
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     card: Optional[int] = field(
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
 
@@ -49,18 +53,21 @@ class Available:
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     currency: Optional[str] = field(
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     source_types: Optional[SourceTypes] = field(
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
 
@@ -74,18 +81,21 @@ class Pending:
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     currency: Optional[str] = field(
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     source_types: Optional[SourceTypes] = field(
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
 
@@ -100,29 +110,34 @@ class Balance:
         metadata={
             "name": "object",
             "type": "Element",
+            "required": True,
         }
     )
     available: Tuple[Available, ...] = field(
         default_factory=tuple,
         metadata={
             "type": "Element",
+            "min_occurs": 1,
         }
     )
     connect_reserved: Tuple[ConnectReserved, ...] = field(
         default_factory=tuple,
         metadata={
             "type": "Element",
+            "min_occurs": 1,
         }
     )
     livemode: Optional[bool] = field(
         default=None,
         metadata={
             "type": "Element",
+            "required": True,
         }
     )
     pending: Tuple[Pending, ...] = field(
         default_factory=tuple,
         metadata={
             "type": "Element",
+            "min_occurs": 1,
         }
     )

--- a/xsdata/codegen/mappers/element.py
+++ b/xsdata/codegen/mappers/element.py
@@ -137,7 +137,7 @@ class ElementMapper:
         attr = Attr(index=index, name=name, tag=tag, namespace=namespace)
         attr.types.append(attr_type)
         attr.restrictions.sequence = sequence
-        attr.restrictions.min_occurs = 0
+        attr.restrictions.min_occurs = 1
         attr.restrictions.max_occurs = 1
         cls.add_attribute(target, attr)
 


### PR DESCRIPTION
## 📒 Description

The xml/json document generator assumes all fields have `min_occurs==0` we need to actually calculate it, through training from the samples.

Resolves #740

## 🔗 What I've Done

Assume all fields have `min_occurs==1` until we find a sample which doesn't include that field.


## 💬 Comments

The performance is very poor because we need to load all the data in memory and turn them into classes/fields that we later reduce, but this is the only way to produce accurate results

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
