### PR TITLE
fix: Generate type hints for compound fields with token elements

### DIFF
--- a/docs/codegen/config.md
+++ b/docs/codegen/config.md
@@ -154,7 +154,7 @@ xsdata relies on the field ordering for serialization. This process fails for re
 choice or complex sequence elements. When you enable compound fields, these elements are
 grouped into a single field.
 
-```xml show_lines="2:9"
+```xml show_lines="2:10"
 --8<-- "tests/fixtures/compound/schema.xsd"
 ```
 

--- a/tests/codegen/handlers/test_create_compound_fields.py
+++ b/tests/codegen/handlers/test_create_compound_fields.py
@@ -5,7 +5,6 @@ from xsdata.codegen.handlers import CreateCompoundFields
 from xsdata.codegen.models import Restrictions
 from xsdata.models.config import GeneratorConfig
 from xsdata.models.enums import Tag
-from xsdata.utils import collections
 from xsdata.utils.testing import (
     AttrFactory,
     ClassFactory,
@@ -93,9 +92,7 @@ class CreateCompoundFieldsTests(FactoryTestCase):
             name="choice",
             tag="Choice",
             index=0,
-            types=collections.unique_sequence(
-                t for attr in target.attrs for t in attr.types
-            ),
+            types=[],
             choices=[
                 AttrFactory.create(
                     tag=target.attrs[0].tag,

--- a/tests/codegen/handlers/test_disambiguate_choices.py
+++ b/tests/codegen/handlers/test_disambiguate_choices.py
@@ -51,7 +51,8 @@ class DisambiguateChoicesTest(FactoryTestCase):
         self.assertEqual(4, wildcard.restrictions.max_occurs)
 
     def test_process_with_duplicate_simple_types(self):
-        compound = AttrFactory.create(tag=Tag.CHOICE, types=[])
+        compound = AttrFactory.create(tag=Tag.CHOICE)
+        compound.types.clear()
         target = ClassFactory.create()
         target.attrs.append(compound)
         compound.choices.append(AttrFactory.native(DataType.STRING, name="a"))
@@ -70,7 +71,7 @@ class DisambiguateChoicesTest(FactoryTestCase):
         self.assertEqual("a", target.inner[0].qname)
         self.assertEqual("{xs}b", target.inner[1].qname)
 
-        self.assertEqual(["a", "{xs}b"], [x.qname for x in compound.types])
+        self.assertEqual([], [x.qname for x in compound.types])
 
     def test_process_with_duplicate_any_types(self):
         compound = AttrFactory.create(tag=Tag.CHOICE, types=[])

--- a/tests/fixtures/compound/models.py
+++ b/tests/fixtures/compound/models.py
@@ -35,7 +35,7 @@ class Root:
     class Meta:
         name = "root"
 
-    alpha_or_bravo: List[Union[Alpha, Bravo]] = field(
+    alpha_or_bravo_or_charlie: List[Union[Alpha, Bravo, List[str]]] = field(
         default_factory=list,
         metadata={
             "type": "Elements",
@@ -47,6 +47,13 @@ class Root:
                 {
                     "name": "bravo",
                     "type": Bravo,
+                },
+                {
+                    "name": "charlie",
+                    "type": List[str],
+                    "namespace": "",
+                    "default_factory": list,
+                    "tokens": True,
                 },
             ),
         },

--- a/tests/fixtures/compound/sample.json
+++ b/tests/fixtures/compound/sample.json
@@ -1,5 +1,5 @@
 {
-  "alpha_or_bravo": [
+  "alpha_or_bravo_or_charlie": [
     {
       "a": true
     },
@@ -21,8 +21,18 @@
     {
       "a": true
     },
+    [
+      "a",
+      "b",
+      "c"
+    ],
     {
       "b": true
-    }
+    },
+    [
+      "d",
+      "e",
+      "f"
+    ]
   ]
 }

--- a/tests/fixtures/compound/sample.py
+++ b/tests/fixtures/compound/sample.py
@@ -4,7 +4,7 @@ from tests.fixtures.compound.models import Root
 
 
 obj = Root(
-    alpha_or_bravo=[
+    alpha_or_bravo_or_charlie=[
         Alpha(
 
         ),
@@ -26,8 +26,18 @@ obj = Root(
         Alpha(
 
         ),
+        [
+            'a',
+            'b',
+            'c',
+        ],
         Bravo(
 
         ),
+        [
+            'd',
+            'e',
+            'f',
+        ],
     ]
 )

--- a/tests/fixtures/compound/sample.xml
+++ b/tests/fixtures/compound/sample.xml
@@ -6,5 +6,7 @@
   <alpha a="true" />
   <bravo b="true" />
   <alpha a="true" />
+  <charlie>a b c</charlie>
   <bravo b="true" />
+  <charlie>d e f</charlie>
 </root>

--- a/tests/fixtures/compound/sample.xsdata.xml
+++ b/tests/fixtures/compound/sample.xsdata.xml
@@ -7,5 +7,7 @@
   <alpha a="true"/>
   <bravo b="true"/>
   <alpha a="true"/>
+  <charlie>a b c</charlie>
   <bravo b="true"/>
+  <charlie>d e f</charlie>
 </root>

--- a/tests/fixtures/compound/schema.xsd
+++ b/tests/fixtures/compound/schema.xsd
@@ -1,20 +1,24 @@
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <xsd:element name="root">
-    <xsd:complexType>
-      <xsd:choice maxOccurs="unbounded">
-        <xsd:element ref="alpha" />
-        <xsd:element ref="bravo" />
-      </xsd:choice>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="alpha">
-    <xsd:complexType>
-      <xsd:attribute name="a" type="xsd:boolean" fixed="true" />
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:element name="bravo">
-    <xsd:complexType>
-      <xsd:attribute name="b" type="xsd:boolean" fixed="true" />
-    </xsd:complexType>
-  </xsd:element>
+    <xsd:element name="root">
+        <xsd:complexType>
+            <xsd:choice maxOccurs="unbounded">
+                <xsd:element ref="alpha"/>
+                <xsd:element ref="bravo"/>
+                <xsd:element name="charlie" type="charlie"/>
+            </xsd:choice>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="alpha">
+        <xsd:complexType>
+            <xsd:attribute name="a" type="xsd:boolean" fixed="true"/>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="bravo">
+        <xsd:complexType>
+            <xsd:attribute name="b" type="xsd:boolean" fixed="true"/>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:simpleType name="charlie">
+        <xsd:restriction base="xsd:NMTOKENS"/>
+    </xsd:simpleType>
 </xsd:schema>

--- a/tests/formats/dataclass/test_typing.py
+++ b/tests/formats/dataclass/test_typing.py
@@ -159,7 +159,9 @@ class TypingTests(TestCase):
             Optional[List[Union[int, float]]]: (list, int, float),
             Optional[A]: (int, str),
             Union[List[int], None]: (list, int),
-            Union[List[int], List[str]]: False,
+            Union[Tuple[int, ...], None]: (tuple, int),
+            Union[List[int], List[str]]: (list, int, list, str),
+            Union[List[Dict]]: False,
         }
 
         if sys.version_info[:2] >= (3, 10):
@@ -169,7 +171,8 @@ class TypingTests(TestCase):
                     None | List[int | float]: (list, int, float),
                     None | A: (int, str),
                     List[int] | None: (list, int),
-                    List[int] | List[str]: False,
+                    Tuple[int, ...] | None: (tuple, int),
+                    List[int] | List[str]: (list, int, list, str),
                 }
             )
 

--- a/xsdata/codegen/handlers/create_compound_fields.py
+++ b/xsdata/codegen/handlers/create_compound_fields.py
@@ -145,7 +145,6 @@ class CreateCompoundFields(RelativeHandlerInterface):
             ),
             choices=choices,
         )
-        ClassUtils.reset_choice_types(compound_attr)
         target.attrs.insert(pos, compound_attr)
 
     def sum_counters(self, counters: Dict) -> Tuple[List[int], List[int]]:

--- a/xsdata/codegen/handlers/disambiguate_choices.py
+++ b/xsdata/codegen/handlers/disambiguate_choices.py
@@ -3,7 +3,6 @@ from typing import Iterator
 
 from xsdata.codegen.mixins import ContainerInterface, RelativeHandlerInterface
 from xsdata.codegen.models import Attr, AttrType, Class, Extension, Restrictions
-from xsdata.codegen.utils import ClassUtils
 from xsdata.models.enums import DataType, Tag
 from xsdata.utils import collections, text
 from xsdata.utils.constants import DEFAULT_ATTR_NAME
@@ -62,8 +61,6 @@ class DisambiguateChoices(RelativeHandlerInterface):
 
         for choice in self.find_ambiguous_choices(attr):
             self.disambiguate_choice(target, choice)
-
-        ClassUtils.reset_choice_types(attr)
 
     @classmethod
     def merge_wildcard_choices(cls, attr: Attr):

--- a/xsdata/codegen/utils.py
+++ b/xsdata/codegen/utils.py
@@ -12,7 +12,7 @@ from xsdata.codegen.models import (
     get_qname,
     get_slug,
 )
-from xsdata.models.enums import DataType, Tag
+from xsdata.models.enums import DataType
 from xsdata.utils import collections, namespaces, text
 from xsdata.utils.constants import DEFAULT_ATTR_NAME
 
@@ -453,13 +453,6 @@ class ClassUtils:
             return f"{name}_{index}"
 
         return name
-
-    @classmethod
-    def reset_choice_types(cls, attr: Attr):
-        """Reset the choice types."""
-        if attr.tag == Tag.CHOICE:
-            types = (tp for choice in attr.choices for tp in choice.types)
-            attr.types = collections.unique_sequence(x.clone() for x in types)
 
     @classmethod
     def cleanup_class(cls, target: Class):

--- a/xsdata/formats/dataclass/generator.py
+++ b/xsdata/formats/dataclass/generator.py
@@ -1,7 +1,6 @@
 import re
 import subprocess
 from pathlib import Path
-from textwrap import indent
 from typing import Iterator, List, Optional
 
 from jinja2 import Environment, FileSystemLoader

--- a/xsdata/formats/dataclass/models/builders.py
+++ b/xsdata/formats/dataclass/models/builders.py
@@ -391,6 +391,10 @@ class XmlVarBuilder:
                 f"Xml {xml_type} does not support typing `{type_hint}`"
             )
 
+        if xml_type == XmlType.ELEMENTS:
+            sub_origin = None
+            types = (object,)
+
         local_name = local_name or self.build_local_name(xml_type, name)
 
         if tokens and sub_origin is None:
@@ -586,7 +590,11 @@ class XmlVarBuilder:
 
     @classmethod
     def analyze_types(
-        cls, model: Type, name: str, type_hint: Any, globalns: Any
+        cls,
+        model: Type,
+        name: str,
+        type_hint: Any,
+        globalns: Any,
     ) -> Tuple[Any, Any, Tuple[Type, ...]]:
         """Analyze a type hint and return the origin, sub origin and the type args.
 
@@ -646,6 +654,9 @@ class XmlVarBuilder:
         if object in types and xml_type != XmlType.ELEMENTS:
             # Any type, secondary types are not allowed except for 'Elements' XML type
             return len(types) == 1
+
+        if xml_type == XmlType.ELEMENTS:
+            return True
 
         return self.is_typing_supported(types)
 

--- a/xsdata/formats/dataclass/models/elements.py
+++ b/xsdata/formats/dataclass/models/elements.py
@@ -18,7 +18,7 @@ from typing import (
 from xsdata.formats.converter import converter
 from xsdata.models.enums import NamespaceType
 from xsdata.utils import collections
-from xsdata.utils.namespaces import build_qname, local_name, target_uri
+from xsdata.utils.namespaces import build_qname, target_uri
 
 NoneType = type(None)
 

--- a/xsdata/formats/dataclass/typing.py
+++ b/xsdata/formats/dataclass/typing.py
@@ -138,7 +138,6 @@ def _evaluate_tuple(tp: Any) -> Iterator[Type]:
 
 
 def _evaluate_union(tp: Any) -> Iterator[Type]:
-    origin_locked = False
     for arg in get_args(tp):
         if arg is NONE_TYPE:
             continue
@@ -147,9 +146,10 @@ def _evaluate_union(tp: Any) -> Iterator[Type]:
             yield from _evaluate_typevar(arg)
         else:
             origin = get_origin(arg)
-            if origin is list and not origin_locked:
+            if origin is list:
                 yield from _evaluate_list(arg)
-                origin_locked = True
+            elif origin is tuple:
+                yield from _evaluate_tuple(arg)
             elif origin is None and not is_from_typing(arg):
                 yield arg
             else:


### PR DESCRIPTION
## 📒 Description


We recently added proper typehints on compound fields, but it fails when one of the choices has a tokens element. This pr moves the generation of the typehint to the filters instead of calculating the types in the handlers.


Resolves #895 

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue

## 💬 Comments

> A place to write any comments to the reviewer.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
