### PR TITLE
Rewrite types analyzer

### DIFF
--- a/docs/models/types.md
+++ b/docs/models/types.md
@@ -25,7 +25,6 @@ collections are also supported.
 | Case           | Example                                                                           |
 | -------------- | --------------------------------------------------------------------------------- |
 | List           | `value: List[str] = field(default_factory=list)`                                  |
-| Optional List  | `value: Optional[List[str]] = field(default=None)`                                |
 | List Union     | `value: List[Union[str, int]] = field(default_factory=list)`                      |
 | Tokens List    | `value: List[str] = field(default_factory=list, metadata={"tokens": True})`       |
 | List of Tokens | `value: List[List[str]] = field(default_factory=list, metadata={"tokens": True})` |
@@ -37,7 +36,6 @@ collections are also supported.
 | Case            | Example                                                                                        |
 | --------------- | ---------------------------------------------------------------------------------------------- |
 | Tuple           | `value: Tuple[str, ...] = field(default_factory=tuple)`                                        |
-| Optional Tuple  | `value: Optional[Tuple[str, ...]] = field(default=None)`                                       |
 | Tuple Union     | `value: Tuple[Union[str, int], ...] = field(default_factory=tuple)`                            |
 | Tokens Tuple    | `value: Tuple[str, ...] = field(default_factory=tuple, metadata={"tokens": True})`             |
 | Tuple of Tokens | `value: Tuple[Tuple[str, ...], ...] = field(default_factory=tuple, metadata={"tokens": True})` |

--- a/tests/formats/dataclass/cases/__init__.py
+++ b/tests/formats/dataclass/cases/__init__.py
@@ -1,0 +1,4 @@
+import sys
+
+PY39 = sys.version_info[:2] >= (3, 9)
+PY310 = sys.version_info[:2] >= (3, 10)

--- a/tests/formats/dataclass/cases/attribute.py
+++ b/tests/formats/dataclass/cases/attribute.py
@@ -1,0 +1,51 @@
+from typing import Dict, List, Literal, Set, Tuple, Union
+
+from tests.formats.dataclass.cases import PY39, PY310
+from xsdata.models.enums import Mode
+
+tokens = [
+    (int, False),
+    (Dict[int, int], False),
+    (Dict, False),
+    (Literal["foo"], False),
+    (Set[str], False),
+    (List[Union[List[int], int]], False),
+    (List[List[int]], False),
+    (Tuple[int, ...], ((int,), None, tuple)),
+    (List[int], ((int,), None, list)),
+    (List[Union[str, int]], ((str, int), None, list)),
+]
+
+not_tokens = [
+    (List[int], False),
+    (Dict[int, str], False),
+    (int, ((int,), None, None)),
+    (str, ((str,), None, None)),
+    (Union[str, Mode], ((str, Mode), None, None)),
+]
+
+if PY39:
+    tokens.extend(
+        [
+            (list[int, int], False),
+            (dict[str, str], False),
+            (dict, False),
+            (set[str], False),
+            (tuple[int, ...], ((int,), None, tuple)),
+            (list[int], ((int,), None, list)),
+            (list[Union[str, int]], ((str, int), None, list)),
+        ]
+    )
+
+if PY310:
+    tokens.extend(
+        [
+            (tuple[int | str], ((int, str), None, tuple)),
+        ]
+    )
+
+    not_tokens.extend(
+        [
+            (int | str, ((int, str), None, None)),
+        ]
+    )

--- a/tests/formats/dataclass/cases/attributes.py
+++ b/tests/formats/dataclass/cases/attributes.py
@@ -1,0 +1,20 @@
+from typing import Dict, List, Set, Tuple
+
+from tests.formats.dataclass.cases import PY39
+
+cases = [
+    (int, False),
+    (Set, False),
+    (List, False),
+    (Tuple, False),
+    (Dict[str, int], False),
+    (Dict, ((str,), dict, None)),
+    (Dict[str, str], ((str,), dict, None)),
+]
+
+if PY39:
+    cases.extend(
+        [
+            (dict[str, str], ((str,), dict, None)),
+        ]
+    )

--- a/tests/formats/dataclass/cases/element.py
+++ b/tests/formats/dataclass/cases/element.py
@@ -1,0 +1,45 @@
+from typing import Dict, List, Set, Tuple, Union
+
+from tests.formats.dataclass.cases import PY39
+
+tokens = [
+    (Set, False),
+    (Dict[str, int], False),
+    (Tuple[str, str], False),
+    (List[str], ((str,), None, list)),
+    (Tuple[str, ...], ((str,), None, tuple)),
+    (List[List[str]], ((str,), list, list)),
+    (List[Tuple[str, ...]], ((str,), list, tuple)),
+    (Tuple[List[str], ...], ((str,), tuple, list)),
+]
+
+not_tokens = [
+    (Set, False),
+    (Dict[str, int], False),
+    (Tuple[str, int], False),
+    (List[List[str]], False),
+    (List[Tuple[str, ...]], False),
+    (Tuple[List[str], ...], False),
+    (str, ((str,), None, None)),
+    (List[str], ((str,), list, None)),
+    (List[Union[str, int]], ((str, int), list, None)),
+    (Tuple[str, ...], ((str,), tuple, None)),
+]
+
+if PY39:
+    tokens.extend(
+        [
+            (list[str], ((str,), None, list)),
+            (tuple[str, ...], ((str,), None, tuple)),
+            (list[list[str]], ((str,), list, list)),
+            (list[tuple[str, ...]], ((str,), list, tuple)),
+            (tuple[list[str], ...], ((str,), tuple, list)),
+        ]
+    )
+
+    not_tokens.extend(
+        [
+            (list[str], ((str,), list, None)),
+            (tuple[str, ...], ((str,), tuple, None)),
+        ]
+    )

--- a/tests/formats/dataclass/cases/elements.py
+++ b/tests/formats/dataclass/cases/elements.py
@@ -1,0 +1,32 @@
+from typing import Dict, List, Optional, Tuple, Union
+
+from tests.formats.dataclass.cases import PY39, PY310
+
+cases = [
+    (Dict, False),
+    (str, ((object,), None, None)),
+    (List[str], ((object,), list, None)),
+    (Tuple[str, ...], ((object,), tuple, None)),
+    (Optional[Union[str, int]], ((object,), None, None)),
+    (Union[str, int, None], ((object,), None, None)),
+    (List[Union[List[str], Tuple[str, ...]]], ((object,), list, None)),
+]
+
+
+if PY39:
+    cases.extend(
+        [
+            (list[str], ((object,), list, None)),
+            (tuple[str, ...], ((object,), tuple, None)),
+            (list[Union[list[str], tuple[str, ...]]], ((object,), list, None)),
+        ]
+    )
+
+
+if PY310:
+    cases.extend(
+        [
+            (str | int | None, ((object,), None, None)),
+            (list[list[str] | tuple[str, ...]], ((object,), list, None)),
+        ]
+    )

--- a/tests/formats/dataclass/cases/wildcard.py
+++ b/tests/formats/dataclass/cases/wildcard.py
@@ -1,0 +1,24 @@
+from typing import Dict, List, Literal, Optional, Set, Tuple
+
+from tests.formats.dataclass.cases import PY310
+
+cases = [
+    (int, False),
+    (Dict[int, int], False),
+    (Dict, False),
+    (Set, False),
+    (Literal["foo"], False),
+    (object, ((object,), None, None)),
+    (List[object], ((object,), list, None)),
+    (Tuple[object, ...], ((object,), tuple, None)),
+    (Optional[object], ((object,), None, None)),
+]
+
+if PY310:
+    cases.extend(
+        [
+            (list[object], ((object,), list, None)),
+            (tuple[object, ...], ((object,), tuple, None)),
+            (object | None, ((object,), None, None)),
+        ]
+    )

--- a/tests/formats/dataclass/parsers/test_dict.py
+++ b/tests/formats/dataclass/parsers/test_dict.py
@@ -1,5 +1,5 @@
 import json
-from dataclasses import asdict, make_dataclass
+from dataclasses import asdict, dataclass, field
 from decimal import Decimal
 from typing import List, Optional, Union
 from xml.etree.ElementTree import QName
@@ -389,7 +389,10 @@ class DictDecoderTests(FactoryTestCase):
         self.assertEqual("Unable to locate xsi:type `notexists`", str(cm.exception))
 
     def test_bind_text_with_unions(self):
-        Fixture = make_dataclass("Fixture", [("x", List[Union[int, float, str, bool]])])
+        @dataclass
+        class Fixture:
+            x: List[Union[int, float, str, bool]] = field(metadata={"tokens": True})
+
         values = ["foo", 12.2, "12.2", 12, "12", True, "false"]
 
         result = self.decoder.decode({"x": values}, Fixture)

--- a/tests/formats/dataclass/test_typing.py
+++ b/tests/formats/dataclass/test_typing.py
@@ -1,195 +1,90 @@
-import datetime
-import sys
-from decimal import Decimal
-from enum import Enum
-from typing import Any, Dict, List, Optional, Set, Tuple, Type, TypeVar, Union
-from unittest import TestCase
-from xml.etree.ElementTree import QName
+from typing import Type
 
-from xsdata.formats.dataclass.typing import evaluate
-from xsdata.formats.types import T
-from xsdata.models.datatype import XmlDate, XmlDateTime, XmlDuration, XmlPeriod, XmlTime
-from xsdata.models.enums import Namespace
+import pytest
+
+from tests.formats.dataclass.cases import (
+    attribute,
+    attributes,
+    element,
+    elements,
+    wildcard,
+)
+from xsdata.formats.dataclass.typing import (
+    evaluate,
+    evaluate_attribute,
+    evaluate_attributes,
+    evaluate_element,
+    evaluate_elements,
+    evaluate_wildcard,
+)
 
 
-class TypingTests(TestCase):
-    def assertCases(self, cases):
-        for tp, result in cases.items():
-            if result is False:
-                with self.assertRaises(TypeError):
-                    evaluate(tp)
-            else:
-                self.assertEqual(result, evaluate(tp), msg=tp)
+def test_evaluate_with_typevar():
+    result = evaluate(Type["str"], None)
+    assert str == result
 
-    def test_evaluate_simple(self):
-        types = (
-            int,
-            str,
-            int,
-            bool,
-            float,
-            bytes,
-            object,
-            datetime.time,
-            datetime.date,
-            datetime.datetime,
-            XmlTime,
-            XmlDate,
-            XmlDateTime,
-            XmlDuration,
-            XmlPeriod,
-            QName,
-            Decimal,
-            Enum,
-            Namespace,
-        )
-        cases = {tp: (tp,) for tp in types}
-        self.assertCases(cases)
+    with pytest.raises(TypeError):
+        evaluate(Type, None)
 
-    def test_evaluate_unsupported_typing(self):
-        cases = [Any, Set[str]]
 
-        for case in cases:
-            with self.assertRaises(TypeError):
-                evaluate(case)
+@pytest.mark.parametrize("case,expected", attribute.tokens)
+def test_evaluate_attribute_with_tokens(case, expected):
+    if expected:
+        assert expected == evaluate_attribute(case, tokens=True)
+    else:
+        with pytest.raises(TypeError):
+            evaluate_attribute(case, tokens=True)
 
-    def test_evaluate_dict(self):
-        cases = {
-            Dict: (dict, str, str),
-            Dict[str, int]: (dict, str, int),
-            Dict[Any, Any]: False,
-            Dict[Union[str, int], int]: False,
-            Dict[int, Union[str, int]]: False,
-            Dict[TypeVar("A", bound=int), str]: False,
-            Dict[TypeVar("A"), str]: (dict, str, str),
-        }
 
-        if sys.version_info[:2] >= (3, 9):
-            cases.update(
-                {
-                    dict: (dict, str, str),
-                    dict[str, int]: (dict, str, int),
-                    dict[Any, Any]: False,
-                    dict[Union[str, int], int]: False,
-                    dict[int, Union[str, int]]: False,
-                    dict[TypeVar("A", bound=int), str]: False,
-                    dict[TypeVar("A"), str]: (dict, str, str),
-                }
-            )
+@pytest.mark.parametrize("case,expected", attribute.not_tokens)
+def test_evaluate_attribute_without_tokens(case, expected):
+    if expected:
+        assert expected == evaluate_attribute(case, tokens=False)
+    else:
+        with pytest.raises(TypeError):
+            evaluate_attribute(case, tokens=False)
 
-        if sys.version_info[:2] >= (3, 10):
-            cases.update({dict[str | int, int]: False})
 
-        self.assertCases(cases)
+@pytest.mark.parametrize("case,expected", attributes.cases)
+def test_evaluate_attributes(case, expected):
+    if expected:
+        assert expected == evaluate_attributes(case)
+    else:
+        with pytest.raises(TypeError):
+            evaluate_attributes(case)
 
-    def test_evaluate_list(self):
-        A = TypeVar("A", int, str)
 
-        cases = {
-            List[A]: (list, int, str),
-            List[int]: (list, int),
-            List[Union[float, str]]: (list, float, str),
-            List[Optional[int]]: (list, int),
-            List[Tuple[int]]: (list, tuple, int),
-            List[List[Union[bool, str]]]: (list, list, bool, str),
-            List: (list, str),
-            List[Dict[str, str]]: False,
-            List[Any]: False,
-        }
+@pytest.mark.parametrize("case,expected", element.tokens)
+def test_evaluate_element_with_tokens(case, expected):
+    if expected:
+        assert expected == evaluate_element(case, tokens=True)
+    else:
+        with pytest.raises(TypeError):
+            evaluate_element(case, tokens=True)
 
-        if sys.version_info[:2] >= (3, 9):
-            cases.update(
-                {
-                    list[A]: (list, int, str),
-                    list[int]: (list, int),
-                    list[Union[float, str]]: (list, float, str),
-                    list[Optional[int]]: (list, int),
-                    list[Tuple[int]]: (list, tuple, int),
-                    list[list[Union[bool, str]]]: (list, list, bool, str),
-                    list: (list, str),
-                    list["str"]: (list, str),
-                    list[dict[str, str]]: False,
-                    list[Any]: False,
-                }
-            )
 
-        self.assertCases(cases)
+@pytest.mark.parametrize("case,expected", element.not_tokens)
+def test_evaluate_element_without_tokens(case, expected):
+    if expected:
+        assert expected == evaluate_element(case, tokens=False)
+    else:
+        with pytest.raises(TypeError):
+            evaluate_element(case, tokens=False)
 
-    def test_evaluate_tuple(self):
-        A = TypeVar("A", int, str)
 
-        cases = {
-            Tuple[A]: (tuple, int, str),
-            Tuple[int]: (tuple, int),
-            Tuple[int, ...]: (tuple, int),
-            Tuple[List[int], ...]: (tuple, list, int),
-            Tuple[Union[float, str]]: (tuple, float, str),
-            Tuple[Optional[int]]: (tuple, int),
-            Tuple[Tuple[int]]: (tuple, tuple, int),
-            Tuple[Tuple[Union[bool, str]]]: (tuple, tuple, bool, str),
-            Tuple: (tuple, str),
-            Tuple[Dict[str, str]]: False,
-            Tuple[Any, ...]: False,
-        }
+@pytest.mark.parametrize("case,expected", elements.cases)
+def test_evaluate_elements(case, expected):
+    if expected:
+        assert expected == evaluate_elements(case)
+    else:
+        with pytest.raises(TypeError):
+            evaluate_elements(case)
 
-        if sys.version_info[:2] >= (3, 9):
-            cases.update(
-                {
-                    tuple[A]: (tuple, int, str),
-                    tuple[int]: (tuple, int),
-                    tuple[int, ...]: (tuple, int),
-                    tuple[List[int], ...]: (tuple, list, int),
-                    tuple[Union[float, str]]: (tuple, float, str),
-                    tuple[Optional[int]]: (tuple, int),
-                    tuple[tuple[int]]: (tuple, tuple, int),
-                    tuple[tuple[Union[bool, str]]]: (tuple, tuple, bool, str),
-                    tuple: (tuple, str),
-                    tuple[dict[str, str]]: False,
-                    tuple[Any, ...]: False,
-                }
-            )
 
-        self.assertCases(cases)
-
-    def test_evaluate_union(self):
-        A = TypeVar("A", int, str)
-
-        cases = {
-            Optional[Union[bool, str]]: (bool, str),
-            Optional[List[Union[int, float]]]: (list, int, float),
-            Optional[A]: (int, str),
-            Union[List[int], None]: (list, int),
-            Union[Tuple[int, ...], None]: (tuple, int),
-            Union[List[int], List[str]]: (list, int, list, str),
-            Union[List[Dict]]: False,
-        }
-
-        if sys.version_info[:2] >= (3, 10):
-            cases.update(
-                {
-                    None | bool | str: (bool, str),
-                    None | List[int | float]: (list, int, float),
-                    None | A: (int, str),
-                    List[int] | None: (list, int),
-                    Tuple[int, ...] | None: (tuple, int),
-                    List[int] | List[str]: (list, int, list, str),
-                }
-            )
-
-        self.assertCases(cases)
-
-    def test_evaluate_type(self):
-        self.assertEqual((str,), evaluate(Type["str"]))
-
-        with self.assertRaises(TypeError):
-            evaluate(Type)
-
-    def test_evaluate_typevar(self):
-        A = TypeVar("A", int, str)
-        B = TypeVar("B", bound=object)
-
-        self.assertEqual((int, str), evaluate(A))
-        self.assertEqual((object,), evaluate(B))
-
-        with self.assertRaises(TypeError):
-            evaluate(T)
+@pytest.mark.parametrize("case,expected", wildcard.cases)
+def test_evaluate_wildcard(case, expected):
+    if expected:
+        assert expected == evaluate_wildcard(case)
+    else:
+        with pytest.raises(TypeError):
+            evaluate_wildcard(case)

--- a/xsdata/formats/dataclass/filters.py
+++ b/xsdata/formats/dataclass/filters.py
@@ -557,10 +557,11 @@ class Filters:
         length and the additional pad is more than the max line length,
         wrap the text into multiple lines, avoiding breaking long words
         """
-        if (data.startswith("Type[") or data.startswith("type[")) and data.endswith(
-            "]"
-        ):
-            return data if data[5] == '"' else data[5:-1]
+        if data.startswith("ForwardRef("):
+            return data
+
+        if data.startswith("Type["):
+            return data[5:-1]
 
         if data.startswith("Literal[") and data.endswith("]"):
             return data[8:-1]
@@ -822,8 +823,8 @@ class Filters:
             iterable_fmt = self._get_iterable_format()
             result = iterable_fmt.format(result)
 
-        if self.subscriptable_types:
-            return f"type[{result}]"
+        if result.startswith('"'):
+            return f"ForwardRef({result})"
 
         return f"Type[{result}]"
 
@@ -915,8 +916,8 @@ class Filters:
                 "List": [": List["],
                 "Optional": ["Optional["],
                 "Tuple": ["Tuple["],
-                "Type": ["Type["],
                 "Union": ["Union["],
+                "ForwardRef": [": ForwardRef("],
                 "Any": type_patterns("Any"),
             },
             "xml.etree.ElementTree": {"QName": type_patterns("QName")},

--- a/xsdata/formats/dataclass/parsers/dict.py
+++ b/xsdata/formats/dataclass/parsers/dict.py
@@ -2,13 +2,14 @@ import warnings
 from dataclasses import dataclass, field
 from typing import Any, Dict, Iterable, List, Optional, Type, Union
 
+from typing_extensions import get_args, get_origin
+
 from xsdata.exceptions import ConverterWarning, ParserError
 from xsdata.formats.converter import converter
 from xsdata.formats.dataclass.context import XmlContext
 from xsdata.formats.dataclass.models.elements import XmlMeta, XmlVar
 from xsdata.formats.dataclass.parsers.config import ParserConfig
 from xsdata.formats.dataclass.parsers.utils import ParserUtils
-from xsdata.formats.dataclass.typing import get_args, get_origin
 from xsdata.formats.types import T
 from xsdata.utils import collections
 from xsdata.utils.constants import EMPTY_MAP

--- a/xsdata/models/xsd.py
+++ b/xsdata/models/xsd.py
@@ -962,7 +962,7 @@ class Import(AnnotationBase):
 
     namespace: Optional[str] = attribute()
     schema_location: Optional[str] = attribute(name="schemaLocation")
-    location: Optional[str] = field(default=None, metadata={"type": "ignore"})
+    location: Optional[str] = field(default=None, metadata={"type": "Ignore"})
 
 
 @dataclass
@@ -970,7 +970,7 @@ class Include(AnnotationBase):
     """XSD Include model representation."""
 
     schema_location: Optional[str] = attribute(name="schemaLocation")
-    location: Optional[str] = field(default=None, metadata={"type": "ignore"})
+    location: Optional[str] = field(default=None, metadata={"type": "Ignore"})
 
 
 @dataclass
@@ -982,7 +982,7 @@ class Redefine(AnnotationBase):
     complex_types: Array[ComplexType] = array_element(name="complexType")
     groups: Array[Group] = array_element(name="group")
     attribute_groups: Array[AttributeGroup] = array_element(name="attributeGroup")
-    location: Optional[str] = field(default=None, metadata={"type": "ignore"})
+    location: Optional[str] = field(default=None, metadata={"type": "Ignore"})
 
 
 @dataclass
@@ -997,7 +997,7 @@ class Override(AnnotationBase):
     elements: Array[Element] = array_element(name="element")
     attributes: Array[Attribute] = array_element(name="attribute")
     notations: Array[Notation] = array_element(name="notation")
-    location: Optional[str] = field(default=None, metadata={"type": "ignore"})
+    location: Optional[str] = field(default=None, metadata={"type": "Ignore"})
 
 
 @dataclass
@@ -1040,7 +1040,7 @@ class Schema(AnnotationBase):
     elements: Array[Element] = array_element(name="element")
     attributes: Array[Attribute] = array_element(name="attribute")
     notations: Array[Notation] = array_element(name="notation")
-    location: Optional[str] = field(default=None, metadata={"type": "ignore"})
+    location: Optional[str] = field(default=None, metadata={"type": "Ignore"})
 
     def included(self) -> Iterator[UnionType[Import, Include, Redefine, Override]]:
         """Yields an iterator of included resources."""


### PR DESCRIPTION
## 📒 Description

The current analyzer has a few issues:

- Very lenient, allowing types that are not really supported
- Doesn't raise model validation errors for the above cases
- It's not explicit what is and isn't allowed
- It's too difficult to maintain

This pr, will introduce bugs by accident, but I want to fix those bugs instead of supporting cases by accident, people will get mad...

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue

## 💬 Comments

> A place to write any comments to the reviewer.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
