### PR TITLE
This is a prototype for #854

### DIFF
--- a/xsdata/codegen/models.py
+++ b/xsdata/codegen/models.py
@@ -62,6 +62,7 @@ class Restrictions:
     group: Optional[int] = field(default=None)
     process_contents: Optional[str] = field(default=None)
     path: List[Tuple[str, int, int, int]] = field(default_factory=list)
+    is_null: bool = field(default=False)
 
     @property
     def is_list(self) -> bool:

--- a/xsdata/formats/dataclass/filters.py
+++ b/xsdata/formats/dataclass/filters.py
@@ -127,6 +127,7 @@ class Filters:
                 "field_default": self.field_default_value,
                 "field_metadata": self.field_metadata,
                 "field_definition": self.field_definition,
+                "is_null": self.is_null,
                 "class_name": self.class_name,
                 "class_bases": self.class_bases,
                 "class_annotations": self.class_annotations,
@@ -222,6 +223,12 @@ class Filters:
             name = re.sub(rf"{search}", rf"{replace}", name)
 
         return name
+
+    def is_null(
+        self,
+        attr: Attr
+    ) -> bool:
+        return attr.restrictions.is_null
 
     def field_definition(
         self,

--- a/xsdata/formats/dataclass/templates/class.jinja2
+++ b/xsdata/formats/dataclass/templates/class.jinja2
@@ -44,7 +44,7 @@ class {{ class_name }}{{"({})".format(base_classes) if base_classes }}:
 {%- for attr in obj.attrs %}
     {%- set field_typing = attr|field_type(parents) %}
     {%- set field_definition = attr|field_definition(obj.ns_map, parent_namespace, parents) %}
-    {{ attr.name|field_name(obj.name) }}: {{ field_typing }} = {{ field_definition }}
+    {{ attr.name|field_name(obj.name) }}: {%- if attr|is_null %} None {%- else %} {{ field_typing }} = {{ field_definition }} {%- endif -%}
 {%- endfor -%}
 {%- for inner in obj.inner %}
     {%- set tpl = "enum.jinja2" if inner.is_enumeration else "class.jinja2" -%}


### PR DESCRIPTION
## 📒 Description

When a restriction is set, the ideal situation for the datamodel would be that only the properties that fall under the restriction are available. In the current situation, due to inheritance all attributes are available, while only some ore valid.

Open issue: it seems that **XML-attributes** that are made available via a group within a restriction are not resolved, and therefore invalidly removed. 

Prototype for #854 

## 🔗 What I've Done

I have added some code that creates 'null' fields when the inherited attributes are restricted. They are at rendering replaced with None.

## 💬 Comments

From https://www.reddit.com/r/learnpython/comments/12qhzi6/dataclasses_with_inheritance/ I found that kw_only was used to resolve the issue with non-default argument 'class name' follows default argument.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
