### PR TITLE
Prototype override choices with same name

### DIFF
--- a/xsdata/codegen/handlers/validate_attributes_overrides.py
+++ b/xsdata/codegen/handlers/validate_attributes_overrides.py
@@ -60,6 +60,7 @@ class ValidateAttributesOverrides(RelativeHandlerInterface):
             and bool_eq(attr.mixed, source_attr.mixed)
             and bool_eq(attr.restrictions.tokens, source_attr.restrictions.tokens)
             and bool_eq(attr.restrictions.nillable, source_attr.restrictions.nillable)
+            and bool_eq(attr.restrictions.is_optional, source_attr.restrictions.is_optional)
         ):
             cls.remove_attribute(target, attr)
 

--- a/xsdata/codegen/handlers/validate_attributes_overrides.py
+++ b/xsdata/codegen/handlers/validate_attributes_overrides.py
@@ -61,6 +61,7 @@ class ValidateAttributesOverrides(RelativeHandlerInterface):
             and bool_eq(attr.restrictions.tokens, source_attr.restrictions.tokens)
             and bool_eq(attr.restrictions.nillable, source_attr.restrictions.nillable)
             and bool_eq(attr.restrictions.is_optional, source_attr.restrictions.is_optional)
+            and bool_eq(attr.restrictions.is_prohibited, source_attr.restrictions.is_prohibited)
         ):
             cls.remove_attribute(target, attr)
 

--- a/xsdata/codegen/handlers/validate_attributes_overrides.py
+++ b/xsdata/codegen/handlers/validate_attributes_overrides.py
@@ -49,7 +49,6 @@ class ValidateAttributesOverrides(RelativeHandlerInterface):
 
     def group_fields(self, target: Class, attrs: List[Attr]):
         """Group attributes into a new compound field."""
-        pos = target.attrs.index(attrs[0])
         choice = attrs[0].restrictions.choice
 
         assert choice is not None


### PR DESCRIPTION
## 📒 Description

This is a prototype which allows to create the same field names for child classes that effectively restrict a choice element to a single chosen element. I can come up with pretty exotic schemas that would not cover this if ambiguities would occur. It is an attempt to explore the possibilities that raise from ./w3c/msData/particles/particlesL029.xsd.

Resolves #821

## 🔗 What I've Done

I have tried to mimic the name generation from create_compound_fields, but as they are configuration related this is likely not the approach that should be taken here. I would suggests something that would not duplicate code so the effect is similar.

## 💬 Comments

Don't merge as-is :-)

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
