### PR TITLE
Generate wrapper

### DIFF
--- a/tests/codegen/test_container.py
+++ b/tests/codegen/test_container.py
@@ -46,6 +46,7 @@ class ClassContainerTests(FactoryTestCase):
                 "ProcessAttributeTypes",
                 "MergeAttributes",
                 "ProcessMixedContentClass",
+                "UnwrapLists",
             ],
             30: [
                 "ResetAttributeSequences",

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -43,6 +43,7 @@ class GeneratorConfigTests(TestCase):
             "    <UnnestClasses>false</UnnestClasses>\n"
             "    <IgnorePatterns>false</IgnorePatterns>\n"
             "    <IncludeHeader>false</IncludeHeader>\n"
+            "    <WrappedLists>keep</WrappedLists>\n"
             "  </Output>\n"
             "  <Conventions>\n"
             '    <ClassName case="pascalCase" safePrefix="type"/>\n'
@@ -105,6 +106,7 @@ class GeneratorConfigTests(TestCase):
             "    <UnnestClasses>false</UnnestClasses>\n"
             "    <IgnorePatterns>false</IgnorePatterns>\n"
             "    <IncludeHeader>false</IncludeHeader>\n"
+            "    <WrappedLists>keep</WrappedLists>\n"
             "  </Output>\n"
             "  <Conventions>\n"
             '    <ClassName case="pascalCase" safePrefix="type"/>\n'

--- a/xsdata/codegen/container.py
+++ b/xsdata/codegen/container.py
@@ -18,6 +18,7 @@ from xsdata.codegen.handlers import (
     SanitizeAttributesDefaultValue,
     SanitizeEnumerationClass,
     UnnestInnerClasses,
+    UnwrapLists,
     UpdateAttributesEffectiveChoice,
     VacuumInnerClasses,
     ValidateAttributesOverrides,
@@ -54,6 +55,7 @@ class ClassContainer(ContainerInterface):
                 FlattenAttributeGroups(self),
             ],
             Steps.FLATTEN: [
+                UnwrapLists(self),
                 CalculateAttributePaths(),
                 FlattenClassExtensions(self),
                 SanitizeEnumerationClass(self),

--- a/xsdata/codegen/handlers/__init__.py
+++ b/xsdata/codegen/handlers/__init__.py
@@ -15,6 +15,7 @@ from .reset_attribute_sequences import ResetAttributeSequences
 from .sanitize_attributes_default_value import SanitizeAttributesDefaultValue
 from .sanitize_enumeration_class import SanitizeEnumerationClass
 from .unnest_inner_classes import UnnestInnerClasses
+from .unwrap_lists import UnwrapLists
 from .update_attributes_effective_choice import UpdateAttributesEffectiveChoice
 from .vacuum_inner_classes import VacuumInnerClasses
 from .validate_attributes_overrides import ValidateAttributesOverrides
@@ -37,6 +38,7 @@ __all__ = [
     "SanitizeAttributesDefaultValue",
     "SanitizeEnumerationClass",
     "UnnestInnerClasses",
+    "UnwrapLists",
     "UpdateAttributesEffectiveChoice",
     "VacuumInnerClasses",
     "ValidateAttributesOverrides",

--- a/xsdata/codegen/handlers/unwrap_lists.py
+++ b/xsdata/codegen/handlers/unwrap_lists.py
@@ -1,0 +1,45 @@
+from xsdata.codegen.mixins import ContainerInterface, RelativeHandlerInterface
+from xsdata.codegen.models import Attr, Class
+from xsdata.models.config import UnwrapListType
+from typing import Iterable, Tuple
+
+
+class UnwrapLists(RelativeHandlerInterface):
+    """Remove list wrapper elements."""
+
+    __slots__ = "mode"
+
+    mode: UnwrapListType
+
+    def __init__(self, container: ContainerInterface):
+        super().__init__(container)
+        self.mode = container.config.output.wrapped_lists
+
+    def process(self, target: Class):
+        if self.mode is UnwrapListType.KEEP:
+            return
+        for attr, attr_type in self.itter_attributes(target):
+            if len(attr_type.attrs) == 1 and len(attr_type.inner) == 1 and attr_type.attrs[0].is_list:
+                self.unwrap_list(target, attr, attr_type)
+
+    def itter_attributes(self, target: Class) -> Iterable[Tuple[Attr, Class]]:
+        inners = {inner.qname: inner for inner in target.inner}
+        for attribute in target.attrs.copy():
+            if len(attribute.types) != 1:
+                # TODO Check this logic
+                continue
+            inner = inners.get(attribute.types[0].qname, None)
+            if inner is not None:
+                yield attribute, inner
+
+    def unwrap_list(self, target: Class, attr: Attr, attr_type: Class) -> None:
+        wrapped_attribute = attr_type.attrs[0]
+        wrapped_attribute.wrapper = attr.local_name
+
+        if self.mode is UnwrapListType.OUTER_NAME:
+            wrapped_attribute.name = attr.name
+
+        position = target.inner.index(attr_type)
+        target.inner[position] = attr_type.inner[0]
+        position = target.attrs.index(attr)
+        target.attrs[position] = wrapped_attribute

--- a/xsdata/codegen/models.py
+++ b/xsdata/codegen/models.py
@@ -211,6 +211,7 @@ class Attr:
     restrictions: Restrictions = field(default_factory=Restrictions, compare=False)
     parent: Optional["Class"] = field(default=None, compare=False)
     substitution: Optional[str] = field(default=None, compare=False)
+    wrapper: Optional[str] = field(default=None, compare=False)
 
     def __post_init__(self):
         self.local_name = self.name

--- a/xsdata/formats/dataclass/filters.py
+++ b/xsdata/formats/dataclass/filters.py
@@ -375,6 +375,9 @@ class Filters:
         if self.docstring_style == DocstringStyle.ACCESSIBLE and attr.help:
             metadata["doc"] = self.clean_docstring(attr.help, False)
 
+        if attr.wrapper is not None:
+            metadata["wrapper"] = attr.wrapper
+
         return self.filter_metadata(metadata)
 
     def field_choices(

--- a/xsdata/models/config.py
+++ b/xsdata/models/config.py
@@ -168,6 +168,18 @@ class ExtensionType(Enum):
     DECORATOR = "decorator"
 
 
+class UnwrapListType(Enum):
+    """
+    Wrapped lists behaviour
+
+    :cvar KEEP: keep: Keep list wrappers in classes
+    :cvar INNER_NAME: innerName: Remove list wrapper keeping the inner element name
+    :cvar OUTER_NAME: outerName: Remove list wrapper keeping the outer element name
+    """
+    KEEP = "keep"
+    INNER_NAME = "innerName"
+    OUTER_NAME = "outerName"
+
 @dataclass
 class OutputFormat:
     """
@@ -261,6 +273,7 @@ class GeneratorOutput:
     :param ignore_patterns: Ignore pattern restrictions
     :param include_header: Include a header with codegen information in
         the output
+    :param wrapped_lists: Remove wrapper classes from list attributes keeping either the inner or outer element name
     """
 
     package: str = element(default="generated")
@@ -281,6 +294,7 @@ class GeneratorOutput:
     unnest_classes: bool = element(default=False)
     ignore_patterns: bool = element(default=False)
     include_header: bool = element(default=False)
+    wrapped_lists: UnwrapListType = element(default=UnwrapListType.KEEP)
 
     def __post_init__(self):
         self.validate()


### PR DESCRIPTION
## 📒 Description

Adds new feature to code generation to detect wrapped lists and unwrap them in dataclasses, using the [wrapped](https://xsdata.readthedocs.io/en/latest/examples/wrapped-list.html) feature.

Resolves #927

## 🔗 What I've Done

- Added an output config option to unwrap wrapped lists.
- Added an attribute to Attr for `wrapper`, indicating the wrapper element name.
- Added a processor in Translate (Flatten) which 
  - places the list wrapper's `local_name` into the `wrapper` of the wrapped list
  - optionally changes the name of the wrapped list to match the wrapper
  - replaces the wrapper attribute with the wrapped attribute
  - replaces the `inner` for the wrapper with the `inner` for the wrapped


## 💬 Comments

This is currently in draft and needs unit tests / doc changes etc.

Am creating this as a draft now to allow @tefra to comment on the approach, before I work on documentation and unit tests.

One major decision here was whether code should be trigged through the ClassContainer or should be entirely encoded into the dataclass writer.  On balance it seemed simpler to embed this and unit test this in the ClassContainer.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
