### PR TITLE
Drop all wildcards from mixed content choices

### DIFF
--- a/tests/codegen/handlers/test_process_mixed_content_class.py
+++ b/tests/codegen/handlers/test_process_mixed_content_class.py
@@ -20,12 +20,13 @@ class ProcessMixedContentClassTests(FactoryTestCase):
             AttrFactory.attribute(),  # keep
             AttrFactory.reference("foo", restrictions=res.clone()),  # choice
             AttrFactory.native(DataType.INT, restrictions=res.clone()),  # choice
+            AttrFactory.native(DataType.ANY_TYPE, restrictions=res.clone()),  # drop
             AttrFactory.any(),  # drop
         ]
         item = ClassFactory.create(attrs=attrs)
 
         self.processor.process(item)
-        self.assertEqual(4, len(item.attrs))
+        self.assertEqual(5, len(item.attrs))
 
         item.mixed = True
         self.processor.process(item)
@@ -39,7 +40,7 @@ class ProcessMixedContentClassTests(FactoryTestCase):
         expected.restrictions.min_occurs = 0
         expected.restrictions.max_occurs = sys.maxsize
         choices = []
-        for attr in attrs[1:-1]:
+        for attr in attrs[1:-2]:
             choice = attr.clone()
             choice.restrictions.min_occurs = None
             choice.restrictions.max_occurs = None

--- a/xsdata/codegen/handlers/process_mixed_content_class.py
+++ b/xsdata/codegen/handlers/process_mixed_content_class.py
@@ -31,7 +31,7 @@ class ProcessMixedContentClass(HandlerInterface):
         for attr in list(target.attrs):
             if attr.is_attribute:
                 attrs.append(attr)
-            elif attr.tag != Tag.ANY:
+            elif not attr.is_any_type:
                 choice = attr.clone()
                 choice.restrictions.min_occurs = None
                 choice.restrictions.max_occurs = None


### PR DESCRIPTION
## 📒 Description

Until now we ignored `xs:any` elements, but elements without a type are also wildcards.

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue


## 💬 Comments

> A place to write any comments to the reviewer.
>

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
