### PR TITLE
Add lib headers when loading resources

### DIFF
--- a/xsdata/codegen/__init__.py
+++ b/xsdata/codegen/__init__.py
@@ -1,0 +1,6 @@
+from urllib.request import build_opener
+
+from xsdata import __version__
+
+opener = build_opener()
+opener.addheaders = [("User-agent", f"xsdata/{__version__}")]

--- a/xsdata/codegen/transformer.py
+++ b/xsdata/codegen/transformer.py
@@ -12,8 +12,8 @@ from typing import List
 from typing import NamedTuple
 from typing import Optional
 from typing import Tuple
-from urllib.request import urlopen
 
+from xsdata.codegen import opener
 from xsdata.codegen.analyzer import ClassAnalyzer
 from xsdata.codegen.container import ClassContainer
 from xsdata.codegen.mappers.definitions import DefinitionsMapper
@@ -294,7 +294,7 @@ class SchemaTransformer:
         if uri not in self.processed:
             try:
                 self.processed.append(uri)
-                return self.preloaded.pop(uri, None) or urlopen(uri).read()  # nosec
+                return self.preloaded.pop(uri, None) or opener.open(uri).read()  # nosec
             except OSError:
                 logger.warning("Resource not found %s", uri)
         else:

--- a/xsdata/utils/downloader.py
+++ b/xsdata/utils/downloader.py
@@ -4,8 +4,8 @@ from pathlib import Path
 from typing import Dict
 from typing import Optional
 from typing import Union
-from urllib.request import urlopen
 
+from xsdata.codegen import opener
 from xsdata.codegen.parsers import DefinitionsParser
 from xsdata.codegen.parsers import SchemaParser
 from xsdata.logger import logger
@@ -37,7 +37,7 @@ class Downloader:
 
             logger.info("Fetching %s", uri)
 
-            input_stream = urlopen(uri).read()  # nosec
+            input_stream = opener.open(uri).read()  # nosec
             if uri.endswith("wsdl"):
                 self.parse_definitions(uri, input_stream)
             else:


### PR DESCRIPTION
## 📒 Description


xsdata generate/download commands work with remote resources (http/https/...) but certain servers fail with 403 because the library is not sending any headers.


Resolves #866 

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue


## 💬 Comments

> A place to write any comments to the reviewer.
>

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
