### PR TITLE
Support subscriptable types and UnionType

### DIFF
--- a/docs/models.rst
+++ b/docs/models.rst
@@ -120,6 +120,22 @@ Simply follow the Python lib :mod:`python:dataclasses` documentation.
     Everything else will raise an exception as unsupported.
 
 
+
+Support for generics in standard collections and the new union type was added
+in v23.6
+
+
+.. warning::
+
+    You will get false positive errors from mypy if you are using compound fields.
+
+    Mypy `issue <https://github.com/python/mypy/issues/13026>`_
+
+    .. code-block::
+
+        Value of type "Type[type]" is not indexable  [index]
+
+
 Field Metadata
 ==============
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ project_urls =
 [options]
 packages = xsdata
 install_requires =
+    typing-extensions
     importlib-metadata;python_version<"3.8"
 python_requires = >=3.7
 include_package_data = True

--- a/tests/fixtures/artists/metadata.py
+++ b/tests/fixtures/artists/metadata.py
@@ -25,9 +25,10 @@ class Alias:
             "required": True,
         }
     )
-    type: Optional[str] = field(
+    type_value: Optional[str] = field(
         default=None,
         metadata={
+            "name": "type",
             "type": "Attribute",
         }
     )
@@ -303,9 +304,10 @@ class Artist:
             "required": True,
         }
     )
-    type: Optional[str] = field(
+    type_value: Optional[str] = field(
         default=None,
         metadata={
+            "name": "type",
             "type": "Attribute",
             "required": True,
         }

--- a/tests/fixtures/series/series.py
+++ b/tests/fixtures/series/series.py
@@ -215,9 +215,10 @@ class Series:
             "required": True,
         }
     )
-    type: Optional[str] = field(
+    type_value: Optional[str] = field(
         default=None,
         metadata={
+            "name": "type",
             "type": "Element",
             "required": True,
         }

--- a/tests/formats/dataclass/test_filters.py
+++ b/tests/formats/dataclass/test_filters.py
@@ -540,6 +540,9 @@ class FiltersTests(FactoryTestCase):
         attr.restrictions.nillable = True
         self.assertEqual("Optional[FooBar]", self.filters.field_type(attr, []))
 
+        self.filters.union_type = True
+        self.assertEqual("None | FooBar", self.filters.field_type(attr, []))
+
     def test_field_type_with_optional_value(self):
         attr = AttrFactory.create(types=AttrTypeFactory.list(1, qname="foo_bar"))
 
@@ -550,6 +553,9 @@ class FiltersTests(FactoryTestCase):
 
         attr.restrictions.min_occurs = 0
         self.assertEqual("Optional[FooBar]", self.filters.field_type(attr, []))
+
+        self.filters.union_type = True
+        self.assertEqual("None | FooBar", self.filters.field_type(attr, []))
 
     def test_field_type_with_circular_reference(self):
         attr = AttrFactory.create(
@@ -566,6 +572,13 @@ class FiltersTests(FactoryTestCase):
         )
         self.assertEqual(
             'Optional["Parent.Inner.FooBar"]',
+            self.filters.field_type(attr, ["Parent", "Inner"]),
+        )
+
+        self.filters.postponed_annotations = True
+        self.filters.union_type = True
+        self.assertEqual(
+            "None | Parent.Inner.FooBar",
             self.filters.field_type(attr, ["Parent", "Inner"]),
         )
 
@@ -595,6 +608,18 @@ class FiltersTests(FactoryTestCase):
             self.filters.field_type(attr, ["A", "Parent"]),
         )
 
+        self.filters.subscriptable_types = True
+        self.assertEqual(
+            'tuple["A.Parent.FooBar", ...]',
+            self.filters.field_type(attr, ["A", "Parent"]),
+        )
+
+        self.filters.format.frozen = False
+        self.assertEqual(
+            'list["A.Parent.FooBar"]',
+            self.filters.field_type(attr, ["A", "Parent"]),
+        )
+
     def test_field_type_with_token_attr(self):
         attr = AttrFactory.create(
             types=AttrTypeFactory.list(1, qname="foo_bar"),
@@ -612,6 +637,11 @@ class FiltersTests(FactoryTestCase):
         attr.restrictions.max_occurs = 2
         self.assertEqual(
             "Tuple[Tuple[FooBar, ...], ...]", self.filters.field_type(attr, [])
+        )
+
+        self.filters.subscriptable_types = True
+        self.assertEqual(
+            "tuple[tuple[FooBar, ...], ...]", self.filters.field_type(attr, [])
         )
 
     def test_field_type_with_alias(self):
@@ -640,19 +670,39 @@ class FiltersTests(FactoryTestCase):
             self.filters.field_type(attr, ["A", "Parent"]),
         )
 
+        self.filters.union_type = True
+        self.assertEqual(
+            'List["A.Parent.BossLife" | int]',
+            self.filters.field_type(attr, ["A", "Parent"]),
+        )
+        self.filters.subscriptable_types = True
+        self.assertEqual(
+            'list["A.Parent.BossLife" | int]',
+            self.filters.field_type(attr, ["A", "Parent"]),
+        )
+
     def test_field_type_with_any_attribute(self):
         attr = AttrFactory.any_attribute()
 
         self.assertEqual("Dict[str, str]", self.filters.field_type(attr, ["a", "b"]))
+
+        self.filters.subscriptable_types = True
+        self.assertEqual("dict[str, str]", self.filters.field_type(attr, ["a", "b"]))
 
     def test_field_type_with_native_type(self):
         attr = AttrFactory.create(
             types=[
                 AttrTypeFactory.native(DataType.INT),
                 AttrTypeFactory.native(DataType.POSITIVE_INTEGER),
+                AttrTypeFactory.native(DataType.STRING),
             ]
         )
-        self.assertEqual("Optional[int]", self.filters.field_type(attr, ["a", "b"]))
+        self.assertEqual(
+            "Optional[Union[int, str]]", self.filters.field_type(attr, ["a", "b"])
+        )
+
+        self.filters.union_type = True
+        self.assertEqual("None | int | str", self.filters.field_type(attr, ["a", "b"]))
 
     def test_field_type_with_prohibited_attr(self):
         attr = AttrFactory.create(restrictions=Restrictions(max_occurs=0))
@@ -663,6 +713,10 @@ class FiltersTests(FactoryTestCase):
         choice = AttrFactory.create(types=[AttrTypeFactory.create("foobar")])
         actual = self.filters.choice_type(choice, ["a", "b"])
         self.assertEqual("Type[Foobar]", actual)
+
+        self.filters.subscriptable_types = True
+        actual = self.filters.choice_type(choice, ["a", "b"])
+        self.assertEqual("type[Foobar]", actual)
 
     def test_choice_type_with_forward_reference(self):
         choice = AttrFactory.create(
@@ -678,10 +732,22 @@ class FiltersTests(FactoryTestCase):
         actual = self.filters.choice_type(choice, ["a", "b"])
         self.assertEqual('Type["Foobar"]', actual)
 
+        self.filters.postponed_annotations = True
+        actual = self.filters.choice_type(choice, ["a", "b"])
+        self.assertEqual("Type[Foobar]", actual)
+
     def test_choice_type_with_multiple_types(self):
         choice = AttrFactory.create(types=[type_str, type_bool])
         actual = self.filters.choice_type(choice, ["a", "b"])
         self.assertEqual("Type[Union[str, bool]]", actual)
+
+        self.filters.subscriptable_types = True
+        actual = self.filters.choice_type(choice, ["a", "b"])
+        self.assertEqual("type[Union[str, bool]]", actual)
+
+        self.filters.union_type = True
+        actual = self.filters.choice_type(choice, ["a", "b"])
+        self.assertEqual("type[str | bool]", actual)
 
     def test_choice_type_with_list_types_are_ignored(self):
         choice = AttrFactory.create(types=[type_str, type_bool])
@@ -698,6 +764,11 @@ class FiltersTests(FactoryTestCase):
         self.filters.format.frozen = True
         actual = self.filters.choice_type(choice, ["a", "b"])
         self.assertEqual("Type[Tuple[Union[str, bool], ...]]", actual)
+
+        self.filters.union_type = True
+        self.filters.subscriptable_types = True
+        actual = self.filters.choice_type(choice, ["a", "b"])
+        self.assertEqual("type[tuple[str | bool, ...]]", actual)
 
     def test_default_imports_with_decimal(self):
         expected = "from decimal import Decimal"

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -30,7 +30,7 @@ class GeneratorConfigTests(TestCase):
         expected = (
             '<?xml version="1.0" encoding="UTF-8"?>\n'
             f'<Config xmlns="http://pypi.org/project/xsdata" version="{__version__}">\n'
-            '  <Output maxLineLength="79">\n'
+            '  <Output maxLineLength="79" subscriptableTypes="false" unionType="false">\n'
             "    <Package>generated</Package>\n"
             '    <Format repr="true" eq="true" order="false" unsafeHash="false" frozen="false" slots="false" kwOnly="false">dataclasses</Format>\n'
             "    <Structure>filenames</Structure>\n"
@@ -72,7 +72,7 @@ class GeneratorConfigTests(TestCase):
         existing = (
             '<?xml version="1.0" encoding="UTF-8"?>\n'
             '<Config xmlns="http://pypi.org/project/xsdata" version="20.8">\n'
-            '  <Output maxLineLength="79">\n'
+            '  <Output maxLineLength="79" subscriptableTypes="false" unionType="false">\n'
             "    <Package>foo.bar</Package>\n"
             "  </Output>\n"
             "  <Conventions>\n"
@@ -91,7 +91,7 @@ class GeneratorConfigTests(TestCase):
         expected = (
             '<?xml version="1.0" encoding="UTF-8"?>\n'
             f'<Config xmlns="http://pypi.org/project/xsdata" version="{__version__}">\n'
-            '  <Output maxLineLength="79">\n'
+            '  <Output maxLineLength="79" subscriptableTypes="false" unionType="false">\n'
             "    <Package>foo.bar</Package>\n"
             '    <Format repr="true" eq="true" order="false" unsafeHash="false"'
             ' frozen="false" slots="false" kwOnly="false">dataclasses</Format>\n'
@@ -138,6 +138,36 @@ class GeneratorConfigTests(TestCase):
             OutputFormat(eq=False, order=True)
 
         self.assertEqual("eq must be true if order is true", str(cm.exception))
+
+    def test_subscriptable_types_requires_390(self):
+        if sys.version_info < (3, 9):
+            with warnings.catch_warnings(record=True) as w:
+                self.assertFalse(
+                    GeneratorOutput(subscriptable_types=True).subscriptable_types
+                )
+
+            self.assertEqual(
+                "Generics PEP 585 requires python >= 3.9, reverting...",
+                str(w[-1].message),
+            )
+
+        else:
+            self.assertTrue(
+                GeneratorOutput(subscriptable_types=True).subscriptable_types
+            )
+
+    def test_use_union_type_requires_310(self):
+        if sys.version_info < (3, 10):
+            with warnings.catch_warnings(record=True) as w:
+                self.assertFalse(GeneratorOutput(union_type=True).union_type)
+
+            self.assertEqual(
+                "UnionType PEP 604 requires python >= 3.10, reverting...",
+                str(w[-1].message),
+            )
+
+        else:
+            self.assertTrue(GeneratorOutput(union_type=True).union_type)
 
     def test_format_slots_requires_310(self):
         if sys.version_info < (3, 10):

--- a/xsdata/formats/dataclass/parsers/json.py
+++ b/xsdata/formats/dataclass/parsers/json.py
@@ -74,7 +74,7 @@ class JsonParser(AbstractParser):
         try:
             origin = get_origin(clazz)
             list_type = False
-            if origin is List:
+            if origin is list:
                 list_type = True
                 args = get_args(clazz)
 

--- a/xsdata/models/datatype.py
+++ b/xsdata/models/datatype.py
@@ -95,7 +95,7 @@ class XmlDate(NamedTuple):
 
         .. warning::
 
-        date instances don't have timezone information!
+            date instances don't have timezone information!
         """
         return cls(obj.year, obj.month, obj.day)
 

--- a/xsdata/utils/text.py
+++ b/xsdata/utils/text.py
@@ -58,6 +58,7 @@ stop_words = {
     "self",
     "str",
     "try",
+    "type",
     "while",
     "with",
     "yield",


### PR DESCRIPTION
## 📒 Description

This pr adds support for subscriptable types (list[str], dict[str, str]) and the new union type (str | int).

Add generator options to subscriptable/union types


Resolves #681

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue


## 💬 Comments

> A place to write any comments to the reviewer.
>

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
