### PR TITLE
Fix use="required" for attributes in inner classes.

### DIFF
--- a/tests/codegen/handlers/test_calculate_attribute_paths.py
+++ b/tests/codegen/handlers/test_calculate_attribute_paths.py
@@ -69,6 +69,13 @@ class CalculateAttributePathsTests(FactoryTestCase):
                         min_occurs=1,
                         max_occurs=1,
                         path=[("s", 1, 1, 1), ("c", 5, 2, 2)],
+                    ),
+                ),
+                AttrFactory.element(
+                    restrictions=Restrictions(
+                        min_occurs=1,
+                        max_occurs=1,
+                        path=[("s", 1, 1, 1), ("c", 6, 1, 21)],
                     )
                 ),
             ]
@@ -99,5 +106,6 @@ class CalculateAttributePathsTests(FactoryTestCase):
             (1, None, 0, 1),
             (1, None, 2, 2),
             (1, None, 2, 2),
+            (1, None, 1, 21),
         ]
         self.assertEqual(expected, actual)

--- a/tests/codegen/handlers/test_create_compound_fields.py
+++ b/tests/codegen/handlers/test_create_compound_fields.py
@@ -266,3 +266,23 @@ class CreateCompoundFieldsTests(FactoryTestCase):
 
         result = self.processor.sum_counters(counters)
         self.assertEqual((0, 3), (sum(result[0]), sum(result[1])))
+
+    def test_update_counters(self):
+        attr = AttrFactory.create()
+        attr.restrictions.min_occurs = 2
+        attr.restrictions.max_occurs = 3
+        attr.restrictions.path = [("c", 0, 1, 1)]
+
+        counters = {}
+        self.processor.update_counters(attr, counters)
+
+        expected = {("c", 0, 1, 1): {"max": [3], "min": [0]}}
+        self.assertEqual(expected, counters)
+
+        attr.restrictions.min_occurs = 2
+        attr.restrictions.path = [("c", 0, 2, 1)]
+
+        counters = {}
+        self.processor.update_counters(attr, counters)
+        expected = {("c", 0, 2, 1): {"max": [3], "min": [2]}}
+        self.assertEqual(expected, counters)

--- a/tests/codegen/handlers/test_validate_attributes_overrides.py
+++ b/tests/codegen/handlers/test_validate_attributes_overrides.py
@@ -102,12 +102,19 @@ class ValidateAttributesOverridesTests(FactoryTestCase):
         attr_b.fixed = attr_a.fixed
         attr_a.restrictions.tokens = not attr_b.restrictions.tokens
         attr_a.restrictions.nillable = not attr_b.restrictions.nillable
+        attr_a.restrictions.min_occurs = 0
+        attr_b.restrictions.min_occurs = 1
+        attr_a.restrictions.max_occurs = 0
+        attr_b.restrictions.max_occurs = 1
+
         self.processor.validate_override(target, attr_a, attr_b)
         self.assertEqual(1, len(target.attrs))
 
         # Restrictions are compatible again
         attr_a.restrictions.tokens = attr_b.restrictions.tokens
         attr_a.restrictions.nillable = attr_b.restrictions.nillable
+        attr_a.restrictions.min_occurs = attr_b.restrictions.min_occurs = 1
+        attr_a.restrictions.max_occurs = attr_b.restrictions.max_occurs = 1
         self.processor.validate_override(target, attr_a, attr_b)
         self.assertEqual(0, len(target.attrs))
 

--- a/xsdata/codegen/handlers/calculate_attribute_paths.py
+++ b/xsdata/codegen/handlers/calculate_attribute_paths.py
@@ -36,8 +36,6 @@ class CalculateAttributePaths(HandlerInterface):
                 if not attr.restrictions.sequence:
                     attr.restrictions.sequence = index
             elif name == CHOICE:
-                if mi <= 1:
-                    mi = 0
                 if not attr.restrictions.choice:
                     attr.restrictions.choice = index
             elif name == GROUP:

--- a/xsdata/codegen/handlers/validate_attributes_overrides.py
+++ b/xsdata/codegen/handlers/validate_attributes_overrides.py
@@ -60,6 +60,7 @@ class ValidateAttributesOverrides(RelativeHandlerInterface):
             and bool_eq(attr.mixed, source_attr.mixed)
             and bool_eq(attr.restrictions.tokens, source_attr.restrictions.tokens)
             and bool_eq(attr.restrictions.nillable, source_attr.restrictions.nillable)
+            and bool_eq(attr.restrictions.is_optional, source_attr.restrictions.is_optional)
         ):
             cls.remove_attribute(target, attr)
 

--- a/xsdata/codegen/handlers/validate_attributes_overrides.py
+++ b/xsdata/codegen/handlers/validate_attributes_overrides.py
@@ -61,6 +61,7 @@ class ValidateAttributesOverrides(RelativeHandlerInterface):
             and bool_eq(attr.restrictions.tokens, source_attr.restrictions.tokens)
             and bool_eq(attr.restrictions.nillable, source_attr.restrictions.nillable)
             and bool_eq(attr.restrictions.is_optional, source_attr.restrictions.is_optional)
+            and bool_eq(attr.restrictions.is_prohibited, source_attr.restrictions.is_prohibited)
         ):
             cls.remove_attribute(target, attr)
 

--- a/xsdata/codegen/handlers/validate_attributes_overrides.py
+++ b/xsdata/codegen/handlers/validate_attributes_overrides.py
@@ -60,8 +60,8 @@ class ValidateAttributesOverrides(RelativeHandlerInterface):
             and bool_eq(attr.mixed, source_attr.mixed)
             and bool_eq(attr.restrictions.tokens, source_attr.restrictions.tokens)
             and bool_eq(attr.restrictions.nillable, source_attr.restrictions.nillable)
-            and bool_eq(attr.restrictions.is_optional, source_attr.restrictions.is_optional)
-            and bool_eq(attr.restrictions.is_prohibited, source_attr.restrictions.is_prohibited)
+            and bool_eq(attr.is_prohibited, source_attr.is_prohibited)
+            and bool_eq(attr.is_optional, source_attr.is_optional)
         ):
             cls.remove_attribute(target, attr)
 


### PR DESCRIPTION
## 📒 Description

When an element has a restriction, it may _override_ an attribute's use-attribute, for example from optional to required. This patch reflects this change.

Resolves #819

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue

#819 contains the minimum XSD to check the generation. I basically step by step went though the generation process until I found that RESOLVE causes the attributes of 'test' to disappear.

## 💬 Comments

First _true_ contribution? ;-)

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
