### PR TITLE
Ignore xsi attrs when fail on unknown attributes is enabled

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
       - id: docformatter
         args: [ "--in-place", "--pre-summary-newline" ]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.0
+    rev: v1.5.1
     hooks:
       - id: mypy
         files: ^(xsdata/)

--- a/tests/formats/dataclass/parsers/nodes/test_element.py
+++ b/tests/formats/dataclass/parsers/nodes/test_element.py
@@ -221,6 +221,15 @@ class ElementNodeTests(FactoryTestCase):
 
         self.assertEqual("Unknown attribute ExtendedType:a", str(cm.exception))
 
+    def test_bind_with_fail_on_unknown_attributes_ignores_xsi_attributes(self):
+        self.node.meta = self.context.build(ExtendedType)
+        self.node.config.fail_on_unknown_attributes = True
+        self.node.attrs = {QNames.XSI_TYPE: "b"}
+
+        objects = []
+        self.node.bind("foo", "text", "tail", objects)
+        self.assertEqual(1, len(objects))
+
     @mock.patch("xsdata.formats.dataclass.parsers.nodes.element.logger.warning")
     def test_bind_objects(self, mock_warning):
         self.node.meta = self.context.build(TypeC)

--- a/xsdata/formats/dataclass/parsers/nodes/element.py
+++ b/xsdata/formats/dataclass/parsers/nodes/element.py
@@ -17,6 +17,8 @@ from xsdata.formats.dataclass.parsers.utils import ParserUtils
 from xsdata.formats.dataclass.parsers.utils import PendingCollection
 from xsdata.logger import logger
 from xsdata.models.enums import DataType
+from xsdata.models.enums import Namespace
+from xsdata.utils.namespaces import target_uri
 
 
 class ElementNode(XmlNode):
@@ -134,7 +136,10 @@ class ElementNode(XmlNode):
                 if var:
                     self.bind_any_attr(params, var, qname, value)
                 else:
-                    if self.config.fail_on_unknown_attributes:
+                    if (
+                        self.config.fail_on_unknown_attributes
+                        and target_uri(qname) != Namespace.XSI.uri
+                    ):
                         raise ParserError(
                             f"Unknown attribute {self.meta.qname}:{qname}"
                         )


### PR DESCRIPTION
## 📒 Description

xsi:attributes should be ignored when we enable the parser config option `fail_on_unknown_attributes`


Resolves #845

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue


## 💬 Comments

> A place to write any comments to the reviewer.
>

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
