### PR TITLE
feat: Detect circular references more accurately

### DIFF
--- a/docs/codegen/architecture.md
+++ b/docs/codegen/architecture.md
@@ -57,8 +57,6 @@ graph LR
     B --> C[Validate class references]
 ```
 
-API: [xsdata.codegen.analyzer.ClassAnalyzer][]
-
 ### Validate Classes
 
 - Remove types with unknown references
@@ -135,9 +133,13 @@ pass through each step before next one starts. The order of the steps is very im
 
 - [ValidateAttributesOverrides][xsdata.codegen.handlers.ValidateAttributesOverrides]
 
-### Step: Finalize
+### Step: Vacuum
 
 - [VacuumInnerClasses][xsdata.codegen.handlers.VacuumInnerClasses]
+
+### Step: Finalize
+
+- [DetectCircularReferences][xsdata.codegen.handlers.DetectCircularReferences]
 - [CreateCompoundFields][xsdata.codegen.handlers.CreateCompoundFields]
 - [DisambiguateChoices][xsdata.codegen.handlers.DisambiguateChoices]
 - [ResetAttributeSequenceNumbers][xsdata.codegen.handlers.ResetAttributeSequenceNumbers]
@@ -145,4 +147,5 @@ pass through each step before next one starts. The order of the steps is very im
 ### Step: Designate
 
 - [RenameDuplicateClasses][xsdata.codegen.handlers.RenameDuplicateClasses]
+- [ValidateReferences][xsdata.codegen.handlers.ValidateReferences]
 - [DesignateClassPackages][xsdata.codegen.handlers.DesignateClassPackages]

--- a/tests/codegen/handlers/test_detect_circular_references.py
+++ b/tests/codegen/handlers/test_detect_circular_references.py
@@ -1,0 +1,75 @@
+from xsdata.codegen.container import ClassContainer
+from xsdata.codegen.handlers.detect_circular_references import DetectCircularReferences
+from xsdata.models.config import GeneratorConfig
+from xsdata.models.enums import DataType
+from xsdata.utils.testing import (
+    AttrFactory,
+    AttrTypeFactory,
+    ClassFactory,
+    FactoryTestCase,
+)
+
+
+class DetectCircularReferencesTests(FactoryTestCase):
+    def setUp(self):
+        super().setUp()
+        config = GeneratorConfig()
+        self.container = ClassContainer(config=config)
+        self.processor = DetectCircularReferences(self.container)
+
+    def test_process(self):
+        first = ClassFactory.create(qname="first")
+        second = ClassFactory.create(qname="second")
+        third = ClassFactory.create(qname="third")
+
+        first.attrs.append(AttrFactory.native(DataType.STRING))
+        first.attrs.append(
+            AttrFactory.create(
+                types=[
+                    AttrTypeFactory.create(qname="second", reference=second.ref),
+                    AttrTypeFactory.create(qname="third", reference=third.ref),
+                ],
+                choices=[
+                    AttrFactory.reference("second", reference=second.ref),
+                    AttrFactory.reference("third", reference=third.ref),
+                ],
+            )
+        )
+
+        second.attrs = AttrFactory.list(2)
+        third.attrs.append(AttrFactory.reference("first", reference=first.ref))
+        self.container.extend([first, second, third])
+
+        self.processor.process(first)
+
+        first_flags = [tp.circular for tp in first.types()]
+        self.assertEqual([False, False, True, False, True], first_flags)
+
+        second_flags = [tp.circular for tp in second.types()]
+        self.assertEqual([False, False], second_flags)
+
+        # First has the flags this doesn't need it :)
+        third_flags = [tp.circular for tp in third.types()]
+        self.assertEqual([False], third_flags)
+
+    def test_build_reference_types(self):
+        target = ClassFactory.create()
+        inner = ClassFactory.create()
+
+        outer_attr = AttrFactory.create()
+        inner_attr = AttrFactory.reference("foo", reference=target.ref)
+
+        inner.attrs.append(inner_attr)
+        target.inner.append(inner)
+        target.attrs.append(outer_attr)
+
+        self.container.add(target)
+
+        self.processor.build_reference_types()
+
+        expected = {
+            target.ref: [inner_attr.types[0]],
+            inner.ref: [inner_attr.types[0]],
+        }
+
+        self.assertEqual(expected, self.processor.reference_types)

--- a/tests/codegen/test_container.py
+++ b/tests/codegen/test_container.py
@@ -53,8 +53,9 @@ class ClassContainerTests(FactoryTestCase):
                 "SanitizeAttributesDefaultValue",
             ],
             40: ["ValidateAttributesOverrides"],
-            50: [
-                "VacuumInnerClasses",
+            50: ["VacuumInnerClasses"],
+            60: [
+                "DetectCircularReferences",
                 "CreateCompoundFields",
                 "DisambiguateChoices",
                 "ResetAttributeSequenceNumbers",

--- a/xsdata/codegen/handlers/__init__.py
+++ b/xsdata/codegen/handlers/__init__.py
@@ -2,6 +2,7 @@ from .add_attribute_substitutions import AddAttributeSubstitutions
 from .calculate_attribute_paths import CalculateAttributePaths
 from .create_compound_fields import CreateCompoundFields
 from .designate_class_packages import DesignateClassPackages
+from .detect_circular_references import DetectCircularReferences
 from .disambiguate_choices import DisambiguateChoices
 from .filter_classes import FilterClasses
 from .flatten_attribute_groups import FlattenAttributeGroups
@@ -26,6 +27,7 @@ __all__ = [
     "CalculateAttributePaths",
     "CreateCompoundFields",
     "DesignateClassPackages",
+    "DetectCircularReferences",
     "DisambiguateChoices",
     "FilterClasses",
     "FlattenAttributeGroups",
@@ -35,8 +37,8 @@ __all__ = [
     "ProcessMixedContentClass",
     "RenameDuplicateAttributes",
     "RenameDuplicateClasses",
-    "ResetAttributeSequences",
     "ResetAttributeSequenceNumbers",
+    "ResetAttributeSequences",
     "SanitizeAttributesDefaultValue",
     "SanitizeEnumerationClass",
     "UnnestInnerClasses",

--- a/xsdata/codegen/handlers/detect_circular_references.py
+++ b/xsdata/codegen/handlers/detect_circular_references.py
@@ -1,0 +1,90 @@
+from typing import Dict, List
+
+from xsdata.codegen.mixins import (
+    ContainerInterface,
+    RelativeHandlerInterface,
+)
+from xsdata.codegen.models import AttrType, Class
+
+
+class DetectCircularReferences(RelativeHandlerInterface):
+    """Accurately detect circular dependencies between classes.
+
+    Args:
+        container: The class container instance
+
+    Attributes:
+        reference_types: A map of class refs to dependency types
+    """
+
+    __slots__ = "container", "reference_types"
+
+    def __init__(self, container: ContainerInterface):
+        super().__init__(container)
+        self.reference_types: Dict[int, List[AttrType]] = {}
+
+    def process(self, target: Class):
+        """Go through all the attr types and find circular references.
+
+        Args:
+            target: The class to inspect and update
+        """
+        if not self.reference_types:
+            self.build_reference_types()
+
+        for attr in target.attrs:
+            self.process_types(attr.types, target.ref)
+
+            for choice in attr.choices:
+                self.process_types(choice.types, target.ref)
+
+    def process_types(self, types: List[AttrType], class_reference: int):
+        """Go through the types and find circular references.
+
+        Args:
+            types: A list attr/choice type instances
+            class_reference: The parent attr/choice class reference
+        """
+        for tp in types:
+            if not tp.forward and not tp.native and not tp.circular:
+                tp.circular = self.is_circular(tp.reference, class_reference)
+
+    def is_circular(self, start: int, stop: int) -> bool:
+        """Detect if the start reference leads to the stop reference.
+
+        The procedure is a dfs search to avoid max recursion errors.
+
+        Args:
+            start: The attr type reference
+            stop: The parent class reference
+
+        Returns:
+            Whether the start reference leads back to the stop reference.
+        """
+        path = set()
+        stack = [start]
+        while len(stack) != 0:
+            if stop in path:
+                return True
+
+            ref = stack.pop()
+            path.add(ref)
+
+            for tp in self.reference_types[ref]:
+                if not tp.circular and tp.reference not in path:
+                    stack.append(tp.reference)
+
+        return stop in path
+
+    def build_reference_types(self):
+        """Build the reference types mapping."""
+
+        def generate(target: Class):
+            yield target.ref, [tp for tp in target.types() if tp.reference]
+
+            for inner in target.inner:
+                yield from generate(inner)
+
+        for item in self.container:
+            for ref, types in generate(item):
+                self.reference_types[ref] = types

--- a/xsdata/codegen/models.py
+++ b/xsdata/codegen/models.py
@@ -474,8 +474,10 @@ class Status(IntEnum):
     SANITIZED = 31
     RESOLVING = 40
     RESOLVED = 41
-    FINALIZING = 50
-    FINALIZED = 51
+    CLEANING = 50
+    CLEANED = 51
+    FINALIZING = 60
+    FINALIZED = 61
 
 
 @dataclass
@@ -606,25 +608,9 @@ class Class(CodegenModel):
     @property
     def references(self) -> Iterator[int]:
         """Yield all class object reference numbers."""
-
-        def all_refs():
-            for ext in self.extensions:
-                yield ext.type.reference
-
-            for attr in self.attrs:
-                for tp in attr.types:
-                    yield tp.reference
-
-                for choice in attr.choices:
-                    for ctp in choice.types:
-                        yield ctp.reference
-
-            for inner in self.inner:
-                yield from inner.references
-
-        for ref in all_refs():
-            if ref:
-                yield ref
+        for tp in self.types():
+            if tp.reference:
+                yield tp.reference
 
     @property
     def target_module(self) -> str:


### PR DESCRIPTION
## 📒 Description

The circular reference detection produces way to many false positives and in some cases causes invalid classes with missing imports. The original code was smart but it's time to rewrite it.


Resolves #xxxx

## 🔗 What I've Done

I am so proud of this :)



## 💬 Comments

> A place to write any comments to the reviewer.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
