### PR TITLE
Make pretty print indentation configurable

### DIFF
--- a/tests/formats/dataclass/serializers/test_json.py
+++ b/tests/formats/dataclass/serializers/test_json.py
@@ -138,3 +138,36 @@ class JsonSerializerTests(TestCase):
         expected = expected[:-1]
         actual = [name for name, value in serializer.next_value(book)]
         self.assertEqual(expected, actual)
+
+    def test_pretty_print_indent(self):
+        serializer = JsonSerializer()
+        serializer.config.pretty_print = True
+        serializer.config.pretty_print_indent = "    "
+
+        actual = serializer.render(self.books)
+        expected = f"""{{
+    "book": [
+        {{
+            "author": "{self.expected["book"][0]["author"]}",
+            "title": "{self.expected["book"][0]["title"]}",
+            "genre": "{self.expected["book"][0]["genre"]}",
+            "price": {self.expected["book"][0]["price"]},
+            "pub_date": "{self.expected["book"][0]["pub_date"]}",
+            "review": "{self.expected["book"][0]["review"]}",
+            "id": "{self.expected["book"][0]["id"]}",
+            "lang": "en"
+        }},
+        {{
+            "author": "{self.expected["book"][1]["author"]}",
+            "title": "{self.expected["book"][1]["title"]}",
+            "genre": "{self.expected["book"][1]["genre"]}",
+            "price": null,
+            "pub_date": null,
+            "review": "{self.expected["book"][1]["review"]}",
+            "id": "{self.expected["book"][1]["id"]}",
+            "lang": "en"
+        }}
+    ]
+}}"""
+
+        self.assertEqual(expected, actual)

--- a/tests/formats/dataclass/serializers/writers/test_lxml.py
+++ b/tests/formats/dataclass/serializers/writers/test_lxml.py
@@ -57,3 +57,12 @@ class LxmlEventWriterTests(TestCase):
         _, actual = actual.split("\n", 1)
         _, expected = expected.split("\n", 1)
         self.assertEqual(expected.replace("  ", "").replace("\n", ""), actual)
+
+    def test_pretty_print_indent(self):
+        self.serializer.config.pretty_print_indent = "    "
+        actual = self.serializer.render(books)
+        expected = fixtures_dir.joinpath("books/books_auto_ns.xml").read_text()
+
+        _, actual = actual.split("\n", 1)
+        _, expected = expected.split("\n", 1)
+        self.assertEqual(expected.replace("  ", "    "), actual)

--- a/tests/formats/dataclass/serializers/writers/test_native.py
+++ b/tests/formats/dataclass/serializers/writers/test_native.py
@@ -51,3 +51,12 @@ class XmlEventWriterTests(TestCase):
         _, actual = actual.split("\n", 1)
         _, expected = expected.split("\n", 1)
         self.assertEqual(expected.replace("  ", "").replace("\n", ""), actual)
+
+    def test_pretty_print_indent(self):
+        self.serializer.config.pretty_print_indent = "    "
+        actual = self.serializer.render(books)
+        expected = fixtures_dir.joinpath("books/books_auto_ns.xml").read_text()
+
+        _, actual = actual.split("\n", 1)
+        _, expected = expected.split("\n", 1)
+        self.assertEqual(expected.replace("  ", "    "), actual)

--- a/xsdata/formats/dataclass/serializers/config.py
+++ b/xsdata/formats/dataclass/serializers/config.py
@@ -13,6 +13,7 @@ class SerializerConfig:
     :param xml_version: XML Version number (1.0|1.1)
     :param xml_declaration: Generate XML declaration
     :param pretty_print: Enable pretty output
+    :param pretty_print_indent: Indentation string for each indent level
     :param ignore_default_attributes: Ignore optional attributes with
         default values
     :param schema_location: xsi:schemaLocation attribute value
@@ -27,6 +28,7 @@ class SerializerConfig:
         "xml_version",
         "xml_declaration",
         "pretty_print",
+        "pretty_print_indent",
         "ignore_default_attributes",
         "schema_location",
         "no_namespace_schema_location",
@@ -39,6 +41,7 @@ class SerializerConfig:
         xml_version: str = "1.0",
         xml_declaration: bool = True,
         pretty_print: bool = False,
+        pretty_print_indent: Optional[str] = None,
         ignore_default_attributes: bool = False,
         schema_location: Optional[str] = None,
         no_namespace_schema_location: Optional[str] = None,
@@ -48,6 +51,7 @@ class SerializerConfig:
         self.xml_version = xml_version
         self.xml_declaration = xml_declaration
         self.pretty_print = pretty_print
+        self.pretty_print_indent = pretty_print_indent
         self.ignore_default_attributes = ignore_default_attributes
         self.schema_location = schema_location
         self.no_namespace_schema_location = no_namespace_schema_location

--- a/xsdata/formats/dataclass/serializers/json.py
+++ b/xsdata/formats/dataclass/serializers/json.py
@@ -11,6 +11,7 @@ from typing import Iterator
 from typing import Optional
 from typing import TextIO
 from typing import Tuple
+from typing import Union
 
 from xsdata.formats.bindings import AbstractSerializer
 from xsdata.formats.converter import converter
@@ -61,7 +62,7 @@ class JsonSerializer(AbstractSerializer):
         :param out: The output stream
         :param obj: The input dataclass instance
         """
-        indent: Optional[int] = None
+        indent: Optional[Union[int, str]] = None
         if self.indent:
             warnings.warn(
                 "JsonSerializer indent property is deprecated, use SerializerConfig",
@@ -69,7 +70,7 @@ class JsonSerializer(AbstractSerializer):
             )
             indent = self.indent
         elif self.config.pretty_print:
-            indent = 2
+            indent = self.config.pretty_print_indent or 2
 
         self.dump_factory(self.convert(obj), out, indent=indent)
 

--- a/xsdata/formats/dataclass/serializers/writers/lxml.py
+++ b/xsdata/formats/dataclass/serializers/writers/lxml.py
@@ -2,6 +2,7 @@ from typing import Dict
 from typing import Generator
 from typing import TextIO
 
+from lxml.etree import indent
 from lxml.etree import tostring
 from lxml.sax import ElementTreeContentHandler
 
@@ -36,6 +37,9 @@ class LxmlEventWriter(XmlWriter):
         super().write(events)
 
         assert isinstance(self.handler, ElementTreeContentHandler)
+
+        if self.config.pretty_print and self.config.pretty_print_indent is not None:
+            indent(self.handler.etree, self.config.pretty_print_indent)
 
         xml = tostring(
             self.handler.etree,

--- a/xsdata/formats/dataclass/serializers/writers/native.py
+++ b/xsdata/formats/dataclass/serializers/writers/native.py
@@ -42,7 +42,9 @@ class XmlEventWriter(XmlWriter):
         if self.config.pretty_print:
             if self.current_level:
                 self.handler.ignorableWhitespace("\n")
-                self.handler.ignorableWhitespace("  " * self.current_level)
+                self.handler.ignorableWhitespace(
+                    (self.config.pretty_print_indent or "  ") * self.current_level
+                )
 
             self.current_level += 1
             self.pending_end_element = False
@@ -55,7 +57,9 @@ class XmlEventWriter(XmlWriter):
         self.current_level -= 1
         if self.pending_end_element:
             self.handler.ignorableWhitespace("\n")
-            self.handler.ignorableWhitespace("  " * self.current_level)
+            self.handler.ignorableWhitespace(
+                (self.config.pretty_print_indent or "  ") * self.current_level
+            )
 
         super().end_tag(qname)
 


### PR DESCRIPTION
## 📒 Description

Hello, I'd like to be able to customize the indentation when pretty print is enabled. So this patch is adding a setting `SerializerConfig.pretty_print_indent`, allowing to set indentation string per level when `pretty_print` is `True`.

Simple example:
```
from xsdata.formats.dataclass.serializers.config import SerializerConfig
from xsdata.formats.dataclass.serializers import XmlSerializer
from xsdata.formats.dataclass.serializers.writers.lxml import LxmlEventWriter
from xsdata.formats.dataclass.serializers.writers.native import XmlEventWriter
import dataclasses

@dataclasses.dataclass
class Bar:
    nested_a: int
    nested_b: int

@dataclasses.dataclass
class Foo:
    foo: int
    bar: Bar

f = Foo(1, Bar(2, 3))

print(XmlSerializer(
    config=SerializerConfig(pretty_print=True, pretty_print_indent="            "),
    writer=LxmlEventWriter
).render(f))

print(XmlSerializer(
    config=SerializerConfig(pretty_print=True, pretty_print_indent=" "),
    writer=XmlEventWriter
).render(f))
```

Which results in:
```
<?xml version="1.0" encoding="UTF-8"?>
<Foo>
            <foo>1</foo>
            <bar>
                        <nested_a>2</nested_a>
                        <nested_b>3</nested_b>
            </bar>
</Foo>

<?xml version="1.0" encoding="UTF-8"?>
<Foo>
 <foo>1</foo>
 <bar>
  <nested_a>2</nested_a>
  <nested_b>3</nested_b>
 </bar>
</Foo>
```
## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
