### PR TITLE
Maintain forward references when generating a recursive schema

### DIFF
--- a/tests/formats/dataclass/test_filters.py
+++ b/tests/formats/dataclass/test_filters.py
@@ -743,6 +743,10 @@ class FiltersTests(FactoryTestCase):
         actual = self.filters.choice_type(choice, ["a", "b"])
         self.assertEqual("Type[Foobar]", actual)
 
+        choice.types[0].substituted = True
+        actual = self.filters.choice_type(choice, ["a", "b"])
+        self.assertEqual('Type["Foobar"]', actual)
+
     def test_choice_type_with_multiple_types(self):
         choice = AttrFactory.create(types=[type_str, type_bool])
         actual = self.filters.choice_type(choice, ["a", "b"])

--- a/xsdata/formats/dataclass/filters.py
+++ b/xsdata/formats/dataclass/filters.py
@@ -754,7 +754,9 @@ class Filters:
         elif attr_type.circular:
             name = f'"{name}"'
 
-        if self.postponed_annotations:
+        if self.postponed_annotations and not (
+            attr_type.substituted and attr_type.circular
+        ):
             name = name.strip('"')
 
         return name


### PR DESCRIPTION
## 📒 Description

Ensures that compound fields in dataclasses maintain forward references for recursively defined types, even if postponed annotations are enabled.


Resolves #882

## 🔗 What I've Done

Adds an extra check to `xsdata.formats.dataclass.filters.Filters.field_type_name()` to ensure that the given attribute is not a circular reference, before stripping its surrounding `"` characters. If it is a circular reference, the type will retain its surrounding `"` characters.


## 💬 Comments


## 🛫 Checklist

- [ ] Updated docs
- [x] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [x] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
