### PR TITLE
Fix decimal converter to avoid scientific notations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: tests/fixtures
 
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.7.0
+    rev: v3.9.0
     hooks:
       - id: pyupgrade
         args: [ --py37-plus ]
@@ -11,11 +11,11 @@ repos:
     hooks:
       - id: reorder-python-imports
   - repo: https://github.com/ambv/black
-    rev: 23.3.0
+    rev: 23.7.0
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/autoflake
-    rev: v2.1.1
+    rev: v2.2.0
     hooks:
       - id: autoflake
   - repo: https://github.com/PyCQA/flake8
@@ -41,7 +41,7 @@ repos:
       - id: docformatter
         args: [ "--in-place", "--pre-summary-newline" ]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.4.0
+    rev: v1.4.1
     hooks:
       - id: mypy
         files: ^(xsdata/)

--- a/tests/formats/test_converter.py
+++ b/tests/formats/test_converter.py
@@ -42,7 +42,7 @@ class ConverterFactoryTests(TestCase):
         self.assertEqual("1.5", converter.serialize(1.5))
         self.assertEqual("true", converter.serialize(True))
         self.assertEqual("optional", converter.serialize(UseType.OPTIONAL))
-        self.assertEqual("8.77683E-8", converter.serialize(Decimal("8.77683E-8")))
+        self.assertEqual("0.0000000877683", converter.serialize(Decimal("8.77683E-8")))
         self.assertEqual("8.77683E-08", converter.serialize(float("8.77683E-8")))
 
     def test_test(self):
@@ -254,7 +254,9 @@ class DecimalConverterTests(TestCase):
         self.assertEqual("INF", self.converter.serialize(Decimal("inf")))
         self.assertEqual("INF", self.converter.serialize(Decimal("+inf")))
         self.assertEqual("-INF", self.converter.serialize(Decimal("-inf")))
-        self.assertEqual("8.77683E-8", self.converter.serialize(Decimal("8.77683E-8")))
+        self.assertEqual(
+            "0.0000000877683", self.converter.serialize(Decimal("8.77683E-8"))
+        )
 
 
 class DateTimeConverterTests(TestCase):

--- a/xsdata/formats/converter.py
+++ b/xsdata/formats/converter.py
@@ -324,7 +324,7 @@ class DecimalConverter(Converter):
         if value.is_infinite():
             return str(value).replace("Infinity", "INF")
 
-        return str(value)
+        return f"{value:f}"
 
 
 class QNameConverter(Converter):


### PR DESCRIPTION
## 📒 Description
xs:decimals don't support scientific notations at all.

fixes #817

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue


## 💬 Comments

> A place to write any comments to the reviewer.
>

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
