### PR TITLE
make FieldInfo a protocol

### DIFF
--- a/xsdata/formats/dataclass/compat.py
+++ b/xsdata/formats/dataclass/compat.py
@@ -13,7 +13,7 @@ class FieldInfo(Protocol):
 
     name: str
     init: bool
-    metadata: 'MappingProxyType[Any, Any]'
+    metadata: "MappingProxyType[Any, Any]"
     default: Any
     default_factory: Any
 

--- a/xsdata/formats/dataclass/compat.py
+++ b/xsdata/formats/dataclass/compat.py
@@ -15,7 +15,7 @@ class FieldInfo(Protocol):
     default: Any
     default_factory: Any
     init: bool
-    metadata: MappingProxyType[Any, Any]
+    metadata: 'MappingProxyType[Any, Any]'
 
 
 class ClassType(abc.ABC):

--- a/xsdata/formats/dataclass/compat.py
+++ b/xsdata/formats/dataclass/compat.py
@@ -12,10 +12,10 @@ class FieldInfo(Protocol):
     """A class field info wrapper."""
 
     name: str
-    default: Any
-    default_factory: Any
     init: bool
     metadata: 'MappingProxyType[Any, Any]'
+    default: Any
+    default_factory: Any
 
 
 class ClassType(abc.ABC):

--- a/xsdata/formats/dataclass/compat.py
+++ b/xsdata/formats/dataclass/compat.py
@@ -1,20 +1,21 @@
 import abc
 from dataclasses import MISSING, fields, is_dataclass
-from typing import Any, Dict, Iterator, List, NamedTuple, Optional, Set, Type, cast
+from types import MappingProxyType
+from typing import Any, Dict, Iterator, Optional, Protocol, Set, Type
 
 from xsdata.exceptions import XmlContextError
 from xsdata.formats.dataclass.models.generics import AnyElement, DerivedElement
 from xsdata.utils.hooks import load_entry_points
 
 
-class FieldInfo(NamedTuple):
+class FieldInfo(Protocol):
     """A class field info wrapper."""
 
     name: str
-    init: bool
-    metadata: Dict[str, Any]
     default: Any
     default_factory: Any
+    init: bool
+    metadata: MappingProxyType[Any, Any]
 
 
 class ClassType(abc.ABC):
@@ -173,7 +174,7 @@ class Dataclasses(ClassType):
 
     def get_fields(self, obj: Any) -> Iterator[FieldInfo]:
         """Return a dataclass fields iterator."""
-        yield from cast(List[FieldInfo], fields(obj))
+        yield from fields(obj)
 
     def default_value(self, field: FieldInfo, default: Optional[Any] = None) -> Any:
         """Return the default value or factory of the given model field."""


### PR DESCRIPTION
## 📒 Description

This makes a modification to #848 to make the `dataclass.compat.FieldInfo` type a bit more accurate.  In #848,  the return type was changed to a `NamedTuple`, but that named tuple wasn't actually used anywhere, instead, a regular `dataclasses.Field` is returned (as it was before) but it's just `cast` to the `FieldInfo` to satisfy type checkers.  This means that all downstream users now get a typing error unless they also import your `FieldInfo` object and use a cast as well, even though they technically are returning the same `Field` object that you are returning internally.

## 🔗 What I've Done

I used a `Protocol` that matches the subset of dataclasses.Field that you are using, rather than the combination of `NamedTuple` and `yield from cast(List[FieldInfo], fields(obj))`

## 💬 Comments

> A place to write any comments to the reviewer.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
