### PR TITLE
fix: Always keep forward references for choice types

### DIFF
--- a/tests/formats/dataclass/test_filters.py
+++ b/tests/formats/dataclass/test_filters.py
@@ -741,7 +741,7 @@ class FiltersTests(FactoryTestCase):
 
         self.filters.postponed_annotations = True
         actual = self.filters.choice_type(choice, ["a", "b"])
-        self.assertEqual("Type[Foobar]", actual)
+        self.assertEqual('Type["Foobar"]', actual)
 
     def test_choice_type_with_multiple_types(self):
         choice = AttrFactory.create(types=[type_str, type_bool])

--- a/xsdata/formats/dataclass/filters.py
+++ b/xsdata/formats/dataclass/filters.py
@@ -720,7 +720,7 @@ class Filters:
         is also ignored.
         """
         type_names = collections.unique_sequence(
-            self.field_type_name(x, parents) for x in choice.types
+            self.field_type_name(x, parents, choice=True) for x in choice.types
         )
 
         if self.union_type:
@@ -742,7 +742,9 @@ class Filters:
 
         return f"Type[{result}]"
 
-    def field_type_name(self, attr_type: AttrType, parents: List[str]) -> str:
+    def field_type_name(
+        self, attr_type: AttrType, parents: List[str], choice: bool = False
+    ) -> str:
         name = self.type_name(attr_type)
 
         if attr_type.forward and attr_type.circular:
@@ -754,7 +756,7 @@ class Filters:
         elif attr_type.circular:
             name = f'"{name}"'
 
-        if self.postponed_annotations:
+        if self.postponed_annotations and not choice:
             name = name.strip('"')
 
         return name


### PR DESCRIPTION
## 📒 Description

Ensures that compound fields in dataclasses maintain forward references, even if postponed annotations are enabled.


Resolves #882

## 🔗 What I've Done

Add the choice exception to the postpone annotations rule

## 💬 Comments

> A place to write any comments to the reviewer.
>

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
