### PR TITLE
Support requests sessions on the wsdl client transport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ venv.bak/
 
 # vscode
 .vscode/
+
+# idea runs
+.run/

--- a/docs/wsdl.rst
+++ b/docs/wsdl.rst
@@ -95,6 +95,16 @@ Or if you know what you are doing
     client = Client(config=config)
 
 
+Initialize a transport with a custom requests session instance.
+
+.. code-block::
+
+    from requests import Session
+
+    transport = DefaultTransport(session=Session())
+    client = Client(config=config, transport=transport)
+
+
 Performing Requests
 -------------------
 

--- a/tests/formats/dataclass/test_transport.py
+++ b/tests/formats/dataclass/test_transport.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 
 from requests import HTTPError
 from requests import Response
+from requests import Session
 
 from xsdata.formats.dataclass.transports import DefaultTransport
 
@@ -10,7 +11,7 @@ from xsdata.formats.dataclass.transports import DefaultTransport
 class DefaultTransportTest(TestCase):
     @mock.patch.object(Response, "content", new_callable=mock.PropertyMock)
     @mock.patch.object(Response, "raise_for_status")
-    @mock.patch("xsdata.formats.dataclass.transports.requests.get")
+    @mock.patch.object(Session, "get")
     def test_get(self, mock_get, mock_raise_for_status, mock_content):
         transport = DefaultTransport()
         params = {"a": "b"}
@@ -31,7 +32,7 @@ class DefaultTransportTest(TestCase):
 
     @mock.patch.object(Response, "content", new_callable=mock.PropertyMock)
     @mock.patch.object(Response, "raise_for_status")
-    @mock.patch("xsdata.formats.dataclass.transports.requests.post")
+    @mock.patch.object(Session, "post")
     def test_post(self, mock_post, mock_raise_for_status, mock_content):
         transport = DefaultTransport(timeout=1.0)
         data = {"a": "b"}

--- a/xsdata/formats/dataclass/transports.py
+++ b/xsdata/formats/dataclass/transports.py
@@ -1,8 +1,10 @@
 import abc
 from typing import Any
 from typing import Dict
+from typing import Optional
 
-import requests
+from requests import Response
+from requests import Session
 
 
 class Transport(abc.ABC):
@@ -24,27 +26,30 @@ class DefaultTransport(Transport):
     :param timeout: Read timeout
     """
 
-    __slots__ = "timeout"
+    __slots__ = "timeout", "session"
 
-    def __init__(self, timeout: float = 2.0):
+    def __init__(self, timeout: float = 2.0, session: Optional[Session] = None):
         self.timeout = timeout
+        self.session = session or Session()
 
     def get(self, url: str, params: Dict, headers: Dict) -> bytes:
         """
         :raises HTTPError: if status code is not valid for content unmarshalling.
         """
-        res = requests.get(url, params=params, headers=headers, timeout=self.timeout)
+        res = self.session.get(
+            url, params=params, headers=headers, timeout=self.timeout
+        )
         return self.handle_response(res)
 
     def post(self, url: str, data: Any, headers: Dict) -> Any:
         """
         :raises HTTPError: if status code is not valid for content unmarshalling.
         """
-        res = requests.post(url, data=data, headers=headers, timeout=self.timeout)
+        res = self.session.post(url, data=data, headers=headers, timeout=self.timeout)
         return self.handle_response(res)
 
     @classmethod
-    def handle_response(cls, response: requests.Response) -> bytes:
+    def handle_response(cls, response: Response) -> bytes:
         """
         Status codes 200 or 500 means that we can unmarshall the response.
 


### PR DESCRIPTION
## 📒 Description

Allow using a custom requests session instance on the wsdl client transport


Resolves #726

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue


## 💬 Comments

> A place to write any comments to the reviewer.
>

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
