### PR TITLE
feat: Remove whitespace from bytes encoded xml strings

### DIFF
--- a/tests/formats/test_converter.py
+++ b/tests/formats/test_converter.py
@@ -1,9 +1,9 @@
 import sys
+import unittest
 from datetime import date, datetime, time
 from decimal import Decimal
 from enum import Enum
 from typing import Any
-from unittest import TestCase
 from xml.etree.ElementTree import QName
 
 import pytest
@@ -15,7 +15,7 @@ from xsdata.models.datatype import XmlDuration, XmlPeriod
 from xsdata.models.enums import UseType
 
 
-class ConverterFactoryTests(TestCase):
+class ConverterFactoryTests(unittest.TestCase):
     def test_deserialize(self):
         with self.assertRaises(ConverterError) as cm:
             converter.deserialize("a", [int])
@@ -106,7 +106,7 @@ class ConverterFactoryTests(TestCase):
         converter.unregister_converter(MinusOneInt)
 
 
-class StrConverterTests(TestCase):
+class StrConverterTests(unittest.TestCase):
     def setUp(self):
         self.converter = converter.type_converter(str)
 
@@ -119,7 +119,7 @@ class StrConverterTests(TestCase):
         self.assertEqual("1", self.converter.serialize(1))
 
 
-class StringConverterTests(TestCase):
+class StringConverterTests(unittest.TestCase):
     def setUp(self):
         self.converter = converter.type_converter(str)
 
@@ -134,7 +134,7 @@ class StringConverterTests(TestCase):
         self.assertEqual("1", self.converter.serialize(1))
 
 
-class BoolConverterTests(TestCase):
+class BoolConverterTests(unittest.TestCase):
     def setUp(self):
         self.converter = converter.type_converter(bool)
 
@@ -155,7 +155,7 @@ class BoolConverterTests(TestCase):
         self.assertEqual("false", self.converter.serialize(False))
 
 
-class IntConverterTests(TestCase):
+class IntConverterTests(unittest.TestCase):
     def setUp(self):
         self.converter = converter.type_converter(int)
 
@@ -171,7 +171,7 @@ class IntConverterTests(TestCase):
         self.assertEqual("2", self.converter.serialize(2))
 
 
-class FloatConverterTests(TestCase):
+class FloatConverterTests(unittest.TestCase):
     def setUp(self):
         self.converter = converter.type_converter(float)
 
@@ -191,14 +191,14 @@ class FloatConverterTests(TestCase):
         self.assertEqual("8.77683E-08", self.converter.serialize(float("8.77683E-8")))
 
 
-class BytesConverterTests(TestCase):
+class BytesConverterTests(unittest.TestCase):
     def setUp(self):
         self.converter = converter.type_converter(bytes)
 
     def test_serialize_with_base16_format(self):
         inputs = [
-            ("312d322d33", "312D322D33"),
-            ("312D322D33", "312D322D33"),
+            ("312d\n322d33", "312D322D33"),
+            ("312D \t322D33", "312D322D33"),
         ]
 
         for actual, expected in inputs:
@@ -245,7 +245,7 @@ class BytesConverterTests(TestCase):
             self.converter.deserialize("foo", format="foo")
 
 
-class DecimalConverterTests(TestCase):
+class DecimalConverterTests(unittest.TestCase):
     def setUp(self):
         self.converter = converter.type_converter(Decimal)
 
@@ -265,7 +265,7 @@ class DecimalConverterTests(TestCase):
         )
 
 
-class DateTimeConverterTests(TestCase):
+class DateTimeConverterTests(unittest.TestCase):
     def setUp(self):
         self.converter = converter.type_converter(datetime)
 
@@ -298,7 +298,7 @@ class DateTimeConverterTests(TestCase):
             self.converter.deserialize("21 June 2018 15:40", format="")
 
 
-class DateConverterTests(TestCase):
+class DateConverterTests(unittest.TestCase):
     def setUp(self):
         self.converter = converter.type_converter(date)
 
@@ -311,7 +311,7 @@ class DateConverterTests(TestCase):
         self.assertEqual(original, self.converter.serialize(obj, format=fmt))
 
 
-class TimeConverterTests(TestCase):
+class TimeConverterTests(unittest.TestCase):
     def setUp(self):
         self.converter = converter.type_converter(time)
 
@@ -324,7 +324,7 @@ class TimeConverterTests(TestCase):
         self.assertEqual(original, self.converter.serialize(obj, format=fmt))
 
 
-class QNameConverterTests(TestCase):
+class QNameConverterTests(unittest.TestCase):
     def setUp(self):
         self.converter = converter.type_converter(QName)
 
@@ -365,7 +365,7 @@ class EnumA(Enum):
     J = (Telephone(1, 2, 3), Telephone(4, 5, 6))
 
 
-class EnumConverterTests(TestCase):
+class EnumConverterTests(unittest.TestCase):
     def setUp(self):
         self.converter = converter.type_converter(Enum)
 
@@ -399,7 +399,7 @@ class EnumConverterTests(TestCase):
         self.assertEqual("2.1", self.converter.serialize(EnumA.C))
 
 
-class ProxyConverterTests(TestCase):
+class ProxyConverterTests(unittest.TestCase):
     def setUp(self):
         self.converter = ProxyConverter(lambda x: int(x))
 
@@ -413,7 +413,7 @@ class ProxyConverterTests(TestCase):
         self.assertEqual("1", self.converter.serialize(1))
 
 
-class XmlDurationConverterTests(TestCase):
+class XmlDurationConverterTests(unittest.TestCase):
     def setUp(self):
         self.converter = converter.type_converter(XmlDuration)
 
@@ -429,7 +429,7 @@ class XmlDurationConverterTests(TestCase):
         self.assertNotIsInstance(actual, XmlDuration)
 
 
-class XmlPeriodConverterTests(TestCase):
+class XmlPeriodConverterTests(unittest.TestCase):
     def setUp(self):
         self.converter = converter.type_converter(XmlPeriod)
 

--- a/xsdata/formats/converter.py
+++ b/xsdata/formats/converter.py
@@ -2,6 +2,7 @@ import abc
 import base64
 import binascii
 import math
+import re
 from datetime import date, datetime, time
 from decimal import Decimal, InvalidOperation
 from enum import Enum, EnumMeta
@@ -424,6 +425,7 @@ class BytesConverter(Converter):
 
         try:
             fmt = kwargs.get("format")
+            value = re.sub(r"\s+", "", value)
 
             if fmt == "base16":
                 return binascii.unhexlify(value)


### PR DESCRIPTION
## 📒 Description

At some point we enabled strict bytes parsing and in a lot of samples people/libraries love to split the values into multiple lines which now fails in xsdata. Let's ensure no whitespace exists before we parse the actual value

Resolves #xxxx

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue

## 💬 Comments

> A place to write any comments to the reviewer.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
