### PR TITLE
fix: Run Ruff on package directories rather than files

### DIFF
--- a/docs/codegen/config.md
+++ b/docs/codegen/config.md
@@ -85,6 +85,13 @@ The output package for the generated code, e.g. `code.models`
 
 **CLI Option:** `-p, --package TEXT`
 
+!!! Warning
+
+    Formatting and linting is executed on any directory that contains a Python file
+    created during generation, including other Python files in the same directory prior
+    to generation. As such it is recommended that the directories represented by this
+    option do not include any previously created files.
+
 ### Format
 
 The output format for the generated code, e.g. `code.models`


### PR DESCRIPTION
## 📒 Description

Run Ruff on package directories rather than individual files, to avoid large schema sets exceeding the character limits when on Windows.

Resolves #1048

## 🔗 What I've Done

Updates the `DataclassGenerator.render()` method to collect package directories rather than individual files, to be passed to the `ruff_code()` method.

Also adds a warning to the Configuration page of the documentation to indicate that Ruff will be run on any file in the package directory.

## 💬 Comments

> A place to write any comments to the reviewer.

## 🛫 Checklist

- [x] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
