### PR TITLE
fix: Maintain compound field types ordering

### DIFF
--- a/tests/codegen/handlers/test_create_compound_fields.py
+++ b/tests/codegen/handlers/test_create_compound_fields.py
@@ -4,10 +4,9 @@ from xsdata.codegen.container import ClassContainer
 from xsdata.codegen.handlers import CreateCompoundFields
 from xsdata.codegen.models import Restrictions
 from xsdata.models.config import GeneratorConfig
-from xsdata.models.enums import DataType
 from xsdata.models.enums import Tag
+from xsdata.utils import collections
 from xsdata.utils.testing import AttrFactory
-from xsdata.utils.testing import AttrTypeFactory
 from xsdata.utils.testing import ClassFactory
 from xsdata.utils.testing import ExtensionFactory
 from xsdata.utils.testing import FactoryTestCase
@@ -92,7 +91,9 @@ class CreateCompoundFieldsTests(FactoryTestCase):
             name="choice",
             tag="Choice",
             index=0,
-            types=list({t for attr in target.attrs for t in attr.types}),
+            types=collections.unique_sequence(
+                t for attr in target.attrs for t in attr.types
+            ),
             choices=[
                 AttrFactory.create(
                     tag=target.attrs[0].tag,

--- a/xsdata/codegen/handlers/create_compound_fields.py
+++ b/xsdata/codegen/handlers/create_compound_fields.py
@@ -13,6 +13,7 @@ from xsdata.codegen.models import Restrictions
 from xsdata.codegen.utils import ClassUtils
 from xsdata.formats.dataclass.models.elements import XmlType
 from xsdata.models.enums import Tag
+from xsdata.utils import collections
 from xsdata.utils.collections import group_by
 
 ALL = "a"
@@ -88,7 +89,7 @@ class CreateCompoundFields(RelativeHandlerInterface):
 
         min_occurs, max_occurs = self.sum_counters(counters)
         name = self.choose_name(target, names)
-        types = list({t for attr in attrs for t in attr.types})
+        types = collections.unique_sequence(t for attr in attrs for t in attr.types)
 
         target.attrs.insert(
             pos,


### PR DESCRIPTION
## 📒 Description

The new compound fields types feature, is generating the types in random order in every generation.


Resolves #xxxx

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue


## 💬 Comments

> A place to write any comments to the reviewer.
>

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
