### PR TITLE
fix: move RenameDuplicateAttributes to before SanitizeAttributesDefaultValue in Steps.SANITIZE

### DIFF
--- a/tests/codegen/test_container.py
+++ b/tests/codegen/test_container.py
@@ -51,8 +51,12 @@ class ClassContainerTests(FactoryTestCase):
                 "MergeAttributes",
                 "ProcessMixedContentClass",
             ],
-            30: ["ResetAttributeSequences", "SanitizeAttributesDefaultValue"],
-            40: ["ValidateAttributesOverrides", "RenameDuplicateAttributes"],
+            30: [
+                "ResetAttributeSequences",
+                "RenameDuplicateAttributes",
+                "SanitizeAttributesDefaultValue",
+            ],
+            40: ["ValidateAttributesOverrides"],
             50: [
                 "VacuumInnerClasses",
                 "CreateCompoundFields",

--- a/xsdata/codegen/container.py
+++ b/xsdata/codegen/container.py
@@ -69,11 +69,11 @@ class ClassContainer(ContainerInterface):
             ],
             Steps.SANITIZE: [
                 ResetAttributeSequences(),
+                RenameDuplicateAttributes(),
                 SanitizeAttributesDefaultValue(self),
             ],
             Steps.RESOLVE: [
                 ValidateAttributesOverrides(self),
-                RenameDuplicateAttributes(),
             ],
             Steps.FINALIZE: [
                 VacuumInnerClasses(),

--- a/xsdata/codegen/handlers/rename_duplicate_attributes.py
+++ b/xsdata/codegen/handlers/rename_duplicate_attributes.py
@@ -7,7 +7,7 @@ from xsdata.utils.constants import DEFAULT_ATTR_NAME
 
 
 def attr_group_name(x: Attr) -> str:
-    return x.name or DEFAULT_ATTR_NAME
+    return x.slug or DEFAULT_ATTR_NAME
 
 
 class RenameDuplicateAttributes(HandlerInterface):

--- a/xsdata/codegen/handlers/rename_duplicate_attributes.py
+++ b/xsdata/codegen/handlers/rename_duplicate_attributes.py
@@ -7,7 +7,7 @@ from xsdata.utils.constants import DEFAULT_ATTR_NAME
 
 
 def attr_group_name(x: Attr) -> str:
-    return x.slug or DEFAULT_ATTR_NAME
+    return x.name or DEFAULT_ATTR_NAME
 
 
 class RenameDuplicateAttributes(HandlerInterface):


### PR DESCRIPTION
## 📒 Description

This fixes #805, an issue with enums with conflicting slugs

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue


## 💬 Comments

While this fixes the problem i described... i have no idea what else it will break, so letting the tests run, and we can discuss

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
