### PR TITLE
Add special handling in PycodeSerializer for bytes

### DIFF
--- a/tests/formats/dataclass/serializers/test_code.py
+++ b/tests/formats/dataclass/serializers/test_code.py
@@ -104,6 +104,11 @@ class PycodeSerializerTests(TestCase):
         iterator = self.serializer.write_object(Namespace.SOAP11, 0, set())
         self.assertEqual("Namespace.SOAP11", "".join(iterator))
 
+    def test_write_bytes_with_single_quote(self):
+        iterator = self.serializer.write_object(b"\xfaj'", 0, set())
+        self.assertEqual("b\"\\xfaj'\"", "".join(iterator))
+
+
     def test_build_imports_with_nested_types(self):
         expected = "from tests.fixtures.models import Parent\n"
         actual = self.serializer.build_imports({Parent.Inner})

--- a/tests/formats/dataclass/serializers/test_code.py
+++ b/tests/formats/dataclass/serializers/test_code.py
@@ -104,10 +104,12 @@ class PycodeSerializerTests(TestCase):
         iterator = self.serializer.write_object(Namespace.SOAP11, 0, set())
         self.assertEqual("Namespace.SOAP11", "".join(iterator))
 
-    def test_write_bytes_with_single_quote(self):
-        iterator = self.serializer.write_object(b"\xfaj'", 0, set())
-        self.assertEqual("b\"\\xfaj'\"", "".join(iterator))
+    def test_write_bytes(self):
+        iterator = self.serializer.write_object(b"a", 0, set())
+        self.assertEqual('b"a"', "".join(iterator))
 
+        iterator = self.serializer.write_object(b"\xfa\"'", 0, set())
+        self.assertEqual('b"\\xfa"\\\'"', "".join(iterator))
 
     def test_build_imports_with_nested_types(self):
         expected = "from tests.fixtures.models import Parent\n"

--- a/xsdata/utils/objects.py
+++ b/xsdata/utils/objects.py
@@ -1,4 +1,5 @@
 import math
+import re
 from typing import Any
 from xml.etree.ElementTree import QName
 from xml.sax.saxutils import quoteattr
@@ -30,6 +31,8 @@ def literal_value(value: Any) -> str:
         return f'QName("{value.text}")'
 
     if isinstance(value, bytes):
-        return repr(value)
+        # Use the contents of the bytes verbatim, but ensure that it is
+        # wrapped in double quotes
+        return re.sub(r"b'(.*)'$", r'b"\g<1>"', repr(value))
 
     return repr(value).replace("'", '"')

--- a/xsdata/utils/objects.py
+++ b/xsdata/utils/objects.py
@@ -29,4 +29,7 @@ def literal_value(value: Any) -> str:
     if isinstance(value, QName):
         return f'QName("{value.text}")'
 
+    if isinstance(value, bytes):
+        return repr(value)
+
     return repr(value).replace("'", '"')


### PR DESCRIPTION
## 📒 Description

Adds special handling to `PycodeSerializer` to ensure that byte strings are not modified and that their representation is handled literally.


Resolves #878

## 🔗 What I've Done

Update `literal_value()` to add special handling for byte strings, so that the literal `repr()` of the string is used, instead of falling back to the default call to `repr()` which subsequently replaces single quotes in the resulting string.

Also adds a quick unit test to exhibit the fix.


## 💬 Comments


## 🛫 Checklist

- [ ] Updated docs
- [x] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [x] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
