### PR TITLE
Support strict content process for wildcards

### DIFF
--- a/docs/models.rst
+++ b/docs/models.rst
@@ -176,7 +176,10 @@ binding procedures.
    * - format
      - str
      - Format option for types like datetime, or bytes, see :ref:`Data Types`
-
+   * - process_contents
+     - str
+     - Specify the level of validation for wildcard fields:
+       ``strict | skip``, default: ``strict`` will avoid using generics.
 
 The code generator adds also the field restrictions like `minLength` or `required` flag
 but currently they are only used to troubleshoot the code generator.

--- a/tests/codegen/models/test_restrictions.py
+++ b/tests/codegen/models/test_restrictions.py
@@ -23,6 +23,7 @@ class RestrictionsTests(TestCase):
             explicit_timezone="+1",
             nillable=True,
             path=[("s", 0, 1, 1)],
+            process_contents="skip",
         )
 
     def test_property_is_list(self):
@@ -89,6 +90,7 @@ class RestrictionsTests(TestCase):
             "min_length": 1,
             "nillable": True,
             "pattern": "[A-Z]",
+            "process_contents": "skip",
             "total_digits": 333,
             "white_space": "collapse",
         }
@@ -113,6 +115,7 @@ class RestrictionsTests(TestCase):
             "min_length": 1,
             "nillable": True,
             "pattern": "[A-Z]",
+            "process_contents": "skip",
             "total_digits": 333,
             "white_space": "collapse",
         }

--- a/tests/formats/dataclass/serializers/test_xml.py
+++ b/tests/formats/dataclass/serializers/test_xml.py
@@ -534,6 +534,29 @@ class XmlSerializerTests(TestCase):
         self.assertIsInstance(result, Generator)
         self.assertEqual(expected, list(result))
 
+    def test_write_choice_when_no_matching_choice_exists_but_value_is_model(self):
+        var = XmlVarFactory.create(
+            xml_type=XmlType.ELEMENTS,
+            name="compound",
+            qname="compound",
+            elements={
+                "a": XmlVarFactory.create(
+                    xml_type=XmlType.WILDCARD, qname="a", types=(object,)
+                )
+            },
+        )
+
+        ebook = make_dataclass("eBook", [], bases=(BookForm,))
+        expected = [
+            (XmlWriterEvent.START, "eBook"),
+            (XmlWriterEvent.ATTR, "lang", "en"),
+            (XmlWriterEvent.END, "eBook"),
+        ]
+
+        result = self.serializer.write_value(ebook(), var, None)
+        self.assertIsInstance(result, Generator)
+        self.assertEqual(expected, list(result))
+
     def test_write_choice_when_no_matching_choice_exists(self):
         var = XmlVarFactory.create(
             xml_type=XmlType.ELEMENTS,

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -167,7 +167,8 @@ class GeneratorConfigTests(TestCase):
             )
 
         else:
-            self.assertTrue(GeneratorOutput(union_type=True).union_type)
+            output = GeneratorOutput(union_type=True, postponed_annotations=True)
+            self.assertTrue(output.union_type)
 
     def test_format_slots_requires_310(self):
         if sys.version_info < (3, 10):

--- a/tests/models/xsd/test_any.py
+++ b/tests/models/xsd/test_any.py
@@ -39,4 +39,5 @@ class AnyTests(TestCase):
 
     def test_get_restrictions(self):
         obj = Any(min_occurs=1, max_occurs=2)
-        self.assertEqual({"max_occurs": 2, "min_occurs": 0}, obj.get_restrictions())
+        expected = {"max_occurs": 2, "min_occurs": 0, "process_contents": "strict"}
+        self.assertEqual(expected, obj.get_restrictions())

--- a/xsdata/codegen/models.py
+++ b/xsdata/codegen/models.py
@@ -37,29 +37,8 @@ GLOBAL_TYPES = (Tag.ELEMENT, Tag.BINDING_OPERATION, Tag.BINDING_MESSAGE, Tag.MES
 
 @dataclass
 class Restrictions:
-    """
-    Model representation of a dataclass field validation and type metadata.
-
-    :param min_occurs:
-    :param max_occurs:
-    :param min_exclusive:
-    :param min_inclusive:
-    :param min_length:
-    :param max_exclusive:
-    :param max_inclusive:
-    :param max_length:
-    :param total_digits:
-    :param fraction_digits:
-    :param length:
-    :param white_space:
-    :param pattern:
-    :param explicit_timezone:
-    :param nillable:
-    :param sequence:
-    :param tokens:
-    :param format:
-    :param choice:
-    """
+    """Model representation of a dataclass field validation and type
+    metadata."""
 
     min_occurs: Optional[int] = field(default=None)
     max_occurs: Optional[int] = field(default=None)
@@ -81,6 +60,7 @@ class Restrictions:
     format: Optional[str] = field(default=None)
     choice: Optional[int] = field(default=None)
     group: Optional[int] = field(default=None)
+    process_contents: Optional[str] = field(default=None)
     path: List[Tuple[str, int, int, int]] = field(default_factory=list)
 
     @property
@@ -128,6 +108,7 @@ class Restrictions:
             "white_space",
             "pattern",
             "explicit_timezone",
+            "process_contents",
         )
 
         for key in keys:
@@ -163,6 +144,9 @@ class Restrictions:
             ):
                 continue
 
+            if key == "process_contents" and value != "skip":
+                continue
+
             if key.endswith("clusive") and types:
                 value = converter.deserialize(value, sorted_types)
 
@@ -188,17 +172,8 @@ class AttrCategory(IntEnum):
 
 @dataclass(unsafe_hash=True)
 class AttrType:
-    """
-    Model representation for the typing information for fields and extensions.
-
-    :param qname:
-    :param alias:
-    :param reference:
-    :param native:
-    :param forward:
-    :param circular:
-    :param substituted:
-    """
+    """Model representation for the typing information for fields and
+    extensions."""
 
     qname: str
     alias: Optional[str] = field(default=None, compare=False)
@@ -232,22 +207,7 @@ class AttrType:
 
 @dataclass
 class Attr:
-    """
-    Model representation for a dataclass field.
-
-    :param tag:
-    :param name:
-    :param local_name:
-    :param index:
-    :param default:
-    :param fixed:
-    :param mixed:
-    :param types:
-    :param choices:
-    :param namespace:
-    :param help:
-    :param restrictions:
-    """
+    """Model representation for a dataclass field."""
 
     tag: str
     name: str = field(compare=False)
@@ -386,13 +346,7 @@ class Attr:
 
 @dataclass(unsafe_hash=True)
 class Extension:
-    """
-    Model representation of a dataclass base class.
-
-    :param tag:
-    :param type:
-    :param restrictions:
-    """
+    """Model representation of a dataclass base class."""
 
     tag: str
     type: AttrType
@@ -423,32 +377,8 @@ class Status(IntEnum):
 
 @dataclass
 class Class:
-    """
-    Model representation of a dataclass with fields, base/inner classes and
-    additional metadata settings.
-
-    :param qname:
-    :param tag:
-    :param location:
-    :param mixed:
-    :param abstract:
-    :param nillable:
-    :param local_type:
-    :param status:
-    :param container:
-    :param package:
-    :param module:
-    :param namespace:
-    :param help:
-    :param meta_name:
-    :param default:
-    :param fixed:
-    :param substitutions:
-    :param extensions:
-    :param attrs:
-    :param inner:
-    :param ns_map:
-    """
+    """Model representation of a dataclass with fields, base/inner classes and
+    additional metadata settings."""
 
     qname: str
     tag: str

--- a/xsdata/formats/dataclass/models/builders.py
+++ b/xsdata/formats/dataclass/models/builders.py
@@ -272,6 +272,7 @@ class XmlVarBuilder:
         namespace = metadata.get("namespace")
         choices = metadata.get("choices", EMPTY_SEQUENCE)
         mixed = metadata.get("mixed", False)
+        process_contents = metadata.get("process_contents", "strict")
         required = metadata.get("required", False)
         nillable = metadata.get("nillable", False)
         format_str = metadata.get("format", None)
@@ -331,6 +332,7 @@ class XmlVarBuilder:
             format=format_str,
             clazz=clazz,
             any_type=any_type,
+            process_contents=process_contents,
             required=required,
             nillable=nillable,
             sequence=sequence,

--- a/xsdata/formats/dataclass/models/elements.py
+++ b/xsdata/formats/dataclass/models/elements.py
@@ -90,6 +90,7 @@ class XmlVar(MetaMixin):
         "format",
         "derived",
         "any_type",
+        "process_contents",
         "required",
         "nillable",
         "sequence",
@@ -126,6 +127,7 @@ class XmlVar(MetaMixin):
         format: Optional[str],
         derived: bool,
         any_type: bool,
+        process_contents: str,
         required: bool,
         nillable: bool,
         sequence: Optional[int],
@@ -148,6 +150,7 @@ class XmlVar(MetaMixin):
         self.format = format
         self.derived = derived
         self.any_type = any_type
+        self.process_contents = process_contents
         self.required = required
         self.nillable = nillable
         self.sequence = sequence

--- a/xsdata/formats/dataclass/parsers/tree.py
+++ b/xsdata/formats/dataclass/parsers/tree.py
@@ -52,6 +52,7 @@ class TreeParser(NodeParser):
                 format=None,
                 derived=False,
                 any_type=False,
+                process_contents="strict",
                 required=False,
                 nillable=False,
                 sequence=None,

--- a/xsdata/models/xsd.py
+++ b/xsdata/models/xsd.py
@@ -389,7 +389,9 @@ class Any(AnnotationBase):
     namespace: str = attribute(default="##any")
     min_occurs: int = attribute(default=1, name="minOccurs")
     max_occurs: UnionType[int, str] = attribute(default=1, name="maxOccurs")
-    process_contents: Optional[ProcessType] = attribute(name="processContents")
+    process_contents: ProcessType = attribute(
+        default=ProcessType.STRICT, name="processContents"
+    )
 
     def __post_init__(self):
         self.namespace = " ".join(unique_sequence(self.namespace.split()))
@@ -417,6 +419,7 @@ class Any(AnnotationBase):
         return {
             "min_occurs": 0,
             "max_occurs": max_occurs,
+            "process_contents": self.process_contents.value,
         }
 
 

--- a/xsdata/utils/testing.py
+++ b/xsdata/utils/testing.py
@@ -421,6 +421,7 @@ class XmlVarFactory(Factory):
             required=required,
             nillable=nillable,
             sequence=sequence,
+            process_contents="strict",
             list_element=list_element,
             default=default,
             xml_type=xml_type,


### PR DESCRIPTION
## 📒 Description

Wildcards with `process_contents != skip` will force the parser to look for the target class by the qualified name of the element and avoid using of the generic classes.


Resolves #803 

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue


## 💬 Comments

> A place to write any comments to the reviewer.
>

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
