### PR TITLE
Prohibit parent fields on restriction extensions

### DIFF
--- a/tests/codegen/models/test_attr.py
+++ b/tests/codegen/models/test_attr.py
@@ -25,6 +25,12 @@ class AttrTests(FactoryTestCase):
         attr.namespace = __file__
         self.assertNotEqual(attr, clone)
 
+    def test_can_be_restricted(self):
+        self.assertFalse(AttrFactory.create(tag=Tag.ATTRIBUTE).can_be_restricted())
+        self.assertFalse(AttrFactory.create(tag=Tag.EXTENSION).can_be_restricted())
+        self.assertFalse(AttrFactory.create(tag=Tag.RESTRICTION).can_be_restricted())
+        self.assertTrue(AttrFactory.create(tag=Tag.ELEMENT).can_be_restricted())
+
     def test_property_key(self):
         attr = AttrFactory.attribute(name="a", namespace="b")
         self.assertEqual("Attribute.b.a", attr.key)

--- a/tests/codegen/models/test_class.py
+++ b/tests/codegen/models/test_class.py
@@ -144,6 +144,16 @@ class ClassTests(FactoryTestCase):
         obj.attrs.append(AttrFactory.create(tag=Tag.EXTENSION))
         self.assertFalse(obj.is_global_type)
 
+    def test_property_is_restricted(self):
+        obj = ClassFactory.create()
+        ext = ExtensionFactory.create(tag=Tag.EXTENSION)
+        obj.extensions.append(ext)
+
+        self.assertFalse(obj.is_restricted)
+
+        ext.tag = Tag.RESTRICTION
+        self.assertTrue(obj.is_restricted)
+
     def test_property_is_simple_type(self):
         obj = ClassFactory.elements(2)
 

--- a/tests/fixtures/models.py
+++ b/tests/fixtures/models.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from dataclasses import field
-from typing import Dict
+from typing import Dict, Any
 from typing import List
 from typing import Optional
 from typing import Type
@@ -30,6 +30,7 @@ class TypeC:
     y: str
     z: float
     fixed: str = field(init=False, default="ignored")
+    restricted: Any = field(init=False, metadata={"type": "Ignore"})
 
 
 @dataclass

--- a/xsdata/codegen/models.py
+++ b/xsdata/codegen/models.py
@@ -333,6 +333,10 @@ class Attr:
             if datatype:
                 yield datatype.type
 
+    def can_be_restricted(self) -> bool:
+        """Return whether this attribute can be restricted."""
+        return self.xml_type not in (Tag.ATTRIBUTE, None)
+
 
 @dataclass(unsafe_hash=True)
 class Extension:
@@ -459,6 +463,12 @@ class Class:
     def is_mixed(self) -> bool:
         """Return whether this class supports mixed content."""
         return self.mixed or any(x.mixed for x in self.attrs)
+
+    @property
+    def is_restricted(self) -> bool:
+        return any(
+            True for extension in self.extensions if extension.tag == Tag.RESTRICTION
+        )
 
     @property
     def is_service(self) -> bool:

--- a/xsdata/formats/dataclass/compat.py
+++ b/xsdata/formats/dataclass/compat.py
@@ -85,7 +85,9 @@ class ClassType(abc.ABC):
             return 0.0
 
         if self.is_model(obj):
-            return sum(score(getattr(obj, var.name)) for var in self.get_fields(obj))
+            return sum(
+                score(getattr(obj, var.name, None)) for var in self.get_fields(obj)
+            )
 
         return score(obj)
 


### PR DESCRIPTION
## 📒 Description

When a type has a restriction base, we need to prohibit the use of parent fields that don't appear in the type itself.


Resolves #854

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue


## 💬 Comments

> A place to write any comments to the reviewer.
>

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
