### PR TITLE
ci: add dependabot section for github action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,12 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: monthly
+  groups:
+    # open a single pull-request for all GitHub actions updates
+    github-actions:
+      patterns:
+      - '*'


### PR DESCRIPTION
## 📒 Description

Hi there, this is my first PR to the project. The PR adds:

- a section in the Dependabot config to update GitHub Actions, using a group to get only a single PR

## 🔗 What I've Done

## 💬 Comments

## 🛫 Checklist

Does not apply.

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
