### PR TITLE
Use substitution groups for compound field names only when all elements are derived from one

### DIFF
--- a/tests/codegen/handlers/test_create_compound_fields.py
+++ b/tests/codegen/handlers/test_create_compound_fields.py
@@ -170,6 +170,9 @@ class CreateCompoundFieldsTests(FactoryTestCase):
         actual = self.processor.choose_name(target, ["a", "b", "c"], ["d", "e", "f"])
         self.assertEqual("d_Or_e_Or_f", actual)
 
+        actual = self.processor.choose_name(target, ["a", "b", "c"], ["d", "f"])
+        self.assertEqual("a_Or_b_Or_c", actual)
+
     def test_build_reserved_names(self):
         base = ClassFactory.create(
             attrs=[

--- a/xsdata/codegen/handlers/create_compound_fields.py
+++ b/xsdata/codegen/handlers/create_compound_fields.py
@@ -121,7 +121,7 @@ class CreateCompoundFields(RelativeHandlerInterface):
     def choose_name(
         self, target: Class, names: List[str], substitutions: List[str]
     ) -> str:
-        if self.config.use_substitution_groups and substitutions:
+        if self.config.use_substitution_groups and len(names) == len(substitutions):
             names = substitutions
 
         names = collections.unique_sequence(names)


### PR DESCRIPTION
## 📒 Description

The new option to use the substitution groups to name the compound fields is confusing when repeatable choices are mixed with substitution groups.

This pr enforces the new field naming pattern only when all elements are part of a substitution group


Resolves #904 

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue


## 💬 Comments

> A place to write any comments to the reviewer.
>

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
