### PR TITLE
Generate override prohibited properties

### DIFF
--- a/tests/codegen/handlers/test_validate_attributes_overrides.py
+++ b/tests/codegen/handlers/test_validate_attributes_overrides.py
@@ -51,6 +51,13 @@ class ValidateAttributesOverridesTests(FactoryTestCase):
             class_a.attrs[1], class_c.attrs[1]
         )
 
+    def test_process_remove_non_overriding_prohibited_attrs(self):
+        target = ClassFactory.elements(1)
+        target.attrs[0].restrictions.max_occurs = 0
+
+        self.processor.process(target)
+        self.assertEqual(0, len(target.attrs))
+
     def test_overrides(self):
         a = AttrFactory.create(tag=Tag.SIMPLE_TYPE)
         b = a.clone()

--- a/tests/codegen/mappers/test_schema.py
+++ b/tests/codegen/mappers/test_schema.py
@@ -319,12 +319,6 @@ class SchemaMapperTests(FactoryTestCase):
         mock_build_class_attribute_types.assert_called_once_with(item, attribute)
         mock_element_namespace.assert_called_once_with(attribute, item.target_namespace)
 
-    def test_build_class_attribute_skip_prohibited(self):
-        item = ClassFactory.create(ns_map={"bar": "foo"})
-        attribute = Attribute(use=UseType.PROHIBITED)
-        SchemaMapper.build_class_attribute(item, attribute, Restrictions())
-        self.assertEqual(0, len(item.attrs))
-
     @mock.patch.object(Attribute, "attr_types", new_callable=mock.PropertyMock)
     @mock.patch.object(SchemaMapper, "build_inner_classes")
     def test_build_class_attribute_types(

--- a/tests/codegen/mappers/test_schema.py
+++ b/tests/codegen/mappers/test_schema.py
@@ -180,13 +180,14 @@ class SchemaMapperTests(FactoryTestCase):
         bar_type = AttrTypeFactory.create(qname="bar")
         foo_type = AttrTypeFactory.create(qname="foo")
 
-        bar = ExtensionFactory.create(bar_type)
-        double = ExtensionFactory.create(bar_type)
-        foo = ExtensionFactory.create(foo_type)
+        bar = ExtensionFactory.create(bar_type, tag=Tag.RESTRICTION)
+        double = ExtensionFactory.create(bar_type, tag=Tag.RESTRICTION)
+        foo = ExtensionFactory.create(foo_type, tag=Tag.EXTENSION)
 
         mock_children_extensions.return_value = [bar, double, foo]
         self_ext = ExtensionFactory.reference(
             qname="{xsdata}something",
+            tag=Tag.ELEMENT,
             restrictions=Restrictions(min_occurs=1, max_occurs=1),
         )
 
@@ -253,15 +254,16 @@ class SchemaMapperTests(FactoryTestCase):
 
         item = ClassFactory.create(ns_map={"bk": "book"})
         children = SchemaMapper.children_extensions(complex_type, item)
-        expected = list(
-            map(
-                ExtensionFactory.create,
-                [
-                    AttrTypeFactory.create(qname=build_qname("book", "b")),
-                    AttrTypeFactory.create(qname=build_qname("book", "c")),
-                ],
-            )
-        )
+        expected = [
+            ExtensionFactory.create(
+                AttrTypeFactory.create(qname=build_qname("book", "b")),
+                tag=Tag.RESTRICTION,
+            ),
+            ExtensionFactory.create(
+                AttrTypeFactory.create(qname=build_qname("book", "c")),
+                tag=Tag.EXTENSION,
+            ),
+        ]
 
         self.assertIsInstance(children, GeneratorType)
         self.assertEqual(expected, list(children))

--- a/tests/codegen/models/test_attr.py
+++ b/tests/codegen/models/test_attr.py
@@ -63,6 +63,13 @@ class AttrTests(FactoryTestCase):
         attr.restrictions.max_occurs = 1
         self.assertFalse(attr.is_list)
 
+    def test_property_is_prohibited(self):
+        attr = AttrFactory.create(restrictions=Restrictions(max_occurs=0))
+        self.assertTrue(attr.is_prohibited)
+
+        attr.restrictions.max_occurs = 1
+        self.assertFalse(attr.is_list)
+
     def test_property_is_optional(self):
         attr = AttrFactory.create(restrictions=Restrictions(min_occurs=0))
         self.assertTrue(attr.is_optional)

--- a/tests/formats/dataclass/test_filters.py
+++ b/tests/formats/dataclass/test_filters.py
@@ -148,7 +148,7 @@ class FiltersTests(FactoryTestCase):
     def test_field_definition_with_prohibited_attr(self):
         attr = AttrFactory.native(DataType.INT)
         attr.restrictions.max_occurs = 0
-        attr.default = "foo"
+        attr.default = "1"
 
         result = self.filters.field_definition(attr, {}, None, ["Root"])
         expected = (

--- a/tests/formats/dataclass/test_filters.py
+++ b/tests/formats/dataclass/test_filters.py
@@ -145,6 +145,22 @@ class FiltersTests(FactoryTestCase):
         )
         self.assertEqual(expected, result)
 
+    def test_field_definition_with_prohibited_attr(self):
+        attr = AttrFactory.native(DataType.INT)
+        attr.restrictions.max_occurs = 0
+        attr.default = "foo"
+
+        result = self.filters.field_definition(attr, {}, None, ["Root"])
+        expected = (
+            "field(\n"
+            "        init=False,\n"
+            "        metadata={\n"
+            '            "type": "Ignore",\n'
+            "        }\n"
+            "    )"
+        )
+        self.assertEqual(expected, result)
+
     @mock.patch.object(Filters, "field_default_value")
     def test_field_definition_with_restriction_pattern(self, mock_field_default_value):
         mock_field_default_value.return_value = None
@@ -538,6 +554,11 @@ class FiltersTests(FactoryTestCase):
         )
         self.assertEqual("Optional[int]", self.filters.field_type(attr, ["a", "b"]))
 
+    def test_field_type_with_prohibited_attr(self):
+        attr = AttrFactory.create(restrictions=Restrictions(max_occurs=0))
+
+        self.assertEqual("Any", self.filters.field_type(attr, ["a", "b"]))
+
     def test_choice_type(self):
         choice = AttrFactory.create(types=[AttrTypeFactory.create("foobar")])
         actual = self.filters.choice_type(choice, ["a", "b"])
@@ -654,6 +675,10 @@ class FiltersTests(FactoryTestCase):
 
         output = " Type["
         expected = "from typing import Type"
+        self.assertIn(expected, self.filters.default_imports(output))
+
+        output = ": Any = "
+        expected = "from typing import Any"
         self.assertIn(expected, self.filters.default_imports(output))
 
     def test_default_imports_combo(self):

--- a/xsdata/codegen/handlers/validate_attributes_overrides.py
+++ b/xsdata/codegen/handlers/validate_attributes_overrides.py
@@ -34,6 +34,8 @@ class ValidateAttributesOverrides(RelativeHandlerInterface):
                     self.validate_override(target, attr, base_attr)
                 else:
                     self.resolve_conflict(attr, base_attr)
+            elif attr.is_prohibited:
+                self.remove_attribute(target, attr)
 
     @classmethod
     def overrides(cls, a: Attr, b: Attr) -> bool:

--- a/xsdata/codegen/mappers/dtd.py
+++ b/xsdata/codegen/mappers/dtd.py
@@ -118,7 +118,9 @@ class DtdMapper:
     @classmethod
     def build_extension(cls, target: Class, data_type: DataType):
         ext_type = AttrType(qname=str(data_type), native=True)
-        extension = Extension(type=ext_type, restrictions=Restrictions())
+        extension = Extension(
+            tag=Tag.EXTENSION, type=ext_type, restrictions=Restrictions()
+        )
         target.extensions.append(extension)
 
     @classmethod

--- a/xsdata/codegen/mappers/schema.py
+++ b/xsdata/codegen/mappers/schema.py
@@ -228,9 +228,6 @@ class SchemaMapper:
         if obj.class_name in (Tag.ELEMENT, Tag.ANY, Tag.GROUP):
             restrictions.merge(parent_restrictions)
 
-        if restrictions.is_prohibited:
-            return
-
         name = obj.real_name
         target.attrs.append(
             Attr(

--- a/xsdata/codegen/mappers/schema.py
+++ b/xsdata/codegen/mappers/schema.py
@@ -114,7 +114,8 @@ class SchemaMapper:
 
         restrictions = obj.get_restrictions()
         extensions = [
-            cls.build_class_extension(target, base, restrictions) for base in obj.bases
+            cls.build_class_extension(obj.class_name, target, base, restrictions)
+            for base in obj.bases
         ]
         extensions.extend(cls.children_extensions(obj, target))
         target.extensions = collections.unique_sequence(extensions)
@@ -198,17 +199,20 @@ class SchemaMapper:
                 continue
 
             for ext in child.bases:
-                yield cls.build_class_extension(target, ext, child.get_restrictions())
+                yield cls.build_class_extension(
+                    child.class_name, target, ext, child.get_restrictions()
+                )
 
             yield from cls.children_extensions(child, target)
 
     @classmethod
     def build_class_extension(
-        cls, target: Class, name: str, restrictions: Dict
+        cls, tag: str, target: Class, name: str, restrictions: Dict
     ) -> Extension:
         """Create an extension for the target class."""
         return Extension(
             type=cls.build_data_type(target, name),
+            tag=tag,
             restrictions=Restrictions(**restrictions),
         )
 

--- a/xsdata/codegen/models.py
+++ b/xsdata/codegen/models.py
@@ -389,10 +389,12 @@ class Extension:
     """
     Model representation of a dataclass base class.
 
+    :param tag:
     :param type:
     :param restrictions:
     """
 
+    tag: str
     type: AttrType
     restrictions: Restrictions = field(hash=False)
 

--- a/xsdata/codegen/models.py
+++ b/xsdata/codegen/models.py
@@ -302,6 +302,11 @@ class Attr:
         return self.restrictions.is_list
 
     @property
+    def is_prohibited(self) -> bool:
+        """Return whether this attribute is prohibited."""
+        return self.restrictions.is_prohibited
+
+    @property
     def is_nameless(self) -> bool:
         """Return whether this attribute has a local name that will be used
         during parsing/serialization."""

--- a/xsdata/utils/testing.py
+++ b/xsdata/utils/testing.py
@@ -196,24 +196,30 @@ class ClassFactory(Factory):
 
 class ExtensionFactory(Factory):
     counter = 65
+    tags = [Tag.ELEMENT, Tag.EXTENSION, Tag.RESTRICTION]
 
     @classmethod
     def create(
         cls,
         attr_type: Optional[AttrType] = None,
         restrictions: Optional[Restrictions] = None,
+        tag: Optional[str] = None,
         **kwargs: Any,
     ) -> Extension:
         return Extension(
+            tag=tag or random.choice(cls.tags),
             type=attr_type or AttrTypeFactory.create(**kwargs),
             restrictions=restrictions or Restrictions(),
         )
 
     @classmethod
     def reference(cls, qname: str, **kwargs: Any) -> Extension:
+        tag = kwargs.pop("tag", None)
         restrictions = kwargs.pop("restrictions", None)
         return cls.create(
-            AttrTypeFactory.create(qname=qname, **kwargs), restrictions=restrictions
+            AttrTypeFactory.create(qname=qname, **kwargs),
+            tag=tag,
+            restrictions=restrictions,
         )
 
     @classmethod

--- a/xsdata/utils/text.py
+++ b/xsdata/utils/text.py
@@ -7,6 +7,7 @@ from typing import Tuple
 
 stop_words = {
     "",
+    "Any",
     "Decimal",
     "Dict",
     "Enum",


### PR DESCRIPTION
## 📒 Description


Prohibited fields are dropped before the analyze process. 

This pr makes sure that fields that override parent fields just to disable/prohibit the use are not generated, which results in invalid xml output.


Resolves #781

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue


## 💬 Comments

> A place to write any comments to the reviewer.
>

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
