### PR TITLE
fix(docs): fix typo on type `str`

### DIFF
--- a/docs/models/classes.md
+++ b/docs/models/classes.md
@@ -47,7 +47,7 @@ The local name of the XML/JSON element.
 
 ```
 
-**Type:** `srt`
+**Type:** `str`
 
 **Default:** `The class name`
 
@@ -66,7 +66,7 @@ The namespace name of the XML element
 
 ```
 
-**Type:** `srt | None`
+**Type:** `str | None`
 
 **Default:** `None`
 
@@ -102,7 +102,7 @@ doesn't have any meaningful content.
 The namespace name, the XML element was defined under. Used during auto-type discovery
 when the element form is `unqualified`.
 
-**Type:** `srt | None`
+**Type:** `str | None`
 
 **Default:** `None`
 

--- a/docs/models/fields.md
+++ b/docs/models/fields.md
@@ -35,7 +35,7 @@ The local name of the XML/JSON field.
 
 ```
 
-**Type:** `srt`
+**Type:** `str`
 
 **Default:** `The field name`
 


### PR DESCRIPTION
In the docs, the string type was written `srt` instead of `str`. This merge request fix this.