### PR TITLE
docs: update required python version in install docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -43,7 +43,7 @@ Verify installation using the cli entry point.
 Requirements
 ------------
 
-.. admonition:: xsData relies on these awesome libraries and supports `python >= 3.7`
+.. admonition:: xsData relies on these awesome libraries and supports `python >= 3.8`
     :class: hint
 
     * `lxml <https://lxml.de/>`_ - XML parsing


### PR DESCRIPTION
## 📒 Description

This PR updates the required python version in the installation docs. The minimum allowed python version per pyproject.toml is 3.8.

## 🔗 What I've Done

## 💬 Comments

## 🛫 Checklist

- [x] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
