### PR TITLE
Fix compound field forward ref types with subscriptable types

### DIFF
--- a/tests/formats/dataclass/test_filters.py
+++ b/tests/formats/dataclass/test_filters.py
@@ -921,6 +921,7 @@ class FiltersTests(FactoryTestCase):
             "level_two": {"a": 1},
             "list": [
                 {"type": "Type[object]"},
+                {"type": 'type["something"]'},
                 {"type": "Type[object] mpla"},
             ],
             "default": "1",
@@ -941,6 +942,9 @@ class FiltersTests(FactoryTestCase):
             '    "list": [\n'
             "        {\n"
             '            "type": object,\n'
+            "        },\n"
+            "        {\n"
+            '            "type": type["something"],\n'
             "        },\n"
             "        {\n"
             '            "type": "Type[object] mpla",\n'

--- a/xsdata/formats/dataclass/filters.py
+++ b/xsdata/formats/dataclass/filters.py
@@ -480,7 +480,9 @@ class Filters:
         length and the additional pad is more than the max line length,
         wrap the text into multiple lines, avoiding breaking long words
         """
-        if data.startswith("Type[") and data.endswith("]"):
+        if (data.startswith("Type[") or data.startswith("type[")) and data.endswith(
+            "]"
+        ):
             return data if data[5] == '"' else data[5:-1]
 
         if data.startswith("Literal[") and data.endswith("]"):


### PR DESCRIPTION
## 📒 Description

Address `type["something]"`


Resolves #900

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue


## 💬 Comments
The filters need some major refactoring

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
