### PR TITLE
feat: Validate fixed values

### DIFF
--- a/tests/formats/dataclass/parsers/nodes/test_element.py
+++ b/tests/formats/dataclass/parsers/nodes/test_element.py
@@ -83,7 +83,7 @@ class ElementNodeTests(FactoryTestCase):
         self.node.meta = self.context.build(FixedType)
 
         objects = []
-        self.assertTrue(self.node.bind("foo", "not the fixed value", None, objects))
+        self.assertTrue(self.node.bind("foo", "abc", None, objects))
         self.assertEqual(("foo", FixedType()), objects[-1])
 
     def test_bind_with_derived_element(self):
@@ -182,7 +182,7 @@ class ElementNodeTests(FactoryTestCase):
         self.node.meta = self.context.build(AttrsType)
         self.node.attrs = {
             "index": "0",
-            "fixed": "will be ignored",
+            "fixed": "ignored",
             "{what}ever": "qname",
             "extended": "attr",
         }
@@ -198,7 +198,7 @@ class ElementNodeTests(FactoryTestCase):
         self.node.config.fail_on_unknown_attributes = True
         self.node.attrs = {
             "index": "0",
-            "fixed": "will be ignored",
+            "fixed": "ignored",
             "{what}ever": "qname",
             "extended": "attr",
         }

--- a/tests/formats/dataclass/parsers/test_dict.py
+++ b/tests/formats/dataclass/parsers/test_dict.py
@@ -12,6 +12,7 @@ from tests.fixtures.models import (
     BaseType,
     ChoiceType,
     ExtendedType,
+    FixedType,
     OptionalChoiceType,
     TypeA,
     TypeB,
@@ -172,6 +173,13 @@ class DictDecoderTests(FactoryTestCase):
 
         with self.assertRaises(ParserError):
             self.decoder.bind_dataclass({"x": 1, "y": "a"}, TypeD)
+
+    def test_bind_dataclass_with_fixed_field(self):
+        obj = self.decoder.bind_dataclass({"value": "abc"}, FixedType)
+        self.assertEqual("abc", obj.value)
+
+        with self.assertRaises(ParserError):
+            self.decoder.bind_dataclass({"value": "abcd"}, FixedType)
 
     def test_bind_derived_dataclass(self):
         data = {

--- a/tests/formats/test_converter.py
+++ b/tests/formats/test_converter.py
@@ -53,6 +53,18 @@ class ConverterFactoryTests(TestCase):
 
         self.assertTrue(converter.test("0", [float]))
         self.assertFalse(converter.test("0", [float], strict=True))
+
+        self.assertTrue(converter.test("INF", [float], strict=True))
+        self.assertTrue(converter.test("inf", [float], strict=True))
+        self.assertTrue(converter.test("+INF", [float], strict=True))
+        self.assertTrue(converter.test("+inf", [float], strict=True))
+        self.assertTrue(converter.test("-INF", [float], strict=True))
+        self.assertTrue(converter.test("-inf", [float], strict=True))
+        self.assertTrue(converter.test("NAN", [float], strict=True))
+        self.assertTrue(converter.test("NaN", [float], strict=True))
+        self.assertTrue(converter.test("nan", [float], strict=True))
+        self.assertTrue(converter.test("-NAN", [float], strict=True))
+
         self.assertTrue(converter.test(".0", [float]))
         self.assertFalse(converter.test(".0", [float], strict=True))
         self.assertTrue(converter.test("1.0", [float]))

--- a/xsdata/formats/converter.py
+++ b/xsdata/formats/converter.py
@@ -160,6 +160,11 @@ class ConverterFactory:
             return False
 
         if strict and isinstance(decoded, (float, int, Decimal, XmlPeriod)):
+            if isinstance(decoded, float) and (
+                math.isinf(decoded) or math.isnan(decoded)
+            ):
+                return True
+
             encoded = self.serialize(decoded, **kwargs)
             return value.strip() == encoded
 

--- a/xsdata/models/config.py
+++ b/xsdata/models/config.py
@@ -497,7 +497,7 @@ class GeneratorConfig:
         name = "Config"
         namespace = "http://pypi.org/project/xsdata"
 
-    version: str = attribute(init=False, default=__version__)
+    version: str = attribute(default=__version__)
     output: GeneratorOutput = element(default_factory=GeneratorOutput)
     conventions: GeneratorConventions = element(default_factory=GeneratorConventions)
     substitutions: GeneratorSubstitutions = element(
@@ -542,7 +542,9 @@ class GeneratorConfig:
                 fail_on_converter_warnings=True,
             ),
         )
-        return parser.from_path(path, cls)
+        cfg = parser.from_path(path, cls)
+        cfg.version = __version__
+        return cfg
 
     @classmethod
     def write(cls, output: TextIO, obj: "GeneratorConfig"):


### PR DESCRIPTION
## 📒 Description

Until now we skipped parsing and validated fixed values, but this interferes with the parsing unions of classes with the same fields but with different fixed values.


Resolves #1012 

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue

## 💬 Comments

> A place to write any comments to the reviewer.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
