### PR TITLE
fix: Allow soap client config subclassing

### DIFF
--- a/tests/formats/dataclass/test_client.py
+++ b/tests/formats/dataclass/test_client.py
@@ -1,3 +1,4 @@
+from dataclasses import asdict, replace
 from unittest import TestCase, mock
 
 from tests.fixtures.calculator import (
@@ -43,7 +44,7 @@ class ClientTests(TestCase):
     def test_from_service(self):
         client = Client.from_service(CalculatorSoapAdd, location="http://testurl.com")
 
-        actual = client.config._asdict()
+        actual = asdict(client.config)
         expected = {
             "style": "document",
             "input": CalculatorSoapAddInput,
@@ -138,7 +139,7 @@ class ClientTests(TestCase):
         self.assertEqual({"content-type": "text/xml", "foo": "bar"}, result)
         self.assertEqual(1, len(headers))
 
-        config = config._replace(soap_action="add")
+        config = replace(config, soap_action="add")
         client = Client(config=config)
         result = client.prepare_headers({})
         self.assertEqual({"SOAPAction": "add", "content-type": "text/xml"}, result)

--- a/xsdata/formats/dataclass/client.py
+++ b/xsdata/formats/dataclass/client.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass, fields
 from typing import Any, Dict, NamedTuple, Optional, Type, Union
 
 from xsdata.exceptions import ClientValueError
@@ -7,7 +8,8 @@ from xsdata.formats.dataclass.serializers import XmlSerializer
 from xsdata.formats.dataclass.transports import DefaultTransport, Transport
 
 
-class Config(NamedTuple):
+@dataclass(frozen=True)
+class Config:
     """Service configuration class.
 
     Attributes:
@@ -45,8 +47,8 @@ class Config(NamedTuple):
             A new config instance.
         """
         params = {
-            key: kwargs[key] if key in kwargs else getattr(obj, key, None)
-            for key in cls._fields
+            f.name: kwargs[f.name] if f.name in kwargs else getattr(obj, f.name, None)
+            for f in fields(cls)
         }
 
         return cls(**params)


### PR DESCRIPTION
## 📒 Description

Almost 3 years ago I converted the config to a namedtuple, let's revert back to dataclass so people an actually subclass the config.

Resolves #1009

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue

## 💬 Comments

> A place to write any comments to the reviewer.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
