### PR TITLE
fix: Avoid recursive error on nested group references

### DIFF
--- a/tests/codegen/handlers/test_validate_references.py
+++ b/tests/codegen/handlers/test_validate_references.py
@@ -60,3 +60,37 @@ class ValidateReferencesTests(FactoryTestCase):
 
         with self.assertRaises(CodegenError):
             self.handler.run()
+
+    def test_validate_parent_references_with_root_class_with_parent(self):
+        target = ClassFactory.create()
+        target.parent = ClassFactory.create()
+        self.container.add(target)
+
+        with self.assertRaises(CodegenError):
+            self.handler.run()
+
+    def test_validate_parent_references_with_wrong_parent(self):
+        parent = ClassFactory.create()
+        child = ClassFactory.create()
+        wrong = ClassFactory.create()
+
+        parent.inner.append(child)
+        child.parent = wrong
+
+        self.container.extend([parent, wrong])
+
+        with self.assertRaises(CodegenError):
+            self.handler.run()
+
+    def test_validate_parent_references_with_wrong_parent_ref(self):
+        parent = ClassFactory.create()
+        child = ClassFactory.create()
+        wrong = parent.clone()
+
+        parent.inner.append(child)
+        child.parent = wrong
+
+        self.container.extend([parent])
+
+        with self.assertRaises(CodegenError):
+            self.handler.run()

--- a/tests/codegen/test_container.py
+++ b/tests/codegen/test_container.py
@@ -114,6 +114,9 @@ class ClassContainerTests(FactoryTestCase):
         target = ClassFactory.create(
             inner=[ClassFactory.elements(2), ClassFactory.elements(1)]
         )
+        for inner in target.inner:
+            inner.parent = target
+
         self.container.add(target)
 
         self.container.process()

--- a/tests/codegen/test_utils.py
+++ b/tests/codegen/test_utils.py
@@ -400,3 +400,28 @@ class ClassUtilsTests(FactoryTestCase):
         types = [xs_any]
         actual = ClassUtils.filter_types(types)
         self.assertEqual(1, len(actual))
+
+    def test_find_nested(self):
+        a = ClassFactory.create(qname="a")
+        b = ClassFactory.create(qname="b")
+        c = ClassFactory.create(qname="c")
+
+        a.inner.append(b)
+        b.inner.append(c)
+        c.parent = b
+        b.parent = a
+
+        self.assertEqual(a, ClassUtils.find_nested(a, "a"))
+        self.assertEqual(b, ClassUtils.find_nested(a, "b"))
+        self.assertEqual(b, ClassUtils.find_nested(c, "b"))
+        self.assertEqual(a, ClassUtils.find_nested(c, "a"))
+
+        a2 = ClassFactory.create(qname="a")
+        c.inner.append(a2)
+        a2.parent = c
+
+        # Breadth-first search
+        self.assertEqual(a2, ClassUtils.find_nested(c, "a"))
+
+        with self.assertRaises(CodegenError):
+            ClassUtils.find_nested(a, "nope")

--- a/tests/codegen/test_utils.py
+++ b/tests/codegen/test_utils.py
@@ -214,20 +214,6 @@ class ClassUtilsTests(FactoryTestCase):
         with self.assertRaises(CodegenError):
             ClassUtils.copy_inner_class(source, target, attr_type)
 
-    def test_find_inner(self):
-        obj = ClassFactory.create(qname="{a}parent")
-        first = ClassFactory.create(qname="{a}a")
-        second = ClassFactory.create(qname="{c}c")
-        third = ClassFactory.enumeration(2, qname="{d}d")
-        obj.inner.extend((first, second, third))
-
-        with self.assertRaises(CodegenError):
-            self.assertIsNone(ClassUtils.find_inner(obj, "nope"))
-
-        self.assertEqual(first, ClassUtils.find_inner(obj, "{a}a"))
-        self.assertEqual(second, ClassUtils.find_inner(obj, "{c}c"))
-        self.assertEqual(third, ClassUtils.find_inner(obj, "{d}d"))
-
     def test_flatten(self):
         target = ClassFactory.create(
             qname="{xsdata}root", attrs=AttrFactory.list(3), inner=ClassFactory.list(2)

--- a/xsdata/codegen/container.py
+++ b/xsdata/codegen/container.py
@@ -148,7 +148,7 @@ class ClassContainer(ContainerInterface):
         Raises:
             CodeGenerationError: If the inner class is not found.
         """
-        inner = ClassUtils.find_inner(source, qname)
+        inner = ClassUtils.find_nested(source, qname)
         if inner.status < self.step:
             self.process_class(inner, self.step)
 

--- a/xsdata/codegen/handlers/disambiguate_choices.py
+++ b/xsdata/codegen/handlers/disambiguate_choices.py
@@ -171,6 +171,7 @@ class DisambiguateChoices(RelativeHandlerInterface):
         if not inner:
             self.container.add(ref_class)
         else:
+            ref_class.parent = target
             target.inner.append(ref_class)
 
     def is_simple_type(self, choice: Attr) -> bool:

--- a/xsdata/codegen/handlers/flatten_attribute_groups.py
+++ b/xsdata/codegen/handlers/flatten_attribute_groups.py
@@ -1,6 +1,6 @@
 from xsdata.codegen.exceptions import CodegenError
 from xsdata.codegen.mixins import RelativeHandlerInterface
-from xsdata.codegen.models import Attr, Class
+from xsdata.codegen.models import Attr, Class, Status
 from xsdata.codegen.utils import ClassUtils
 
 
@@ -51,4 +51,5 @@ class FlattenAttributeGroups(RelativeHandlerInterface):
         if source is target:
             ClassUtils.remove_attribute(target, attr)
         else:
-            ClassUtils.copy_group_attributes(source, target, attr)
+            is_circular_ref = source.status == Status.UNGROUPING
+            ClassUtils.copy_group_attributes(source, target, attr, is_circular_ref)

--- a/xsdata/codegen/handlers/unnest_inner_classes.py
+++ b/xsdata/codegen/handlers/unnest_inner_classes.py
@@ -60,6 +60,7 @@ class UnnestInnerClasses(RelativeHandlerInterface):
             The new class instance
         """
         clone = inner.clone()
+        clone.parent = None
         clone.local_type = True
         clone.qname = build_qname(inner.target_namespace, f"{name}_{inner.name}")
 

--- a/xsdata/codegen/mappers/definitions.py
+++ b/xsdata/codegen/mappers/definitions.py
@@ -376,6 +376,7 @@ class DefinitionsMapper:
             )
             attr = cls.build_attr(name, inner.qname, forward=True, namespace=namespace)
 
+            inner.parent = target
             target.inner.append(inner)
             target.attrs.append(attr)
 

--- a/xsdata/codegen/mappers/dict.py
+++ b/xsdata/codegen/mappers/dict.py
@@ -66,6 +66,7 @@ class DictMapper(RawDocumentMapper):
         else:
             if isinstance(value, dict):
                 inner = cls.build_class(value, name)
+                inner.parent = target
                 attr_type = AttrType(qname=inner.qname, forward=True)
                 target.inner.append(inner)
             else:

--- a/xsdata/codegen/mappers/dtd.py
+++ b/xsdata/codegen/mappers/dtd.py
@@ -327,5 +327,5 @@ class DtdMapper:
                     types=[attr_type.clone()],
                 )
             )
-
+        inner.parent = target
         target.inner.append(inner)

--- a/xsdata/codegen/mappers/element.py
+++ b/xsdata/codegen/mappers/element.py
@@ -106,6 +106,7 @@ class ElementMapper(RawDocumentMapper):
 
                 if child.attributes or child.children:
                     inner = cls.build_class(child, namespace)
+                    inner.parent = target
                     attr_type = AttrType(qname=inner.qname, forward=True)
                     target.inner.append(inner)
                 else:

--- a/xsdata/codegen/mappers/schema.py
+++ b/xsdata/codegen/mappers/schema.py
@@ -360,6 +360,7 @@ class SchemaMapper:
         location = target.location
         namespace = target.target_namespace
         for inner in cls.build_inner_classes(obj, location, namespace):
+            inner.parent = target
             target.inner.append(inner)
             types.append(AttrType(qname=inner.qname, forward=True))
 

--- a/xsdata/codegen/mixins.py
+++ b/xsdata/codegen/mixins.py
@@ -25,6 +25,10 @@ class ContainerInterface(abc.ABC):
         """Yield an iterator for the class map values."""
 
     @abc.abstractmethod
+    def process(self):
+        """Run the processor and filter steps."""
+
+    @abc.abstractmethod
     def find(self, qname: str, condition: Callable = return_true) -> Optional[Class]:
         """Find class that matches the given qualified name and condition callable.
 

--- a/xsdata/codegen/models.py
+++ b/xsdata/codegen/models.py
@@ -714,6 +714,16 @@ class Class(CodegenModel):
 
         return any(inner.has_forward_ref() for inner in self.inner)
 
+    def parent_names(self) -> List[str]:
+        """Return the outer class names."""
+        result = []
+        target = self.parent
+        while target is not None:
+            result.append(target.name)
+            target = target.parent
+
+        return list(reversed(result))
+
 
 @dataclass
 class Import:

--- a/xsdata/codegen/models.py
+++ b/xsdata/codegen/models.py
@@ -512,6 +512,7 @@ class Class(CodegenModel):
         attrs: The list of all the attr instances
         inner: The list of all the inner class instances
         ns_map: The namespace prefix-URI map
+        parent: The parent outer class
     """
 
     qname: str
@@ -535,6 +536,7 @@ class Class(CodegenModel):
     attrs: List[Attr] = field(default_factory=list)
     inner: List["Class"] = field(default_factory=list)
     ns_map: Dict = field(default_factory=dict)
+    parent: Optional["Class"] = field(default=None, compare=False)
 
     @property
     def name(self) -> str:

--- a/xsdata/codegen/utils.py
+++ b/xsdata/codegen/utils.py
@@ -206,6 +206,7 @@ class ClassUtils:
             clone.module = target.module
             clone.status = Status.RAW
             attr_type.reference = clone.ref
+            clone.parent = target
             target.inner.append(clone)
 
     @classmethod
@@ -259,6 +260,7 @@ class ClassUtils:
             An iterator over all the found classes.
         """
         target.location = location
+        target.parent = None
 
         while target.inner:
             yield from cls.flatten(target.inner.pop(), location)

--- a/xsdata/codegen/utils.py
+++ b/xsdata/codegen/utils.py
@@ -196,7 +196,7 @@ class ClassUtils:
         if not attr_type.forward:
             return
 
-        inner = ClassUtils.find_inner(source, attr_type.qname)
+        inner = ClassUtils.find_nested(source, attr_type.qname)
         if inner is target:
             attr_type.circular = True
             attr_type.reference = target.ref
@@ -209,26 +209,6 @@ class ClassUtils:
             attr_type.reference = clone.ref
             clone.parent = target
             target.inner.append(clone)
-
-    @classmethod
-    def find_inner(cls, source: Class, qname: str) -> Class:
-        """Find an inner class in the source class by its qualified name.
-
-        Args:
-            source: The parent class instance
-            qname: The inner class qualified name
-
-        Returns:
-            The inner class instance
-
-        Raises:
-            CodeGenerationError: If no inner class matched.
-        """
-        for inner in source.inner:
-            if inner.qname == qname:
-                return inner
-
-        raise CodegenError("Missing inner class", parent=source, qname=qname)
 
     @classmethod
     def find_attr(cls, source: Class, name: str) -> Optional[Attr]:

--- a/xsdata/codegen/utils.py
+++ b/xsdata/codegen/utils.py
@@ -115,7 +115,9 @@ class ClassUtils:
             index += 1
 
     @classmethod
-    def copy_group_attributes(cls, source: Class, target: Class, attr: Attr):
+    def copy_group_attributes(
+        cls, source: Class, target: Class, attr: Attr, skip_inner_classes: bool = False
+    ):
         """Copy the attrs of the source class to the target class.
 
         The attr represents a reference to the source class which is
@@ -125,6 +127,8 @@ class ClassUtils:
             source: The source class instance
             target: The target class instance
             attr: The group attr instance
+            skip_inner_classes: Whether the attr is circular reference, which
+                means we can skip copying the inner classes.
         """
         index = target.attrs.index(attr)
         target.attrs.pop(index)
@@ -134,7 +138,8 @@ class ClassUtils:
             target.attrs.insert(index, clone)
             index += 1
 
-            cls.copy_inner_classes(source, target, clone)
+            if not skip_inner_classes:
+                cls.copy_inner_classes(source, target, clone)
 
     @classmethod
     def copy_extensions(cls, source: Class, target: Class, extension: Extension):

--- a/xsdata/formats/dataclass/templates/class.jinja2
+++ b/xsdata/formats/dataclass/templates/class.jinja2
@@ -3,7 +3,6 @@
     {%- include "docstrings." + docstring_name + ".jinja2" -%}
 {% endset -%}
 {% set parent_namespace = obj.namespace if obj.namespace is not none else parent_namespace|default(None) -%}
-{% set parents = parents|default([obj.name]) -%}
 {% set class_name =  obj.name|class_name -%}
 {% set class_annotations =  obj | class_annotations(class_name) -%}
 {% set global_type = level == 0 and not obj.local_type -%}
@@ -42,15 +41,14 @@ class {{ class_name }}{{"({})".format(base_classes) if base_classes }}:
 {{ post_meta_output|indent(4, first=True) }}
 {%- endif -%}
 {%- for attr in obj.attrs %}
-    {%- set field_typing = attr|field_type(parents) %}
-    {%- set field_definition = attr|field_definition(obj.ns_map, parent_namespace, parents) %}
+    {%- set field_typing = obj|field_type(attr) %}
+    {%- set field_definition = obj|field_definition(attr, parent_namespace) %}
     {{ attr.name|field_name(obj.name) }}: {{ field_typing }} = {{ field_definition }}
 {%- endfor -%}
 {%- for inner in obj.inner %}
     {%- set tpl = "enum.jinja2" if inner.is_enumeration else "class.jinja2" -%}
-    {%- set inner_parents = parents + [inner.name] -%}
     {%- filter indent(4) -%}
-        {%- with obj=inner, parents=inner_parents, level=(level + 1) -%}
+        {%- with obj=inner, level=(level + 1) -%}
             {% include tpl %}
         {%- endwith -%}
     {%- endfilter -%}


### PR DESCRIPTION
## 📒 Description

The generator supports inner class references, only from outer -> inner, not for inner classes on the same level, or any kind of uneven references, like this.

```python
from dataclasses import dataclass

@dataclass
class A:
    a: "B"

    @dataclass
    class B:
        b: "A.C"

        @dataclass
        class D:
            d: str

    @dataclass
    class C:
        c: "A.B.D"
```

This is a limiting factor for groups with self references, that causes recursion limit errors. Let's see if we can address that!


Resolves #1008 

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue

## 💬 Comments

> A place to write any comments to the reviewer.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
