### PR TITLE
feat: Add warning for same module designation

### DIFF
--- a/tests/codegen/handlers/test_designate_class_packages.py
+++ b/tests/codegen/handlers/test_designate_class_packages.py
@@ -23,6 +23,7 @@ class DesignateClassPackagesTests(FactoryTestCase):
         prpa = "file://HL7V3/NE2008/multicacheschemas/PRPA_MT201307UV02.xsd"
         coct = "file://HL7V3/NE2008/multicacheschemas/COCT_MT080000UV.xsd"
         foo_bar = "http://xsdata/foo/bar/schema.xsd"
+        foo_wsdl = "http://xsdata/foo/bar/schema.wsdl"
         foo_common = "http://xsdata/foo/common.xsd"
         xsi = Namespace.XSI.location
         xlink = Namespace.XLINK.location
@@ -31,6 +32,7 @@ class DesignateClassPackagesTests(FactoryTestCase):
         multi_one = ClassFactory.list(2, location=prpa)
         multi_two = ClassFactory.list(1, location=coct)
         http_one = ClassFactory.list(1, location=foo_bar)
+        wsdl_one = ClassFactory.list(1, location=foo_wsdl)
         http_two = ClassFactory.list(1, location=foo_common)
         local_one = ClassFactory.list(1, location=xsi)
         local_two = ClassFactory.list(1, location=xlink)
@@ -39,23 +41,25 @@ class DesignateClassPackagesTests(FactoryTestCase):
         self.container.extend(multi_one)
         self.container.extend(multi_two)
         self.container.extend(http_one)
+        self.container.extend(wsdl_one)
         self.container.extend(http_two)
         self.container.extend(local_one)
         self.container.extend(local_two)
 
-        self.config.output.package = "foo.bar"
+        self.config.output.package = "foo"
 
         self.handler.run()
 
-        self.assertEqual("foo.bar.coreschemas", core[0].package)
-        self.assertEqual("foo.bar.coreschemas", core[0].inner[0].package)
-        self.assertEqual("foo.bar.multicacheschemas", multi_one[0].package)
-        self.assertEqual("foo.bar.multicacheschemas", multi_one[1].package)
-        self.assertEqual("foo.bar.multicacheschemas", multi_two[0].package)
-        self.assertEqual("foo.bar.bar", http_one[0].package)
-        self.assertEqual("foo.bar", http_two[0].package)
-        self.assertEqual("foo.bar", local_one[0].package)
-        self.assertEqual("foo.bar", local_two[0].package)
+        self.assertEqual("foo.coreschemas", core[0].package)
+        self.assertEqual("foo.coreschemas", core[0].inner[0].package)
+        self.assertEqual("foo.multicacheschemas", multi_one[0].package)
+        self.assertEqual("foo.multicacheschemas", multi_one[1].package)
+        self.assertEqual("foo.multicacheschemas", multi_two[0].package)
+        self.assertEqual("foo.bar", http_one[0].package)
+        self.assertEqual("foo", http_two[0].package)
+        self.assertEqual("foo.bar", wsdl_one[0].package)
+        self.assertEqual("foo", local_one[0].package)
+        self.assertEqual("foo", local_two[0].package)
 
     def test_group_by_namespace(self):
         classes = [


### PR DESCRIPTION
## 📒 Description

Add warning to notify users if classes from two different locations end up in the same module, when the filenames structure style is used.

```
warning: Classes from different locations are designated to same module.
You can resolve this if you switch to another `--structure-style`.
file:///home/chris/projects/xsdata/issue/schema/conn/SignatureService_V7_5_6.wsdl
file:///home/chris/projects/xsdata/issue/schema/conn/SignatureService_V7_5_6.xsd
```

Resolves #1014

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue

## 💬 Comments

> A place to write any comments to the reviewer.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
