### PR TITLE
Add config option to use substitution names for compound fields when available

### DIFF
--- a/docs/examples/compound-fields.rst
+++ b/docs/examples/compound-fields.rst
@@ -22,7 +22,9 @@ fields in order to preserve the elements ordering during roundtrip conversions.
         :lines: 33-53
 
 
-All choice elements are grouped into a single list field.
+All choice elements are grouped into a single field. The name of field
+can be manipulated with the :class:`~xsdata.models.config.CompoundFields`
+configuration.
 
 .. testcode::
 

--- a/tests/codegen/handlers/test_add_attribute_substitutions.py
+++ b/tests/codegen/handlers/test_add_attribute_substitutions.py
@@ -81,6 +81,11 @@ class AddAttributeSubstitutionsTests(FactoryTestCase):
         self.assertEqual(1, target.attrs[2].restrictions.min_occurs)
         self.assertEqual(0, target.attrs[3].restrictions.min_occurs)
 
+        self.assertEqual("foo", target.attrs[0].substitution)
+        self.assertEqual("foo", target.attrs[1].substitution)
+        self.assertEqual(None, target.attrs[2].substitution)
+        self.assertEqual("foo", target.attrs[3].substitution)
+
         self.processor.process_attribute(target, second_attr)
         self.assertEqual(4, len(target.attrs))
 

--- a/tests/codegen/handlers/test_create_compound_fields.py
+++ b/tests/codegen/handlers/test_create_compound_fields.py
@@ -144,26 +144,31 @@ class CreateCompoundFieldsTests(FactoryTestCase):
     def test_choose_name(self):
         target = ClassFactory.create()
 
-        actual = self.processor.choose_name(target, ["a", "b", "c"])
+        actual = self.processor.choose_name(target, ["a", "b", "c"], [])
         self.assertEqual("a_Or_b_Or_c", actual)
 
-        actual = self.processor.choose_name(target, ["a", "b", "c", "d"])
+        actual = self.processor.choose_name(target, ["a", "b", "c", "d"], [])
         self.assertEqual("choice", actual)
 
         target.attrs.append(AttrFactory.create(name="choice"))
-        actual = self.processor.choose_name(target, ["a", "b", "c", "d"])
+        actual = self.processor.choose_name(target, ["a", "b", "c", "d"], [])
         self.assertEqual("choice_1", actual)
 
-        actual = self.processor.choose_name(target, ["a", "b", "c", "d"])
+        actual = self.processor.choose_name(target, ["a", "b", "c", "d"], [])
         self.assertEqual("choice_1", actual)
 
         self.processor.config.default_name = "ThisOrThat"
-        actual = self.processor.choose_name(target, ["a", "b", "c", "d"])
+        actual = self.processor.choose_name(target, ["a", "b", "c", "d"], [])
         self.assertEqual("ThisOrThat", actual)
 
         self.processor.config.force_default_name = True
-        actual = self.processor.choose_name(target, ["a", "b", "c"])
+        actual = self.processor.choose_name(target, ["a", "b", "c"], [])
         self.assertEqual("ThisOrThat", actual)
+
+        self.processor.config.force_default_name = False
+        self.processor.config.use_substitution_groups = True
+        actual = self.processor.choose_name(target, ["a", "b", "c"], ["d", "e", "f"])
+        self.assertEqual("d_Or_e_Or_f", actual)
 
     def test_build_reserved_names(self):
         base = ClassFactory.create(

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -38,7 +38,7 @@ class GeneratorConfigTests(TestCase):
             "    <DocstringStyle>reStructuredText</DocstringStyle>\n"
             "    <FilterStrategy>allGlobals</FilterStrategy>\n"
             "    <RelativeImports>false</RelativeImports>\n"
-            '    <CompoundFields defaultName="choice" forceDefaultName="false">false</CompoundFields>\n'
+            '    <CompoundFields defaultName="choice" useSubstitutionGroups="false" forceDefaultName="false" maxNameParts="3">false</CompoundFields>\n'
             "    <PostponedAnnotations>false</PostponedAnnotations>\n"
             "    <UnnestClasses>false</UnnestClasses>\n"
             "    <IgnorePatterns>false</IgnorePatterns>\n"
@@ -100,7 +100,7 @@ class GeneratorConfigTests(TestCase):
             "    <DocstringStyle>reStructuredText</DocstringStyle>\n"
             "    <FilterStrategy>allGlobals</FilterStrategy>\n"
             "    <RelativeImports>false</RelativeImports>\n"
-            '    <CompoundFields defaultName="choice" forceDefaultName="false">false</CompoundFields>\n'
+            '    <CompoundFields defaultName="choice" useSubstitutionGroups="false" forceDefaultName="false" maxNameParts="3">false</CompoundFields>\n'
             "    <PostponedAnnotations>false</PostponedAnnotations>\n"
             "    <UnnestClasses>false</UnnestClasses>\n"
             "    <IgnorePatterns>false</IgnorePatterns>\n"

--- a/xsdata/codegen/handlers/add_attribute_substitutions.py
+++ b/xsdata/codegen/handlers/add_attribute_substitutions.py
@@ -34,9 +34,9 @@ class AddAttributeSubstitutions(RelativeHandlerInterface):
     def process_attribute(self, target: Class, attr: Attr):
         """
         Check if the given attribute matches any substitution class in order to
-        clone it's attributes to the target class.
+        clone its attributes to the target class.
 
-        The cloned attributes are placed below the attribute the are
+        The cloned attributes are placed below the attribute they are
         supposed to substitute.
 
         Guard against multiple substitutions in case of xs:groups.
@@ -55,6 +55,8 @@ class AddAttributeSubstitutions(RelativeHandlerInterface):
                 clone = ClassUtils.clone_attribute(substitution, attr.restrictions)
                 clone.restrictions.min_occurs = 0
                 clone.restrictions.max_occurs = attr.restrictions.max_occurs
+
+                attr.substitution = clone.substitution = attr_type.name
 
                 pos = collections.find(target.attrs, clone)
                 index = pos + 1 if pos > -1 else index

--- a/xsdata/codegen/models.py
+++ b/xsdata/codegen/models.py
@@ -210,6 +210,7 @@ class Attr:
     help: Optional[str] = field(default=None, compare=False)
     restrictions: Restrictions = field(default_factory=Restrictions, compare=False)
     parent: Optional["Class"] = field(default=None, compare=False)
+    substitution: Optional[str] = field(default=None, compare=False)
 
     def __post_init__(self):
         self.local_name = self.name

--- a/xsdata/models/config.py
+++ b/xsdata/models/config.py
@@ -222,15 +222,21 @@ class CompoundFields:
 
     :param enabled: Use compound fields for repeatable elements
     :param default_name: Default compound field name
-    :param force_default_name: Always use the default compound field,
-        otherwise if the number of elements is less than 4 the generator
-        will try to dynamically create the field name e.g.
+    :param use_substitution_groups: Use substitution groups if they
+        exist, instead of element names.
+    :param force_default_name: Always use the default compound field
+        name, or try to generate one by the list of element names if
+        they are no longer than the max name parts. e.g.
         hat_or_dress_or_something.
+    :param max_name_parts: Maximum number of element names before using
+        the default name.
     """
 
     enabled: bool = text_node(default=False, cli="compound-fields")
     default_name: str = attribute(default="choice", cli=False)
+    use_substitution_groups: bool = attribute(default=False, cli=False)
     force_default_name: bool = attribute(default=False, cli=False)
+    max_name_parts: int = attribute(default=3, cli=False)
 
 
 @dataclass


### PR DESCRIPTION
## 📒 Description

Add a configuration option to use substitution groups for the generation of compound fields, when they are available.
Add a configuration to control the maximum name parts for compound fields. If the name parts exceed the configuration the default name is used. This was 


Resolves #861 

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue


## 💬 Comments

> A place to write any comments to the reviewer.
>

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
