### PR TITLE
Allow the user to provide a generator instead of a list.

### DIFF
--- a/xsdata/formats/dataclass/serializers/xml.py
+++ b/xsdata/formats/dataclass/serializers/xml.py
@@ -155,6 +155,8 @@ class XmlSerializer(AbstractSerializer):
             yield from self.write_elements(value, var, namespace)
         elif var.list_element and collections.is_array(value):
             yield from self.write_list(value, var, namespace)
+        elif var.list_element and isinstance(value, Generator):
+            yield from self.write_list(value, var, namespace)
         else:
             yield from self.write_any_type(value, var, namespace)
 

--- a/xsdata/formats/dataclass/typing.py
+++ b/xsdata/formats/dataclass/typing.py
@@ -1,5 +1,6 @@
 import sys
 from typing import Any, Iterator, Tuple, Type, TypeVar, Union
+from collections.abc import Iterable
 
 from typing_extensions import get_args, get_origin
 
@@ -166,6 +167,7 @@ def _evaluate_typevar(tp: TypeVar):
 
 __evaluations__ = {
     tuple: _evaluate_tuple,
+    Iterable: _evaluate_list,
     list: _evaluate_list,
     dict: _evaluate_mapping,
     Union: _evaluate_union,


### PR DESCRIPTION
## 📒 Description

When creating large (read: huge) XML documents, materialising elements should be delayed as much as possible. I think the only place when it actually should be available is _just_ prior to writing. This gives the biggest oppertunity to have the smallest memory footprint possible for element directly derived from a database.

## 🔗 What I've Done

Introduce a check for typing.Generator, and handle it exactly as if it was a list.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
