### PR TITLE
fix: Respect encoding configuration in lxml event writer

### DIFF
--- a/tests/formats/dataclass/serializers/writers/test_lxml.py
+++ b/tests/formats/dataclass/serializers/writers/test_lxml.py
@@ -1,3 +1,4 @@
+from dataclasses import make_dataclass
 from unittest import TestCase
 
 from tests import fixtures_dir
@@ -34,12 +35,12 @@ class LxmlEventWriterTests(TestCase):
         self.assertEqual(expected, actual)
 
     def test_encoding(self):
-        self.serializer.config.encoding = "US-ASCII"
-        self.serializer.config.xml_version = "1.1"
-        actual = self.serializer.render(books)
-        xml_declaration, _ = actual.split("\n", 1)
-
-        self.assertEqual('<?xml version="1.1" encoding="US-ASCII"?>', xml_declaration)
+        self.serializer.config.encoding = "ISO-8859-1"
+        x = make_dataclass("x", [("value", str)])
+        obj = x("á, é, í, ó")
+        actual = self.serializer.render(obj)
+        expected = '<?xml version="1.0" encoding="ISO-8859-1"?>\n<x>á, é, í, ó</x>\n'
+        self.assertEqual(expected, actual)
 
     def test_declaration_disabled(self):
         self.serializer.config.xml_declaration = False

--- a/tests/formats/dataclass/serializers/writers/test_native.py
+++ b/tests/formats/dataclass/serializers/writers/test_native.py
@@ -1,3 +1,4 @@
+from dataclasses import make_dataclass
 from unittest import TestCase
 
 from tests import fixtures_dir
@@ -28,12 +29,12 @@ class XmlEventWriterTests(TestCase):
         self.assertEqual(expected, actual)
 
     def test_encoding(self):
-        self.serializer.config.xml_version = "1.1"
-        self.serializer.config.encoding = "US-ASCII"
-        actual = self.serializer.render(books)
-        xml_declaration, _ = actual.split("\n", 1)
-
-        self.assertEqual('<?xml version="1.1" encoding="US-ASCII"?>', xml_declaration)
+        self.serializer.config.encoding = "ISO-8859-1"
+        x = make_dataclass("x", [("value", str)])
+        obj = x("á, é, í, ó")
+        actual = self.serializer.render(obj)
+        expected = '<?xml version="1.0" encoding="ISO-8859-1"?>\n<x>á, é, í, ó</x>\n'
+        self.assertEqual(expected, actual)
 
     def test_declaration_disabled(self):
         self.serializer.config.xml_declaration = False

--- a/xsdata/formats/dataclass/serializers/writers/lxml.py
+++ b/xsdata/formats/dataclass/serializers/writers/lxml.py
@@ -60,6 +60,6 @@ class LxmlEventWriter(XmlWriter):
             encoding=self.config.encoding,
             pretty_print=self.config.pretty_print,
             xml_declaration=False,
-        ).decode()
+        ).decode(self.config.encoding)
 
         self.output.write(xml)


### PR DESCRIPTION
Resolves: #923

## 📒 Description

> Write a brief description of your PR.

Resolves #xxxx

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue

## 💬 Comments

> A place to write any comments to the reviewer.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
