### PR TITLE
Type hints for compound fields

### DIFF
--- a/tests/codegen/handlers/test_create_compound_fields.py
+++ b/tests/codegen/handlers/test_create_compound_fields.py
@@ -92,7 +92,7 @@ class CreateCompoundFieldsTests(FactoryTestCase):
             name="choice",
             tag="Choice",
             index=0,
-            types=[AttrTypeFactory.native(DataType.ANY_TYPE)],
+            types=list({t for attr in target.attrs for t in attr.types}),
             choices=[
                 AttrFactory.create(
                     tag=target.attrs[0].tag,

--- a/tests/fixtures/compound/models.py
+++ b/tests/fixtures/compound/models.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import List
+from typing import List, Union
 
 
 @dataclass
@@ -35,7 +35,7 @@ class Root:
     class Meta:
         name = "root"
 
-    alpha_or_bravo: List[object] = field(
+    alpha_or_bravo: List[Union[Bravo, Alpha]] = field(
         default_factory=list,
         metadata={
             "type": "Elements",

--- a/xsdata/codegen/handlers/create_compound_fields.py
+++ b/xsdata/codegen/handlers/create_compound_fields.py
@@ -7,13 +7,11 @@ from typing import Tuple
 from xsdata.codegen.mixins import ContainerInterface
 from xsdata.codegen.mixins import RelativeHandlerInterface
 from xsdata.codegen.models import Attr
-from xsdata.codegen.models import AttrType
 from xsdata.codegen.models import Class
 from xsdata.codegen.models import get_restriction_choice
 from xsdata.codegen.models import Restrictions
 from xsdata.codegen.utils import ClassUtils
 from xsdata.formats.dataclass.models.elements import XmlType
-from xsdata.models.enums import DataType
 from xsdata.models.enums import Tag
 from xsdata.utils.collections import group_by
 
@@ -86,18 +84,18 @@ class CreateCompoundFields(RelativeHandlerInterface):
             ClassUtils.remove_attribute(target, attr)
             names.append(attr.local_name)
             choices.append(self.build_attr_choice(attr))
-
             self.update_counters(attr, counters)
 
         min_occurs, max_occurs = self.sum_counters(counters)
         name = self.choose_name(target, names)
+        types = list({t for attr in attrs for t in attr.types})
 
         target.attrs.insert(
             pos,
             Attr(
                 name=name,
                 index=0,
-                types=[AttrType(qname=str(DataType.ANY_TYPE), native=True)],
+                types=types,
                 tag=Tag.CHOICE,
                 restrictions=Restrictions(
                     min_occurs=sum(min_occurs),

--- a/xsdata/formats/dataclass/models/builders.py
+++ b/xsdata/formats/dataclass/models/builders.py
@@ -526,8 +526,8 @@ class XmlVarBuilder:
             # xs:NMTOKENS need origin list
             return False
 
-        if object in types:
-            # Any type, secondary types are not allowed
+        if object in types and xml_type != XmlType.ELEMENTS:
+            # Any type, secondary types are not allowed except for 'Elements' XML type
             return len(types) == 1
 
         return self.is_typing_supported(types)

--- a/xsdata/formats/dataclass/models/elements.py
+++ b/xsdata/formats/dataclass/models/elements.py
@@ -176,10 +176,10 @@ class XmlVar(MetaMixin):
         self.is_attribute = False
         self.is_attributes = False
 
-        if xml_type == XmlType.ELEMENT or self.clazz:
-            self.is_element = True
-        elif xml_type == XmlType.ELEMENTS:
+        if xml_type == XmlType.ELEMENTS:
             self.is_elements = True
+        elif xml_type == XmlType.ELEMENT or self.clazz:
+            self.is_element = True
         elif xml_type == XmlType.ATTRIBUTE:
             self.is_attribute = True
         elif xml_type == XmlType.ATTRIBUTES:


### PR DESCRIPTION
## 📒 Description

Compound fields are no longer type-hinted as `list[object]`.
Instead, the type hints of compound fields now reflect the types in the corresponding `<xsd:choice>` definition.

Resolves #857

## 🔗 What I've Done
* Changed the compound field handler in `xsdata/codegen/handlers/create_compound_fields.py` such that it passes a de-duplicated list comprising the types of the combined choices as type hints.
* Adjusted the expected attribute in `tests/codegen/handlers/test_create_compound_fields.py`accordingly.
* Changed the resulting model in `tests/fixtures/compound/models.py`accordingly.
* To not break the `XmlParser`, I had to reorder the logic in `XmlVar.is_element`/`XmlVar.is_elements` determination such that `XmlType.ELEMENTS` is picked up before `XmlType.ELEMENT`.
* I changed `XmlVarBuilder.is_valid()` such that `object` is allowed to be listed along with other types in a `Union` for XML type `XmlType.ELEMENTS`.
  This is useful to get proper type hinting when working with xsdata-generated code in an IDE.

## 💬 Comments
Are there additional tests needed explicitly covering this feature?

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [x] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
