### PR TITLE
fix: All non-native types must have a reference id

### DIFF
--- a/tests/codegen/handlers/test_process_attributes_types.py
+++ b/tests/codegen/handlers/test_process_attributes_types.py
@@ -259,6 +259,8 @@ class ProcessAttributeTypesTests(FactoryTestCase):
         attr_type = AttrTypeFactory.create(circular=True)
 
         self.processor.process_inner_type(target, attr, attr_type)
+
+        self.assertEqual(target.ref, attr_type.reference)
         self.assertEqual(0, mock_copy_attribute_properties.call_count)
         self.assertEqual(0, mock_update_restrictions.call_count)
 

--- a/tests/codegen/handlers/test_unnest_inner_classes.py
+++ b/tests/codegen/handlers/test_unnest_inner_classes.py
@@ -77,11 +77,14 @@ class UnnestInnerClassesTests(FactoryTestCase):
                 AttrTypeFactory.create(qname="b", forward=False),
             ]
         )
+        source = ClassFactory.create()
 
-        self.processor.update_types(attr, "a", "c")
+        self.processor.update_types(attr, "a", source)
 
-        self.assertEqual("c", attr.types[0].qname)
+        self.assertEqual(source.qname, attr.types[0].qname)
         self.assertFalse(attr.types[0].forward)
+        self.assertEqual(source.ref, attr.types[0].reference)
+
         self.assertEqual("a", attr.types[1].qname)
         self.assertFalse(attr.types[1].forward)
         self.assertEqual("b", attr.types[2].qname)

--- a/xsdata/codegen/analyzer.py
+++ b/xsdata/codegen/analyzer.py
@@ -1,7 +1,12 @@
-from typing import List
+from dataclasses import fields
+from typing import Iterator, List, Tuple
 
 from xsdata.codegen.container import ClassContainer
-from xsdata.codegen.models import Class
+from xsdata.codegen.models import (
+    AttrType,
+    Class,
+    CodegenModel,
+)
 from xsdata.codegen.validator import ClassValidator
 from xsdata.exceptions import AnalyzerValueError
 
@@ -33,44 +38,54 @@ class ClassAnalyzer:
         return classes
 
     @classmethod
-    def class_references(cls, target: Class) -> List[int]:
-        """Produce a list of instance references for the given class.
-
-        Collect the ids of the class, attr, extension and inner instances.
-
-        Args:
-            target: The target class instance
-
-        List:
-            The list of id references.
-        """
-        result = [id(target)]
-        for attr in target.attrs:
-            result.append(id(attr))
-            result.extend(id(attr_type) for attr_type in attr.types)
-
-        for extension in target.extensions:
-            result.append(id(extension))
-            result.append(id(extension.type))
-
-        for inner in target.inner:
-            result.extend(cls.class_references(inner))
-
-        return result
-
-    @classmethod
     def validate_references(cls, classes: List[Class]):
-        """Validate all codegen objects are not cross-referenced.
+        """Validate codegen object references.
 
-        This validation ensures we never share any attr, or extension
-        between classes.
+        #Todo - Add details on these exceptions
+
+        Rules:
+            1. No shared codegen objects between classes
+            2. All attr types must have a reference id, except natives
 
         Args:
             classes: The list of classes to be generated.
 
         Raises:
-            AnalyzerValueError: If an object is shared between the classes.
+            AnalyzerValueError: If an object violates the rules.
         """
-        references = [ref for obj in classes for ref in cls.class_references(obj)]
-        if len(references) != len(set(references)):
-            raise AnalyzerValueError("Cross references detected!")
+        seen = set()
+        for target in classes:
+            for objects in cls.codegen_models(target):
+                child = objects[-1]
+                ref = id(child)
+                if ref in seen:
+                    raise AnalyzerValueError("Cross reference detected")
+
+                if (
+                    isinstance(child, AttrType)
+                    and not child.reference
+                    and not child.native
+                ):
+                    raise AnalyzerValueError("Unresolved reference")
+
+                seen.add(ref)
+
+    @classmethod
+    def codegen_models(cls, *args: CodegenModel) -> Iterator[Tuple[CodegenModel, ...]]:
+        """Find and yield all children codegen models.
+
+        Args:
+            *args: The codegen objects path.
+
+        Yields:
+            A tuple of codegen models like a path e.g. class, attr, attr_type
+        """
+        yield args
+        model = args[-1]
+        for f in fields(model):
+            value = getattr(model, f.name)
+            if isinstance(value, list) and value and isinstance(value[0], CodegenModel):
+                for val in value:
+                    yield from cls.codegen_models(*args, val)
+            elif isinstance(value, CodegenModel):
+                yield *args, value

--- a/xsdata/codegen/handlers/create_compound_fields.py
+++ b/xsdata/codegen/handlers/create_compound_fields.py
@@ -133,7 +133,9 @@ class CreateCompoundFields(RelativeHandlerInterface):
 
         min_occurs, max_occurs = self.sum_counters(counters)
         name = self.choose_name(target, names, list(filter(None, substitutions)))
-        types = collections.unique_sequence(t for attr in attrs for t in attr.types)
+        types = collections.unique_sequence(
+            t.clone() for attr in attrs for t in attr.types
+        )
 
         target.attrs.insert(
             pos,
@@ -256,7 +258,7 @@ class CreateCompoundFields(RelativeHandlerInterface):
         return Attr(
             name=attr.local_name,
             namespace=attr.namespace,
-            types=attr.types,
+            types=[x.clone() for x in attr.types],
             tag=attr.tag,
             help=attr.help,
             restrictions=restrictions,

--- a/xsdata/codegen/handlers/disambiguate_choices.py
+++ b/xsdata/codegen/handlers/disambiguate_choices.py
@@ -64,7 +64,7 @@ class DisambiguateChoices(RelativeHandlerInterface):
 
         if attr.tag == Tag.CHOICE:
             types = (tp for choice in attr.choices for tp in choice.types)
-            attr.types = collections.unique_sequence(types)
+            attr.types = collections.unique_sequence(x.clone() for x in types)
 
     @classmethod
     def merge_wildcard_choices(cls, attr: Attr):

--- a/xsdata/codegen/handlers/flatten_class_extensions.py
+++ b/xsdata/codegen/handlers/flatten_class_extensions.py
@@ -109,8 +109,11 @@ class FlattenClassExtensions(RelativeHandlerInterface):
             # the target enumeration, mypy doesn't play nicely.
             target.attrs.clear()
 
-        if extension and target.is_enumeration:
-            target.extensions.remove(extension)
+        if extension:
+            if target.is_enumeration:
+                target.extensions.remove(extension)
+            else:
+                extension.type.reference = source.ref
 
     @classmethod
     def merge_enumerations(cls, source: Class, target: Class):

--- a/xsdata/codegen/handlers/process_attributes_types.py
+++ b/xsdata/codegen/handlers/process_attributes_types.py
@@ -154,6 +154,7 @@ class ProcessAttributeTypes(RelativeHandlerInterface):
             attr_type: The attr type instance
         """
         if attr_type.circular:
+            attr_type.reference = target.ref
             return
 
         inner = self.container.find_inner(target, attr_type.qname)
@@ -166,6 +167,8 @@ class ProcessAttributeTypes(RelativeHandlerInterface):
         ):
             self.copy_attribute_properties(inner, target, attr, attr_type)
             target.inner.remove(inner)
+        else:
+            attr_type.reference = inner.ref
 
     def process_dependency_type(self, target: Class, attr: Attr, attr_type: AttrType):
         """Process an attr type that depends on any global type.

--- a/xsdata/codegen/handlers/unnest_inner_classes.py
+++ b/xsdata/codegen/handlers/unnest_inner_classes.py
@@ -42,7 +42,7 @@ class UnnestInnerClasses(RelativeHandlerInterface):
         attr = self.find_forward_attr(target, inner.qname)
         if attr:
             clone = self.clone_class(inner, target.name)
-            self.update_types(attr, inner.qname, clone.qname)
+            self.update_types(attr, inner.qname, clone)
             self.container.add(clone)
 
     @classmethod
@@ -65,17 +65,18 @@ class UnnestInnerClasses(RelativeHandlerInterface):
         return clone
 
     @classmethod
-    def update_types(cls, attr: Attr, search: str, replace: str):
+    def update_types(cls, attr: Attr, search: str, source: Class):
         """Update the references from an inner to a global class.
 
         Args:
             attr: The target attr to inspect and update
             search: The current inner class qname
-            replace: The new global class qname
+            source: The new global class qname
         """
         for attr_type in attr.types:
             if attr_type.qname == search and attr_type.forward:
-                attr_type.qname = replace
+                attr_type.qname = source.qname
+                attr_type.reference = source.ref
                 attr_type.forward = False
 
     @classmethod

--- a/xsdata/codegen/mappers/definitions.py
+++ b/xsdata/codegen/mappers/definitions.py
@@ -145,7 +145,11 @@ class DefinitionsMapper:
             # Only Envelope classes need to be added in service input/output
             if message_class.meta_name:
                 message_type = message_class.name.split("_")[-1]
-                attrs.append(cls.build_attr(message_type, message_class.qname))
+                attrs.append(
+                    cls.build_attr(
+                        message_type, message_class.qname, reference=id(message_class)
+                    )
+                )
 
         assert binding_operation.location is not None
 
@@ -516,6 +520,7 @@ class DefinitionsMapper:
         forward: bool = False,
         namespace: Optional[str] = None,
         default: Optional[str] = None,
+        reference: int = 0,
     ) -> Attr:
         """Helper method to build an attr instance.
 
@@ -526,6 +531,7 @@ class DefinitionsMapper:
             forward: Whether the type is a forward reference
             namespace: The attr namespace
             default: The attr default value
+            reference: The class id reference, if any
 
         Returns:
             The new attr instance.
@@ -539,6 +545,10 @@ class DefinitionsMapper:
             name=name,
             namespace=namespace,
             default=default,
-            types=[AttrType(qname=qname, forward=forward, native=native)],
+            types=[
+                AttrType(
+                    qname=qname, forward=forward, native=native, reference=reference
+                )
+            ],
             restrictions=Restrictions(min_occurs=occurs, max_occurs=occurs),
         )

--- a/xsdata/codegen/models.py
+++ b/xsdata/codegen/models.py
@@ -29,7 +29,12 @@ GLOBAL_TYPES = (
 
 
 @dataclass
-class Restrictions:
+class CodegenModel:
+    """Base codegen model."""
+
+
+@dataclass
+class Restrictions(CodegenModel):
     """Class field validation restrictions.
 
     Args:
@@ -196,7 +201,7 @@ class Restrictions:
 
 
 @dataclass(unsafe_hash=True)
-class AttrType:
+class AttrType(CodegenModel):
     """Class field typing information.
 
     Args:
@@ -249,7 +254,7 @@ class AttrType:
 
 
 @dataclass
-class Attr:
+class Attr(CodegenModel):
     """Class field model representation.
 
     Args:
@@ -435,7 +440,7 @@ class Attr:
 
 
 @dataclass(unsafe_hash=True)
-class Extension:
+class Extension(CodegenModel):
     """Base class model representation.
 
     Args:
@@ -474,7 +479,7 @@ class Status(IntEnum):
 
 
 @dataclass
-class Class:
+class Class(CodegenModel):
     """Class model representation.
 
     Args:

--- a/xsdata/codegen/utils.py
+++ b/xsdata/codegen/utils.py
@@ -197,12 +197,14 @@ class ClassUtils:
         inner = ClassUtils.find_inner(source, attr_type.qname)
         if inner is target:
             attr_type.circular = True
+            attr_type.reference = target.ref
         else:
             # In extreme cases this adds duplicate inner classes
             clone = inner.clone()
             clone.package = target.package
             clone.module = target.module
             clone.status = Status.RAW
+            attr_type.reference = clone.ref
             target.inner.append(clone)
 
     @classmethod

--- a/xsdata/exceptions.py
+++ b/xsdata/exceptions.py
@@ -47,7 +47,7 @@ class DefinitionsValueError(ValueError):
 
 
 class AnalyzerValueError(ValueError):
-    """Unhandled behaviour during class analyze process.."""
+    """Unhandled behaviour during class analyze process."""
 
 
 class ResolverValueError(ValueError):


### PR DESCRIPTION
## 📒 Description

Before the code analyzer exits, it runs some additional checks just to make sure there are no cross-references anywhere because they are evil.

We also need to make sure there are no attr types to user types without any references....

Because I haven't updated these checks for so long, debugging future features was a pain in the a$$


Resolves #xxxx

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue

## 💬 Comments

> A place to write any comments to the reviewer.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
