### PR TITLE
Fix bind wild text with only tail

### DIFF
--- a/tests/formats/dataclass/parsers/nodes/test_element.py
+++ b/tests/formats/dataclass/parsers/nodes/test_element.py
@@ -174,10 +174,10 @@ class ElementNodeTests(FactoryTestCase):
         self.assertEqual({"wildcard": ["txt", "tail"]}, params)
 
         self.node.bind_wild_text(params, var, None, "tail")
-        self.assertEqual({"wildcard": ["txt", "tail", "tail"]}, params)
+        self.assertEqual({"wildcard": [None, "txt", "tail", "tail"]}, params)
 
         self.node.bind_wild_text(params, var, "first", None)
-        self.assertEqual({"wildcard": ["first", "txt", "tail", "tail"]}, params)
+        self.assertEqual({"wildcard": ["first", None, "txt", "tail", "tail"]}, params)
 
     def test_bind_attrs(self):
         self.node.meta = self.context.build(AttrsType)

--- a/xsdata/formats/dataclass/parsers/nodes/element.py
+++ b/xsdata/formats/dataclass/parsers/nodes/element.py
@@ -311,10 +311,12 @@ class ElementNode(XmlNode):
             if items is None:
                 params[var.name] = items = PendingCollection(None, var.factory)
 
-            if txt:
-                items.insert(0, txt)
             if tail:
                 items.append(tail)
+
+            if txt or tail:
+                items.insert(0, txt)
+
         else:
             previous = params.get(var.name, None)
             factory = self.context.class_type.any_element


### PR DESCRIPTION
## 📒 Description

Fix issue when node has a tail but no text.

`<doc><b/>text<a/>text<d/>text<a/></doc>`

In this scenario we need to prepend `None` in the list otherwise tail becomes text


## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue


## 💬 Comments

> A place to write any comments to the reviewer.
>

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
