### PR TITLE
deprecate: Serializer config pretty_print/pretty_print_identation

### DIFF
--- a/docs/data_binding/basics.md
+++ b/docs/data_binding/basics.md
@@ -57,7 +57,7 @@ you want to use a parser/serializer.
 ...     attribute_name_generator=text.kebab_case
 ... )
 >>> serializer = XmlSerializer(context=context)
->>> serializer.config.pretty_print = True
+>>> serializer.config.indent = "  "
 >>> print(serializer.render(obj))
 <?xml version="1.0" encoding="UTF-8"?>
 <person birth-date="1986-09-25">
@@ -194,17 +194,9 @@ Renders the XML declaration header.
 
 **Default:** `True`
 
-### `pretty_print`
+### `indent`
 
-Enable indentation.
-
-**Type**: `bool`
-
-**Default:** `False`
-
-### `pretty_print_indent`
-
-Indentation string for each indent level.
+Indent output by the given string.
 
 **Type**: `Optional[str]`
 
@@ -286,7 +278,7 @@ types.
 >>> city1.streets.append(street1)
 >>> street1.houses.append(house1)
 >>> type_map = {"City": City, "Street": Street, "House": House}
->>> serializer_config = SerializerConfig(pretty_print=True, globalns=type_map)
+>>> serializer_config = SerializerConfig(indent="  ", globalns=type_map)
 >>> xml_serializer = XmlSerializer(config=serializer_config)
 >>> serialized_house = xml_serializer.render(city1)
 >>> print(serialized_house)

--- a/docs/data_binding/dict_encoding.md
+++ b/docs/data_binding/dict_encoding.md
@@ -9,7 +9,7 @@ serialization.
 >>> from xsdata.formats.dataclass.serializers import DictEncoder
 >>> from xsdata.formats.dataclass.serializers.config import SerializerConfig
 
->>> config = SerializerConfig(pretty_print=True)
+>>> config = SerializerConfig(indent="  ")
 >>> context = XmlContext()
 >>> encoder = DictEncoder()
 >>> encoder = DictEncoder(context=context, config=config)

--- a/docs/data_binding/json_serializing.md
+++ b/docs/data_binding/json_serializing.md
@@ -5,7 +5,7 @@
 >>> from xsdata.formats.dataclass.serializers import JsonSerializer
 >>> from xsdata.formats.dataclass.serializers.config import SerializerConfig
 
->>> config = SerializerConfig(pretty_print=True)
+>>> config = SerializerConfig(indent="  ")
 >>> context = XmlContext()
 >>> serializer = JsonSerializer()
 >>> serializer = JsonSerializer(context=context, config=config)

--- a/docs/data_binding/xml_serializing.md
+++ b/docs/data_binding/xml_serializing.md
@@ -5,7 +5,7 @@
 >>> from xsdata.formats.dataclass.serializers import XmlSerializer
 >>> from xsdata.formats.dataclass.serializers.config import SerializerConfig
 
->>> config = SerializerConfig(pretty_print=True)
+>>> config = SerializerConfig(indent="  ")
 >>> context = XmlContext()
 >>> serializer = XmlSerializer()
 >>> serializer = XmlSerializer(context=context, config=config)
@@ -118,7 +118,7 @@ them through config.
 >>> from xsdata.formats.dataclass.serializers.config import SerializerConfig
 ...
 >>> serializer = XmlSerializer(config=SerializerConfig(
-...     pretty_print=True,
+...     indent="  ",
 ...     xml_declaration=False,
 ...     ignore_default_attributes=True,
 ...     schema_location="urn books.xsd",
@@ -142,7 +142,7 @@ them through config.
 
 There are two writers based on lxml and native python that may vary in performance in
 some cases. The output of all them is consistent with a few exceptions when handling
-mixed content with `pretty_print=True`.
+mixed content and enabled indentation.
 
 !!! Hint
 

--- a/docs/models/classes.md
+++ b/docs/models/classes.md
@@ -9,7 +9,7 @@ Plugins can extend support for output formats.
 from dataclasses import dataclass # markdown-exec: hide
 from xsdata.formats.dataclass.serializers import XmlSerializer # markdown-exec: hide
 serializer = XmlSerializer() # markdown-exec: hide
-serializer.config.pretty_print = True # markdown-exec: hide
+serializer.config.indent = "  " # markdown-exec: hide
 @dataclass
 class Book:
     title: str
@@ -34,7 +34,7 @@ The local name of the XML/JSON element.
 >>> from xsdata.formats.dataclass.serializers import XmlSerializer
 >>> from xsdata.utils.text import camel_case
 >>> serializer = XmlSerializer()
->>> serializer.config.pretty_print = True
+>>> serializer.config.indent = "  "
 >>> serializer.config.xml_declaration = False
 >>>
 >>> @dataclass

--- a/docs/models/fields.md
+++ b/docs/models/fields.md
@@ -18,7 +18,7 @@ The local name of the XML/JSON field.
 >>> from xsdata.formats.dataclass.parsers import XmlParser
 >>> parser = XmlParser()
 >>> serializer = XmlSerializer()
->>> serializer.config.pretty_print = True
+>>> serializer.config.indent = "  "
 >>> serializer.config.xml_declaration = False
 >>>
 >>> @dataclass

--- a/docs/models/types.md
+++ b/docs/models/types.md
@@ -234,7 +234,7 @@ You can register you own custom types as well as long as they are not dataclasse
 >>> from xsdata.formats.dataclass.serializers import XmlSerializer
 ...
 >>> serializer = XmlSerializer()
->>> serializer.config.pretty_print = True
+>>> serializer.config.indent = "  "
 >>> serializer.config.xml_declaration = False
 >>>
 >>> class TheGoodFloat(float):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ docs = [
     "markdown-exec[ansi]",
     "pymdownx-superfence-filter-lines",
 ]
-lxml = ["lxml>=4.4.1"]
+lxml = ["lxml>=4.5.0"]
 soap = ["requests"]
 test = [
     "pre-commit",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ def validate_bindings(schema: Path, clazz: Type):
 
     sample = schema.parent.joinpath("sample.xml")
     obj = XmlParser().from_path(sample, clazz)
-    config = SerializerConfig(pretty_print=True)
+    config = SerializerConfig(indent="  ")
     actual = JsonSerializer(config=config).render(obj)
 
     expected = sample.with_suffix(".json")
@@ -23,7 +23,7 @@ def validate_bindings(schema: Path, clazz: Type):
     else:
         expected.write_text(actual, encoding="utf-8")
 
-    config = SerializerConfig(pretty_print=True)
+    config = SerializerConfig(indent="  ")
     xml = XmlSerializer(config=config).render(obj)
 
     validator = etree.XMLSchema(etree.parse(str(schema)))

--- a/tests/formats/dataclass/serializers/test_config.py
+++ b/tests/formats/dataclass/serializers/test_config.py
@@ -1,0 +1,34 @@
+import unittest
+import warnings
+
+from xsdata.formats.dataclass.serializers.config import SerializerConfig
+
+
+class SerializerConfigTest(unittest.TestCase):
+    def test_deprecated_fields(self):
+        with warnings.catch_warnings(record=True) as w:
+            config = SerializerConfig(pretty_print=True)
+            self.assertEqual("  ", config.indent)
+
+            config = SerializerConfig(pretty_print_indent="\t")
+            self.assertEqual("\t", config.indent)
+
+        expected = [
+            "Setting `pretty_print` is deprecated, use `indent` instead",
+            "Setting `pretty_print_indent` is deprecated, use `indent` instead",
+        ]
+        self.assertEqual(expected, [str(m.message) for m in w])
+
+        with warnings.catch_warnings(record=True) as w:
+            config = SerializerConfig()
+            config.pretty_print = True
+            self.assertTrue("  ", config.indent)
+
+            config.pretty_print_indent = "\t"
+            self.assertTrue("\t", config.indent)
+
+        expected = [
+            "Setting `pretty_print` is deprecated, use `indent` instead",
+            "Setting `pretty_print_indent` is deprecated, use `indent` instead",
+        ]
+        self.assertEqual(expected, [str(m.message) for m in w])

--- a/tests/formats/dataclass/serializers/test_dict.py
+++ b/tests/formats/dataclass/serializers/test_dict.py
@@ -104,36 +104,3 @@ class DictEncoderTests(TestCase):
         expected = expected[:-1]
         actual = [name for name, value in serializer.next_value(book)]
         self.assertEqual(expected, actual)
-
-    def test_pretty_print_indent(self):
-        serializer = JsonSerializer()
-        serializer.config.pretty_print = True
-        serializer.config.pretty_print_indent = "    "
-
-        actual = serializer.render(self.books)
-        expected = f"""{{
-    "book": [
-        {{
-            "author": "{self.expected["book"][0]["author"]}",
-            "title": "{self.expected["book"][0]["title"]}",
-            "genre": "{self.expected["book"][0]["genre"]}",
-            "price": {self.expected["book"][0]["price"]},
-            "pub_date": "{self.expected["book"][0]["pub_date"]}",
-            "review": "{self.expected["book"][0]["review"]}",
-            "id": "{self.expected["book"][0]["id"]}",
-            "lang": "en"
-        }},
-        {{
-            "author": "{self.expected["book"][1]["author"]}",
-            "title": "{self.expected["book"][1]["title"]}",
-            "genre": "{self.expected["book"][1]["genre"]}",
-            "price": null,
-            "pub_date": null,
-            "review": "{self.expected["book"][1]["review"]}",
-            "id": "{self.expected["book"][1]["id"]}",
-            "lang": "en"
-        }}
-    ]
-}}"""
-
-        self.assertEqual(expected, actual)

--- a/tests/formats/dataclass/serializers/test_json.py
+++ b/tests/formats/dataclass/serializers/test_json.py
@@ -2,6 +2,7 @@ import json
 from unittest.case import TestCase
 
 from tests.fixtures.books import BookForm, Books
+from xsdata.formats.dataclass.serializers.config import SerializerConfig
 from xsdata.formats.dataclass.serializers.json import DictFactory, JsonSerializer
 from xsdata.models.datatype import XmlDate
 
@@ -59,10 +60,9 @@ class JsonSerializerTests(TestCase):
 
         self.assertEqual(self.expected, json.loads(actual))
 
-    def test_pretty_print_indent(self):
-        serializer = JsonSerializer()
-        serializer.config.pretty_print = True
-        serializer.config.pretty_print_indent = "    "
+    def test_indent(self):
+        config = SerializerConfig(indent="    ")
+        serializer = JsonSerializer(config=config)
 
         actual = serializer.render(self.books)
         expected = f"""{{

--- a/tests/formats/dataclass/serializers/writers/test_lxml.py
+++ b/tests/formats/dataclass/serializers/writers/test_lxml.py
@@ -10,7 +10,7 @@ from xsdata.formats.dataclass.serializers.writers import LxmlEventWriter
 
 class LxmlEventWriterTests(TestCase):
     def setUp(self):
-        config = SerializerConfig(pretty_print=True)
+        config = SerializerConfig(indent="  ")
         self.serializer = XmlSerializer(config=config, writer=LxmlEventWriter)
 
     def test_render(self):
@@ -50,20 +50,11 @@ class LxmlEventWriterTests(TestCase):
 
         self.assertEqual(expected, actual)
 
-    def test_pretty_print_false(self):
-        self.serializer.config.pretty_print = False
+    def test_no_indent(self):
+        self.serializer.config.indent = None
         actual = self.serializer.render(books)
         expected = fixtures_dir.joinpath("books/books_auto_ns.xml").read_text()
 
         _, actual = actual.split("\n", 1)
         _, expected = expected.split("\n", 1)
         self.assertEqual(expected.replace("  ", "").replace("\n", ""), actual)
-
-    def test_pretty_print_indent(self):
-        self.serializer.config.pretty_print_indent = "    "
-        actual = self.serializer.render(books)
-        expected = fixtures_dir.joinpath("books/books_auto_ns.xml").read_text()
-
-        _, actual = actual.split("\n", 1)
-        _, expected = expected.split("\n", 1)
-        self.assertEqual(expected.replace("  ", "    "), actual)

--- a/tests/formats/dataclass/serializers/writers/test_native.py
+++ b/tests/formats/dataclass/serializers/writers/test_native.py
@@ -10,7 +10,7 @@ from xsdata.formats.dataclass.serializers.writers import XmlEventWriter
 
 class XmlEventWriterTests(TestCase):
     def setUp(self):
-        config = SerializerConfig(pretty_print=True)
+        config = SerializerConfig(indent="  ")
         self.serializer = XmlSerializer(config=config, writer=XmlEventWriter)
 
     def test_render(self):
@@ -44,20 +44,11 @@ class XmlEventWriterTests(TestCase):
 
         self.assertEqual(expected, actual)
 
-    def test_pretty_print_false(self):
-        self.serializer.config.pretty_print = False
+    def test_no_indent(self):
+        self.serializer.config.indent = None
         actual = self.serializer.render(books)
         expected = fixtures_dir.joinpath("books/books_auto_ns.xml").read_text()
 
         _, actual = actual.split("\n", 1)
         _, expected = expected.split("\n", 1)
         self.assertEqual(expected.replace("  ", "").replace("\n", ""), actual)
-
-    def test_pretty_print_indent(self):
-        self.serializer.config.pretty_print_indent = "    "
-        actual = self.serializer.render(books)
-        expected = fixtures_dir.joinpath("books/books_auto_ns.xml").read_text()
-
-        _, actual = actual.split("\n", 1)
-        _, expected = expected.split("\n", 1)
-        self.assertEqual(expected.replace("  ", "    "), actual)

--- a/tests/integration/test_artists.py
+++ b/tests/integration/test_artists.py
@@ -25,7 +25,7 @@ def test_xml_documents():
 
     parser = XmlParser()
     serializer = XmlSerializer(writer=XmlEventWriter)
-    serializer.config.pretty_print = True
+    serializer.config.indent = "  "
     serializer.config.xml_declaration = False
     ns_map = {None: "http://musicbrainz.org/ns/mmd-2.0#"}
 

--- a/tests/integration/test_calculator.py
+++ b/tests/integration/test_calculator.py
@@ -37,7 +37,7 @@ class CalculatorServiceTests(TestCase):
         mock_most.return_value = response
 
         config = Config.from_service(CalculatorSoapAdd)
-        serializer = XmlSerializer(config=SerializerConfig(pretty_print=True))
+        serializer = XmlSerializer(config=SerializerConfig(indent="  "))
         client = Client(config=config, serializer=serializer)
         result = client.send({"Body": {"Add": {"intA": 1, "intB": 3}}})
 

--- a/tests/integration/test_hello_rpc.py
+++ b/tests/integration/test_hello_rpc.py
@@ -43,7 +43,7 @@ class HelloRpcServiceTests(TestCase):
         mock_most.return_value = response
 
         config = Config.from_service(HelloGetHelloAsString)
-        serializer = XmlSerializer(config=SerializerConfig(pretty_print=True))
+        serializer = XmlSerializer(config=SerializerConfig(indent="  "))
         client = Client(config=config, serializer=serializer)
         result = client.send({"Body": {"getHelloAsString": {"arg0": "chris"}}})
 
@@ -67,7 +67,7 @@ class HelloRpcServiceTests(TestCase):
         mock_most.return_value = response
 
         config = Config.from_service(HelloGetHelloAsString)
-        serializer = XmlSerializer(config=SerializerConfig(pretty_print=True))
+        serializer = XmlSerializer(config=SerializerConfig(indent="  "))
         client = Client(config=config, serializer=serializer)
         result = client.send({"Body": {"getHelloAsString": {"arg0": "chris"}}})
 
@@ -87,7 +87,7 @@ class HelloRpcServiceTests(TestCase):
     @pytest.mark.skip
     def test_live(self):
         config = Config.from_service(HelloGetHelloAsString)
-        serializer = XmlSerializer(config=SerializerConfig(pretty_print=True))
+        serializer = XmlSerializer(config=SerializerConfig(indent="  "))
         client = Client(config=config, serializer=serializer)
         result = client.send({"Body": {"getHelloAsString": {"arg0": "chris"}}})
         print(result)

--- a/tests/integration/test_series.py
+++ b/tests/integration/test_series.py
@@ -27,7 +27,7 @@ def test_json_documents():
     clazz = load_class(result.output, "Series")
 
     parser = JsonParser()
-    config = SerializerConfig(pretty_print=True)
+    config = SerializerConfig(indent="  ")
     serializer = JsonSerializer(config=config)
 
     for i in range(1, 3):

--- a/tests/integration/test_stripe.py
+++ b/tests/integration/test_stripe.py
@@ -30,7 +30,7 @@ def test_json_documents():
     clazz = load_class(result.output, "Balance")
 
     parser = JsonParser()
-    config = SerializerConfig(pretty_print=True)
+    config = SerializerConfig(indent="  ")
     serializer = JsonSerializer(config=config)
 
     for sample in filepath.joinpath("samples").glob("*.json"):

--- a/tests/models/xsd/test_annotation_base.py
+++ b/tests/models/xsd/test_annotation_base.py
@@ -34,4 +34,4 @@ class AnnotationBaseTest(TestCase):
                 ]
             )
         )
-        self.assertEqual("I am a <p>test<span>!</span></p>", base.display_help)
+        self.assertEqual("I am a <p>test<span>!</span>\n</p>", base.display_help)

--- a/xsdata/formats/dataclass/serializers/config.py
+++ b/xsdata/formats/dataclass/serializers/config.py
@@ -1,5 +1,6 @@
-from dataclasses import dataclass
-from typing import Callable, Dict, Optional
+import warnings
+from dataclasses import InitVar, dataclass
+from typing import Any, Callable, Dict, Optional
 
 
 @dataclass
@@ -12,8 +13,7 @@ class SerializerConfig:
         encoding: Text encoding
         xml_version: XML Version number (1.0|1.1)
         xml_declaration: Generate XML declaration
-        pretty_print: Enable pretty output
-        pretty_print_indent: Indentation string for each indent level
+        indent: Indent output by the given string
         ignore_default_attributes: Ignore optional attributes with default values
         schema_location: xsi:schemaLocation attribute value
         no_namespace_schema_location: xsi:noNamespaceSchemaLocation attribute value
@@ -24,9 +24,36 @@ class SerializerConfig:
     encoding: str = "UTF-8"
     xml_version: str = "1.0"
     xml_declaration: bool = True
-    pretty_print: bool = False
-    pretty_print_indent: Optional[str] = None
+    indent: Optional[str] = None
     ignore_default_attributes: bool = False
     schema_location: Optional[str] = None
     no_namespace_schema_location: Optional[str] = None
     globalns: Optional[Dict[str, Callable]] = None
+
+    # Deprecated
+    pretty_print: InitVar[bool] = False
+    pretty_print_indent: InitVar[Optional[str]] = None
+
+    def __post_init__(self, pretty_print: bool, pretty_print_indent: Optional[str]):
+        """Handle deprecated pretty print/indent behaviour."""
+        if pretty_print:
+            self.__setattr__("pretty_print", pretty_print)
+        if pretty_print_indent:
+            self.__setattr__("pretty_print_indent", pretty_print_indent)
+
+    def __setattr__(self, key: str, value: Any):
+        """Handle deprecated pretty print/indent behaviour."""
+        if key == "pretty_print":
+            warnings.warn(
+                "Setting `pretty_print` is deprecated, use `indent` instead",
+                DeprecationWarning,
+            )
+            self.indent = "  "
+        elif key == "pretty_print_indent":
+            warnings.warn(
+                "Setting `pretty_print_indent` is deprecated, use `indent` instead",
+                DeprecationWarning,
+            )
+            self.indent = value
+        else:
+            super().__setattr__(key, value)

--- a/xsdata/formats/dataclass/serializers/json.py
+++ b/xsdata/formats/dataclass/serializers/json.py
@@ -1,7 +1,7 @@
 import json
 from dataclasses import dataclass, field
 from io import StringIO
-from typing import Any, Callable, Dict, Optional, TextIO, Tuple, Union
+from typing import Any, Callable, Dict, TextIO, Tuple
 
 from xsdata.formats.bindings import AbstractSerializer
 from xsdata.formats.dataclass.serializers import DictEncoder
@@ -58,8 +58,4 @@ class JsonSerializer(DictEncoder, AbstractSerializer):
             out: The output text stream
             obj: The input model instance to serialize
         """
-        indent: Optional[Union[int, str]] = None
-        if self.config.pretty_print:
-            indent = self.config.pretty_print_indent or 2
-
-        self.dump_factory(self.encode(obj), out, indent=indent)
+        self.dump_factory(self.encode(obj), out, indent=self.config.indent)

--- a/xsdata/formats/dataclass/serializers/writers/lxml.py
+++ b/xsdata/formats/dataclass/serializers/writers/lxml.py
@@ -1,6 +1,6 @@
 from typing import Iterator
 
-from lxml.etree import indent, tostring
+from lxml import etree
 from lxml.sax import ElementTreeContentHandler
 
 from xsdata.formats.dataclass.serializers.mixins import XmlWriter
@@ -52,14 +52,16 @@ class LxmlEventWriter(XmlWriter):
 
         assert isinstance(self.handler, ElementTreeContentHandler)
 
-        if self.config.pretty_print and self.config.pretty_print_indent is not None:
-            indent(self.handler.etree, self.config.pretty_print_indent)
+        if self.config.indent:
+            etree.indent(self.handler.etree, self.config.indent)
 
-        xml = tostring(
+        xml = etree.tostring(
             self.handler.etree,
             encoding=self.config.encoding,
-            pretty_print=self.config.pretty_print,
             xml_declaration=False,
         ).decode(self.config.encoding)
 
         self.output.write(xml)
+
+        if self.config.indent:
+            self.output.write("\n")

--- a/xsdata/formats/dataclass/serializers/writers/native.py
+++ b/xsdata/formats/dataclass/serializers/writers/native.py
@@ -60,11 +60,11 @@ class XmlEventWriter(XmlWriter):
         """
         super().start_tag(qname)
 
-        if self.config.pretty_print:
+        if self.config.indent:
             if self.current_level:
                 self.handler.ignorableWhitespace("\n")
                 self.handler.ignorableWhitespace(
-                    (self.config.pretty_print_indent or "  ") * self.current_level
+                    self.config.indent * self.current_level
                 )
 
             self.current_level += 1
@@ -83,16 +83,14 @@ class XmlEventWriter(XmlWriter):
         Args:
             qname: The qualified name of the element
         """
-        if not self.config.pretty_print:
+        if not self.config.indent:
             super().end_tag(qname)
             return
 
         self.current_level -= 1
         if self.pending_end_element:
             self.handler.ignorableWhitespace("\n")
-            self.handler.ignorableWhitespace(
-                (self.config.pretty_print_indent or "  ") * self.current_level
-            )
+            self.handler.ignorableWhitespace(self.config.indent * self.current_level)
 
         super().end_tag(qname)
 

--- a/xsdata/models/config.py
+++ b/xsdata/models/config.py
@@ -562,6 +562,6 @@ class GeneratorConfig:
             element_name_generator=text.pascal_case,
             attribute_name_generator=text.camel_case,
         )
-        config = SerializerConfig(pretty_print=True)
+        config = SerializerConfig(indent="  ")
         serializer = XmlSerializer(context=ctx, config=config, writer=XmlEventWriter)
         serializer.write(output, obj, ns_map={None: "http://pypi.org/project/xsdata"})

--- a/xsdata/models/xsd.py
+++ b/xsdata/models/xsd.py
@@ -29,7 +29,7 @@ from xsdata.utils.constants import DEFAULT_ATTR_NAME
 from xsdata.utils.namespaces import clean_uri
 
 docstring_serializer = XmlSerializer(
-    config=SerializerConfig(pretty_print=True, xml_declaration=False)
+    config=SerializerConfig(indent="  ", xml_declaration=False)
 )
 
 


### PR DESCRIPTION
## 📒 Description

We have two config settings for indentation, pretty_print and pretty_print_indent. The first is a bool flag and the other is the spaces to indent. The behavior is not consistent between xml/json.

Let's merge them!

Resolves #xxxx

## 🔗 What I've Done

- Deprecate pretty_print and  pretty_print_indent and replace them with the new one `indent`
- Maintain compatibility in order to not freak out users but raise some warnings


## 💬 Comments

> A place to write any comments to the reviewer.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
