### PR TITLE
perf: Update all class references in one pass

### DIFF
--- a/xsdata/codegen/models.py
+++ b/xsdata/codegen/models.py
@@ -652,17 +652,24 @@ class Class(CodegenModel):
 
     def types(self) -> Iterator[AttrType]:
         """Yields all class types."""
+        for _, tp in self.types_with_parents():
+            yield tp
+
+    def types_with_parents(self) -> Iterator[Tuple[CodegenModel, AttrType]]:
+        """Yields all class types with their parent codegen instance."""
         for ext in self.extensions:
-            yield ext.type
+            yield ext, ext.type
 
         for attr in self.attrs:
-            yield from attr.types
+            for tp in attr.types:
+                yield attr, tp
 
             for choice in attr.choices:
-                yield from choice.types
+                for tp in choice.types:
+                    yield choice, tp
 
         for inner in self.inner:
-            yield from inner.types()
+            yield from inner.types_with_parents()
 
     def children(self) -> Iterator[CodegenModel]:
         """Yield all codegen children."""


### PR DESCRIPTION
## 📒 Description

The rename duplicate classes handler is quite slow for big suites with lots of types with duplicate class names. We can decrease that processing time dramatically if we update all the merged/renamed references in one pass and we also cache a few things.

Resolves #xxxx

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue

## 💬 Comments

> A place to write any comments to the reviewer.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
