### PR TITLE
Pycodeserializer should skip default field values

### DIFF
--- a/tests/formats/dataclass/serializers/test_code.py
+++ b/tests/formats/dataclass/serializers/test_code.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
 
+from tests.fixtures.books import BookForm
+from tests.fixtures.books import Books
 from tests.fixtures.books.fixtures import books
 from xsdata.formats.dataclass.serializers import PycodeSerializer
 from xsdata.models.enums import Namespace
@@ -42,6 +44,24 @@ class PycodeSerializerTests(TestCase):
             ")\n"
         )
 
+        self.assertEqual(expected, result)
+
+    def test_write_class_with_default_values(self):
+        books = Books(book=[BookForm(author="me")])
+        result = self.serializer.render(books, var_name="books")
+        expected = (
+            "from tests.fixtures.books.books import BookForm\n"
+            "from tests.fixtures.books.books import Books\n"
+            "\n"
+            "\n"
+            "books = Books(\n"
+            "    book=[\n"
+            "        BookForm(\n"
+            '            author="me"\n'
+            "        ),\n"
+            "    ]\n"
+            ")\n"
+        )
         self.assertEqual(expected, result)
 
     def test_write_object_with_empty_array(self):

--- a/xsdata/formats/dataclass/compat.py
+++ b/xsdata/formats/dataclass/compat.py
@@ -5,6 +5,7 @@ from dataclasses import is_dataclass
 from dataclasses import MISSING
 from typing import Any
 from typing import Dict
+from typing import Optional
 from typing import Set
 from typing import Tuple
 from typing import Type
@@ -55,7 +56,7 @@ class ClassType(abc.ABC):
         """Return the models fields in the correct mro ordering."""
 
     @abc.abstractmethod
-    def default_value(self, field: Any) -> Any:
+    def default_value(self, field: Any, default: Optional[Any] = None) -> Any:
         """Return the default value or factory of the given model field."""
 
     @abc.abstractmethod
@@ -124,15 +125,14 @@ class Dataclasses(ClassType):
     def get_fields(self, obj: Any) -> Tuple[Any, ...]:
         return fields(obj)
 
-    def default_value(self, field: Field) -> Any:
-        # Ignore type because of https://github.com/python/mypy/issues/6910
-        if field.default_factory is not MISSING:  # type: ignore
-            return field.default_factory  # type: ignore
+    def default_value(self, field: Field, default: Optional[Any] = None) -> Any:
+        if field.default_factory is not MISSING:
+            return field.default_factory
 
         if field.default is not MISSING:
             return field.default
 
-        return None
+        return default
 
     def default_choice_value(self, choice: Dict) -> Any:
         factory = choice.get("default_factory")


### PR DESCRIPTION
## 📒 Description

The pycode serializer should skip default values from the final output


Resolves #xxxx

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue


## 💬 Comments

> A place to write any comments to the reviewer.
>

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
