### PR TITLE
XmlSerializer should ignore empty non-nillable/required tokens

### DIFF
--- a/tests/formats/dataclass/serializers/test_xml.py
+++ b/tests/formats/dataclass/serializers/test_xml.py
@@ -186,11 +186,16 @@ class XmlSerializerTests(TestCase):
         self.assertIsInstance(result, Generator)
         self.assertListEqual([], list(result))
 
+        result = self.serializer.write_value([], var, "xsdata")
+        self.assertIsInstance(result, Generator)
+        self.assertListEqual([], list(result))
+
         expected = [
             (XmlWriterEvent.START, "a"),
             (XmlWriterEvent.DATA, []),
             (XmlWriterEvent.END, "a"),
         ]
+        var.required = True
         result = self.serializer.write_value([], var, "xsdata")
         self.assertIsInstance(result, Generator)
         self.assertListEqual(expected, list(result))

--- a/xsdata/formats/dataclass/serializers/xml.py
+++ b/xsdata/formats/dataclass/serializers/xml.py
@@ -174,7 +174,7 @@ class XmlSerializer(AbstractSerializer):
     def write_tokens(self, value: Any, var: XmlVar, namespace: NoneStr) -> Generator:
         """Produce an events stream for the given tokens list or list of tokens
         lists."""
-        if value is not None or var.nillable:
+        if value or var.nillable or var.required:
             if value and collections.is_array(value[0]):
                 for val in value:
                     yield from self.write_element(val, var, namespace)


### PR DESCRIPTION
## 📒 Description

The xml serializer `write_tokens` only takes into account nillable nmtokens, everything else is generated even when the list is empty but it's not required.

Resolves #860



## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue


## 💬 Comments

> A place to write any comments to the reviewer.
>

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
