### PR TITLE
Add a colon to enable google style docstring parsing (trivial)

### DIFF
--- a/tests/fixtures/books/books.py
+++ b/tests/fixtures/books/books.py
@@ -10,7 +10,7 @@ class BookForm:
     """
     Book Definition.
 
-    Attributes
+    Attributes:
         author: Writer's name
         title: Book Title
         genre: Book Genre

--- a/tests/fixtures/docstrings/google/schema.py
+++ b/tests/fixtures/docstrings/google/schema.py
@@ -24,7 +24,7 @@ class DoubleQuotesSummary:
 
 class RootEnum(Enum):
     """
-    Attributes
+    Attributes:
         A: Lorem ipsum dolor
         B: Lorem ipsum dolor '''sit''' amet, consectetur adipiscing
             elit. Morbi dapibus. My\\Ipsum
@@ -35,7 +35,7 @@ class RootEnum(Enum):
 
 class RootB(Enum):
     """
-    Attributes
+    Attributes:
         YES: This is an inner enum member documentation. Lorem ipsum
             dolor sit amet, consectetur adipiscing elit. Etiam mollis.
         NO: Lorem ipsum dolor My\\Ipsum
@@ -58,7 +58,7 @@ class Root:
     Donec imperdiet lacus sed sagittis scelerisque. Ut sodales metus:
     "sit", "amet", "lectus" My\\Ipsum
 
-    Attributes
+    Attributes:
         a: This is an inner type '''field''' documentation. Lorem ipsum
             dolor sit amet, consectetur adipiscing elit. Aliquam nec.
             My\\Ipsum
@@ -107,7 +107,7 @@ class Root:
         """
         This is an inner type documentation.
 
-        Attributes
+        Attributes:
             sub_a: This is an inner type '''field''' documentation.
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit.
                 Vivamus efficitur. My\\Ipsum

--- a/xsdata/formats/dataclass/templates/docstrings.google.jinja2
+++ b/xsdata/formats/dataclass/templates/docstrings.google.jinja2
@@ -1,7 +1,7 @@
 {% set offset = (level + 2) * 4 + 7 -%}
 {{ '"""{}"""'.format(obj.help | clean_docstring) }}
 {% if obj.has_help_attr %}
-Attributes
+Attributes:
 {%- for var_name, var_doc in obj | class_params %}
 {{ "{}: {}".format(var_name, var_doc) | text_wrap(offset) | indent(first=True) }}
 {%- endfor -%}


### PR DESCRIPTION
## 📒 Description

I tried to generate mkdocs of the generated classes with
https://mkdocstrings.github.io/python/

It fails because a colon is missing:
https://google.github.io/styleguide/pyguide.html#384-classes


## 🔗 What I've Done

I added a colon to the doctring Jinja Template 


## 💬 Comments


## 🛫 Checklist

- ~~Updated docs~~
- ~~Added unit-tests~~
- [x] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [x] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
