### PR TITLE
Generate valid variable names when using originalCase naming convention

### DIFF
--- a/tests/formats/dataclass/test_filters.py
+++ b/tests/formats/dataclass/test_filters.py
@@ -159,6 +159,9 @@ class FiltersTests(FactoryTestCase):
         self.assertEqual("value_minus_1_1", self.filters.field_name("-1.1", "cls"))
         self.assertEqual("cbad", self.filters.field_name("abcd", "cls"))
 
+        self.filters.field_case = NameCase.ORIGINAL
+        self.assertEqual("foo", self.filters.field_name("@foo", "cls"))
+
     def test_constant_name(self):
         self.filters.substitutions[ObjectType.FIELD]["ABC"] = "CBA"
 

--- a/tests/utils/test_text.py
+++ b/tests/utils/test_text.py
@@ -15,6 +15,7 @@ from xsdata.utils.text import screaming_snake_case
 from xsdata.utils.text import snake_case
 from xsdata.utils.text import split_words
 from xsdata.utils.text import StringType
+from xsdata.utils.text import variable
 
 
 class TextTests(TestCase):
@@ -142,6 +143,13 @@ class TextTests(TestCase):
         self.assertEqual("foo1", alnum("\tfoo*1"))
         self.assertEqual("foo1", alnum(" foo*1"))
         self.assertEqual("1", alnum(" βιβλίο*1"))
+
+    def test_variable(self):
+        self.assertEqual("foO1", variable("foO1"))
+        self.assertEqual("foo_1", variable("foo_1"))
+        self.assertEqual("foo1", variable("foo-1"))
+        self.assertEqual("foo1", variable("@foo1"))
+        self.assertEqual("foo1", variable("1foo1"))
 
     def test_classify(self):
         for ltr in string.ascii_uppercase:

--- a/xsdata/formats/dataclass/filters.py
+++ b/xsdata/formats/dataclass/filters.py
@@ -319,7 +319,7 @@ class Filters:
         if not slug or not slug[0].isalpha():
             return self.safe_name(f"{prefix}_{name}", prefix, name_case, **kwargs)
 
-        result = name_case(name, **kwargs)
+        result = text.variable(name_case(name, **kwargs))
         if text.is_reserved(result):
             return self.safe_name(f"{name}_{prefix}", prefix, name_case, **kwargs)
 

--- a/xsdata/utils/text.py
+++ b/xsdata/utils/text.py
@@ -226,3 +226,11 @@ def alnum(value: str) -> str:
     """Return a lower case version of the string only with ascii alphanumerical
     characters."""
     return "".join(filter(__alnum_ascii__.__contains__, value)).lower()
+
+
+def variable(value: str) -> str:
+    """Returns a version of the string that will be a valid Python variable."""
+    # Strip out all characters that are not alphanumeric or underscores
+    value = re.sub(r"\W", "", value)
+    # Then strip out leading digit and underscore characters
+    return re.sub(r"^[^a-zA-Z]+", "", value)


### PR DESCRIPTION
## 📒 Description

When using `originalCase` naming syntax for classes or fields where the names have been generated by the library, ensure that only valid characters are used for the variable in the generated Python code.


Resolves #880 

## 🔗 What I've Done

Implements a new method in the `utils.text` library named `variable()`, which will use some simple regex matching to strip out anything except alphanumeric characters and underscores from the variable name. It will also ensure that a variable name does not start with a digit character.

This resolves both of the examples listed in #880.


## 💬 Comments

None

## 🛫 Checklist

- [ ] Updated docs
- [x] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [x] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
