### PR TITLE
Handle parsing mandatory byte elements with no value

### DIFF
--- a/tests/formats/dataclass/parsers/nodes/test_primitive.py
+++ b/tests/formats/dataclass/parsers/nodes/test_primitive.py
@@ -58,6 +58,25 @@ class PrimitiveNodeTests(TestCase):
         self.assertTrue(node.bind("foo", None, None, objects))
         self.assertIsNone(objects[-1][1])
 
+    def test_bind_nillable_bytes_content(self):
+        var = XmlVarFactory.create(
+            xml_type=XmlType.TEXT,
+            name="foo",
+            qname="foo",
+            types=(bytes,),
+            nillable=False,
+        )
+        ns_map = {"foo": "bar"}
+        node = PrimitiveNode(var, ns_map, False, DerivedElement)
+        objects = []
+
+        self.assertTrue(node.bind("foo", None, None, objects))
+        self.assertEqual(b"", objects[-1][1])
+
+        var.nillable = True
+        self.assertTrue(node.bind("foo", None, None, objects))
+        self.assertIsNone(objects[-1][1])
+
     def test_bind_mixed_with_tail_content(self):
         var = XmlVarFactory.create(
             xml_type=XmlType.TEXT, name="foo", types=(int,), derived=True

--- a/xsdata/formats/dataclass/parsers/nodes/primitive.py
+++ b/xsdata/formats/dataclass/parsers/nodes/primitive.py
@@ -40,7 +40,10 @@ class PrimitiveNode(XmlNode):
         )
 
         if obj is None and not self.var.nillable:
-            obj = ""
+            if bytes in self.var.types:
+                obj = b""
+            else:
+                obj = ""
 
         if self.var.derived:
             obj = self.derived_factory(qname=qname, value=obj)


### PR DESCRIPTION
## 📒 Description

Fixes parsing of empty mandatory byte elements to produce a byte string instead of a unicode string.

Resolves #872 

## 🔗 What I've Done

Adds special handling to the `PrimitiveNode.bind()` method if the incoming type is bytes.


## 💬 Comments

An alternative solution here might be to iterate through the list of incoming types (`self.var.types`) and attempt to construct a default value. However I'm not aware of any cases other than strings or bytes where this method would be called, so it may be overkill.

## 🛫 Checklist

- [ ] Updated docs
- [x] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
