### PR TITLE
Add parser config to load external dtd to resolve entities

### DIFF
--- a/docs/xml.rst
+++ b/docs/xml.rst
@@ -167,9 +167,11 @@ The configuration allows to enable/disable various features and failures.
     ...
     >>> config = ParserConfig(
     ...     base_url=None,
+    ...     load_dtd=False,
     ...     process_xinclude=False,
     ...     fail_on_unknown_properties=False,
     ...     fail_on_unknown_attributes=False,
+    ...     fail_on_converter_warnings=False,
     ... )
     >>> parser = XmlParser(config=config)
     >>> order = parser.from_bytes(xml_path.read_bytes())

--- a/xsdata/formats/dataclass/parsers/config.py
+++ b/xsdata/formats/dataclass/parsers/config.py
@@ -14,8 +14,9 @@ class ParserConfig:
     """
     Parsing configuration options.
 
-    :param base_url: Specify a base URL when parsing from memory and
-        you need support for relative links eg xinclude
+    :param base_url: Specify a base URL when parsing from memory, and
+        you need support for relative links e.g. xinclude
+    :param load_dtd: Enable loading external dtd (lxml only)
     :param process_xinclude: Enable xinclude statements processing
     :param class_factory: Override default object instantiation
     :param fail_on_unknown_properties: Skip unknown properties or
@@ -28,6 +29,7 @@ class ParserConfig:
 
     __slots__ = (
         "base_url",
+        "load_dtd",
         "process_xinclude",
         "class_factory",
         "fail_on_unknown_properties",
@@ -38,6 +40,7 @@ class ParserConfig:
     def __init__(
         self,
         base_url: Optional[str] = None,
+        load_dtd: bool = False,
         process_xinclude: bool = False,
         class_factory: Callable[[Type[T], Dict], T] = default_class_factory,
         fail_on_unknown_properties: bool = True,
@@ -45,6 +48,7 @@ class ParserConfig:
         fail_on_converter_warnings: bool = False,
     ):
         self.base_url = base_url
+        self.load_dtd = load_dtd
         self.process_xinclude = process_xinclude
         self.class_factory = class_factory
         self.fail_on_unknown_properties = fail_on_unknown_properties

--- a/xsdata/formats/dataclass/parsers/handlers/lxml.py
+++ b/xsdata/formats/dataclass/parsers/handlers/lxml.py
@@ -23,10 +23,10 @@ class LxmlEventHandler(XmlHandler):
     def parse(self, source: Any) -> Any:
         """
         Parse an XML document from a system identifier or an InputSource or
-        directly from an lxml Element or Tree.
+        directly from a lxml Element or Tree.
 
-        When Source is an lxml Element or Tree the handler will switch
-        to the :class:`lxml.etree.iterwalk` api.
+        When Source is a lxml Element or Tree the handler will switch to
+        the :class:`lxml.etree.iterwalk` api.
 
         When source is a system identifier or an InputSource the parser
         will ignore comments and recover from errors.
@@ -41,7 +41,13 @@ class LxmlEventHandler(XmlHandler):
             tree.xinclude()
             ctx = etree.iterwalk(tree, EVENTS)
         else:
-            ctx = etree.iterparse(source, EVENTS, recover=True, remove_comments=True)
+            ctx = etree.iterparse(
+                source,
+                EVENTS,
+                recover=True,
+                remove_comments=True,
+                load_dtd=self.parser.config.load_dtd,
+            )
 
         return self.process_context(ctx)
 


### PR DESCRIPTION
## 📒 Description

Loading external dtd is supported by lxml we should expose this in the parser config.


Fixes #769

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue


## 💬 Comments

> A place to write any comments to the reviewer.
>

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
