### PR TITLE
Enable validation when decoding base64 data

### DIFF
--- a/tests/formats/test_converter.py
+++ b/tests/formats/test_converter.py
@@ -223,6 +223,9 @@ class BytesConverterTests(TestCase):
         with self.assertRaises(ConverterError):
             self.converter.deserialize("aaa", format="base16")
 
+        with self.assertRaises(ConverterError):
+            self.converter.deserialize("AA~AA", format="base64")
+
     def test_unknown_formats(self):
         with self.assertRaises(ConverterError):
             self.converter.serialize("foo")

--- a/xsdata/formats/converter.py
+++ b/xsdata/formats/converter.py
@@ -295,7 +295,7 @@ class BytesConverter(Converter):
                 return binascii.unhexlify(value)
 
             if fmt == "base64":
-                return base64.b64decode(value)
+                return base64.b64decode(value, validate=True)
 
             raise ConverterError(f"Unknown format '{fmt}'")
         except ValueError as e:


### PR DESCRIPTION
## 📒 Description

Enables validation on calls to `base64.b64decode()` so that both base16 and base64 will raise a `ConverterError` if invalid characters are decoded.


Resolves #874

## 🔗 What I've Done

Pass `validate=True` to `b64decode()` method. Also implemented a unit test to exercise the behavior.


## 💬 Comments

None

## 🛫 Checklist

- [ ] Updated docs
- [x] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
