### PR TITLE
fix: Use ruff to enforce double quotes on patterns

### DIFF
--- a/tests/formats/dataclass/test_filters.py
+++ b/tests/formats/dataclass/test_filters.py
@@ -302,7 +302,7 @@ class FiltersTests(FactoryTestCase):
             "field(\n"
             "        default=None,\n"
             "        metadata={\n"
-            '            "pattern": r"([^\\ \\? > < \\* / \\" \\": |]{1,256})",\n'
+            '            "pattern": r\'([^\\ \\? > < \\* / " ": |]{1,256})\',\n'
             "        }\n"
             "    )"
         )
@@ -953,7 +953,7 @@ class FiltersTests(FactoryTestCase):
             '    "text": "foo",\n'
             '    "text_two": "fo\'o",\n'
             '    "text_three": "fo\\"o",\n'
-            '    "pattern": r"foo",\n'
+            "    \"pattern\": r'foo',\n"
             '    "custom": Telephone(country_code=30, area_code=123, number=4567),\n'
             '    "level_two": {\n'
             '        "a": 1,\n'

--- a/xsdata/formats/dataclass/filters.py
+++ b/xsdata/formats/dataclass/filters.py
@@ -40,7 +40,6 @@ class Filters:
 
     DEFAULT_KEY = "default"
     FACTORY_KEY = "default_factory"
-    UNESCAPED_DBL_QUOTE_REGEX = re.compile(r"([^\\])\"")
 
     __slots__ = (
         "substitutions",
@@ -569,10 +568,7 @@ class Filters:
             return data
 
         if key == "pattern":
-            # escape double quotes because double quotes surround the regex string
-            # in the rendered output
-            value = self.UNESCAPED_DBL_QUOTE_REGEX.sub(r'\1\\"', data)
-            return f'r"{value}"'
+            return f"r{repr(data)}".replace("\\\\", "\\")
 
         if data == "":
             return '""'


### PR DESCRIPTION
## 📒 Description

The template filter is trying to enforce double quotes on patterns, with some jenky regular expression, let ruff to deal with it

Resolves #1054

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue

## 💬 Comments

> A place to write any comments to the reviewer.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
