### PR TITLE
Remove dataclasses from xsi_cache with unsupported types

### DIFF
--- a/xsdata/formats/dataclass/models/builders.py
+++ b/xsdata/formats/dataclass/models/builders.py
@@ -145,7 +145,7 @@ class XmlMetaBuilder:
                 yield var
 
     def build_class_meta(
-        self, clazz: Type, parent_namespace: Optional[str]
+        self, clazz: Type, parent_namespace: Optional[str] = None
     ) -> ClassMeta:
         """
         Fetch the class meta options and merge defaults.


### PR DESCRIPTION
## 📒 Description

xsdata scans all modules for supported models (dataclasses). If the model includes unsupported types these are excluded but it seems now there is trend people are defining dataclasses like these

```python
if TYPE_CHECKING:
    from typing_extensions import Literal

    _CaptureMethod = Literal["fd", "sys", "no", "tee-sys"]


class Foo:
    a: "_CaptureMethod"
```

Which raises a NameError when xsdata tries to analyze the typing annotation, since it's not defined :face_exhaling: 

A few versions back, I added a patch for pytest which seems to be doing that a lot, but the patch was a bit flaky because it assumed people would always override a class `__module__` property with something that returns a string, which surprisingly is not always the case :facepalm: 

Resolves #795

## 🔗 What I've Done

- Add a more secure patch, which will catch undefined types like the unsupported types and additionally remove these classes from xsi cache on the fly, to avoid re-evaluating the same class more than once.


## 💬 Comments

> A place to write any comments to the reviewer.
>

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
