### PR TITLE
Fix failure of decoding if the specified encoding is not UTF-8.

### DIFF
--- a/xsdata/formats/dataclass/serializers/writers/lxml.py
+++ b/xsdata/formats/dataclass/serializers/writers/lxml.py
@@ -43,6 +43,6 @@ class LxmlEventWriter(XmlWriter):
             encoding=self.config.encoding,
             pretty_print=self.config.pretty_print,
             xml_declaration=False,
-        ).decode()
+        ).decode(self.config.encoding)
 
         self.output.write(xml)


### PR DESCRIPTION
## 📒 Description

Fix failure of decoding if the specified encoding is not UTF-8.

Resolves https://github.com/tefra/xsdata/issues/932

## 🔗 What I've Done

Applied the encoding from the configuration to the decode.

## 💬 Comments

What I am still curious about.

1. When the serializer would render to the requested encoding
2. We decoded this to a string
3. Is the output still in th requested encoding? Or should this have remained binary in order to write it to a file in the requested encoding?

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
