### PR TITLE
chore: modernize ruff config to work with ruff >= 0.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: end-of-file-fixer
       - id: debug-statements
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.11
+    rev: v0.2.1
     hooks:
       - id: ruff
         args: [ --fix, --show-fixes ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     rev: v0.1.11
     hooks:
       - id: ruff
-        args: [ --fix ]
+        args: [ --fix, --show-fixes ]
       - id: ruff-format
 
   - repo: https://github.com/PyCQA/docformatter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ version = {attr = "xsdata.__version__"}
 [tool.ruff]
 target-version = "py38"
 
+[tool.ruff.lint]
 select = [
     # pycodestyle
     "E",

--- a/xsdata/codegen/parsers/schema.py
+++ b/xsdata/codegen/parsers/schema.py
@@ -75,9 +75,9 @@ class SchemaParser(UserXmlParser):
         """Collect the schema's default form for attributes and elements for
         later usage."""
 
-        self.element_form = attrs.get("elementFormDefault", None)
-        self.attribute_form = attrs.get("attributeFormDefault", None)
-        self.default_attributes = attrs.get("defaultAttributes", None)
+        self.element_form = attrs.get("elementFormDefault")
+        self.attribute_form = attrs.get("attributeFormDefault")
+        self.default_attributes = attrs.get("defaultAttributes")
 
     def end_schema(self, obj: T):
         """Normalize various properties for the schema and it's children."""


### PR DESCRIPTION
## 📒 Description

This PR modernizes the ruff config to work with ruff >= 0.2

The config needs a e.g. `[tool.ruff.lint]` section to select the rules.

The pre-commit hook `docformatter` also wanted to changes a few docstrings. I did not include those changes in this PR.

## 🔗 What I've Done

## 💬 Comments

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
