### PR TITLE
Fix nympy paramater docstring format

### DIFF
--- a/tests/fixtures/docstrings/numpy/schema.py
+++ b/tests/fixtures/docstrings/numpy/schema.py
@@ -28,9 +28,11 @@ class RootEnum(Enum):
     """
     Properties
     ----------
-    A: Lorem ipsum dolor
-    B: Lorem ipsum dolor '''sit''' amet, consectetur adipiscing elit.
-        Morbi dapibus. My\\Ipsum
+    A
+        Lorem ipsum dolor
+    B
+        Lorem ipsum dolor '''sit''' amet, consectetur adipiscing elit. Morbi
+        dapibus. My\\Ipsum
     """
     A = "A"
     B = "B"
@@ -40,9 +42,11 @@ class RootB(Enum):
     """
     Properties
     ----------
-    YES: This is an inner enum member documentation. Lorem ipsum dolor
-        sit amet, consectetur adipiscing elit. Etiam mollis.
-    NO: Lorem ipsum dolor My\\Ipsum
+    YES
+        This is an inner enum member documentation. Lorem ipsum dolor sit
+        amet, consectetur adipiscing elit. Etiam mollis.
+    NO
+        Lorem ipsum dolor My\\Ipsum
     """
     YES = "Yes"
     NO = "No"
@@ -64,12 +68,13 @@ class Root:
 
     Parameters
     ----------
-    a: This is an inner type '''field''' documentation. Lorem ipsum
-        dolor sit amet, consectetur adipiscing elit. Aliquam nec.
-        My\\Ipsum
-    b: This is a second root type field documentation.
-    c:
-    d:
+    a
+        This is an inner type '''field''' documentation. Lorem ipsum dolor
+        sit amet, consectetur adipiscing elit. Aliquam nec. My\\Ipsum
+    b
+        This is a second root type field documentation.
+    c
+    d
     """
     class Meta:
         namespace = "urn:docs"
@@ -114,9 +119,10 @@ class Root:
 
         Parameters
         ----------
-        sub_a: This is an inner type '''field''' documentation. Lorem
-            ipsum dolor sit amet, consectetur adipiscing elit. Vivamus
-            efficitur. My\\Ipsum
+        sub_a
+            This is an inner type '''field''' documentation. Lorem ipsum
+            dolor sit amet, consectetur adipiscing elit. Vivamus efficitur.
+            My\\Ipsum
         """
         sub_a: Optional[str] = field(
             default=None,

--- a/tests/fixtures/primer/order.py
+++ b/tests/fixtures/primer/order.py
@@ -19,12 +19,14 @@ class Items:
         """
         Parameters
         ----------
-        product_name:
-        quantity:
-        usprice: Price amount in USD
-        comment:
-        ship_date:
-        part_num: Stock Keeping Unit
+        product_name
+        quantity
+        usprice
+            Price amount in USD
+        comment
+        ship_date
+        part_num
+            Stock Keeping Unit
         """
         product_name: Optional[str] = field(
             default=None,
@@ -153,11 +155,13 @@ class PurchaseOrderType:
 
     Parameters
     ----------
-    ship_to: Shipping Address
-    bill_to: Billing Address
-    comment:
-    items:
-    order_date:
+    ship_to
+        Shipping Address
+    bill_to
+        Billing Address
+    comment
+    items
+    order_date
     """
     ship_to: Optional[Usaddress] = field(
         default=None,

--- a/xsdata/formats/dataclass/filters.py
+++ b/xsdata/formats/dataclass/filters.py
@@ -522,7 +522,9 @@ class Filters:
         )
         return f"(\n{value}\n{' ' * indent})"
 
-    def text_wrap(self, string: str, offset: int = 0) -> str:
+    def text_wrap(
+        self, string: str, offset: int = 0, subsequent_indent: str = "    "
+    ) -> str:
         """Wrap text in respect to the max line length and the given offset."""
         return "\n".join(
             textwrap.wrap(
@@ -531,7 +533,7 @@ class Filters:
                 drop_whitespace=True,
                 replace_whitespace=True,
                 break_long_words=False,
-                subsequent_indent="    ",
+                subsequent_indent=subsequent_indent,
             )
         )
 

--- a/xsdata/formats/dataclass/templates/docstrings.numpy.jinja2
+++ b/xsdata/formats/dataclass/templates/docstrings.numpy.jinja2
@@ -4,6 +4,9 @@
 {{ "Properties" if obj.is_enumeration else "Parameters" }}
 ----------
 {%- for var_name, var_doc in obj | class_params %}
-{{ "{}: {}".format(var_name, var_doc) | text_wrap(offset) }}
+{{ var_name }}
+{%- if var_doc %}
+{{ var_doc | text_wrap(offset, subsequent_indent="") | indent(width=4, first=True) }}
+{%-  endif -%}
 {%- endfor -%}
 {%- endif %}


### PR DESCRIPTION
## 📒 Description

The description of parameters is supposed to go into a new line


Resolves #818

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue


## 💬 Comments

> A place to write any comments to the reviewer.
>

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
