### PR TITLE
Fix PycodeSerializer to escape unicode characters in string values

### DIFF
--- a/tests/formats/dataclass/serializers/test_code.py
+++ b/tests/formats/dataclass/serializers/test_code.py
@@ -65,6 +65,24 @@ class PycodeSerializerTests(TestCase):
         )
         self.assertEqual(expected, result)
 
+    def test_write_string_with_unicode_characters(self):
+        books = Books(book=[BookForm(author="Backslashes \\ One Two \x12 Three")])
+        result = self.serializer.render(books, var_name="books")
+        expected = (
+            "from tests.fixtures.books.books import BookForm\n"
+            "from tests.fixtures.books.books import Books\n"
+            "\n"
+            "\n"
+            "books = Books(\n"
+            "    book=[\n"
+            "        BookForm(\n"
+            '            author="Backslashes \\\\ One Two \\x12 Three"\n'
+            "        ),\n"
+            "    ]\n"
+            ")\n"
+        )
+        self.assertEqual(expected, result)
+
     def test_write_object_with_empty_array(self):
         iterator = self.serializer.write_object([], 0, set())
         self.assertEqual("[]", "".join(iterator))

--- a/xsdata/utils/objects.py
+++ b/xsdata/utils/objects.py
@@ -21,7 +21,7 @@ def attrsetter(obj: Any, attr: str, value: Any):
 
 def literal_value(value: Any) -> str:
     if isinstance(value, str):
-        return quoteattr(value)
+        return quoteattr(value.encode("unicode_escape").decode("ASCII"))
 
     if isinstance(value, float):
         return str(value) if math.isfinite(value) else f'float("{value}")'


### PR DESCRIPTION
## 📒 Description

Ensure that unicode characters in `PycodeSerializer` are correctly escaped and form valid Python code.


Resolves #876

## 🔗 What I've Done

Escapes any unicode characters in strings while still being represented as ASCII data. Also implements a unit test to exhibit desired behavior.


## 💬 Comments

None

## 🛫 Checklist

- [ ] Updated docs
- [x] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
