### PR TITLE
fix: Reset attr types derived from empty simple types

### DIFF
--- a/docs/codegen/download_schemas.md
+++ b/docs/codegen/download_schemas.md
@@ -1,8 +1,28 @@
 # Download Schemas
 
 Generating from remote resources is not a great idea, the cli includes a command to
-download schemas and wsdl locally.
+download schemas and wsdl locally. The command will download any included schemas
+recursively.
 
 ```console exec="1" source="console"
 $ xsdata download --help
+```
+
+**Example**
+
+```console
+❯ xsdata download https://www.w3.org/Math/XMLSchema/mathml3/mathml3.xsd -o ~/schemas
+========= xsdata v24.6.1 / Python 3.11.8 / Platform linux =========
+
+Setting base path to https:/www.w3.org/Math/XMLSchema/mathml3
+Fetching https://www.w3.org/Math/XMLSchema/mathml3/mathml3.xsd
+Fetching https://www.w3.org/Math/XMLSchema/mathml3/mathml3-content.xsd
+Fetching https://www.w3.org/Math/XMLSchema/mathml3/mathml3-strict-content.xsd
+Writing /home/chris/schemas/mathml3-strict-content.xsd
+Writing /home/chris/schemas/mathml3-content.xsd
+Fetching https://www.w3.org/Math/XMLSchema/mathml3/mathml3-presentation.xsd
+Writing /home/chris/schemas/mathml3-presentation.xsd
+Fetching https://www.w3.org/Math/XMLSchema/mathml3/mathml3-common.xsd
+Writing /home/chris/schemas/mathml3-common.xsd
+Writing /home/chris/schemas/mathml3.xsd
 ```

--- a/tests/codegen/handlers/test_process_attributes_types.py
+++ b/tests/codegen/handlers/test_process_attributes_types.py
@@ -145,7 +145,7 @@ class ProcessAttributeTypesTests(FactoryTestCase):
         attr_type = attr.types[0]
 
         self.processor.process_dependency_type(target, attr, attr_type)
-        mock_reset_attribute_type.assert_called_once_with(attr_type, True)
+        mock_reset_attribute_type.assert_called_once_with(attr_type)
 
     @mock.patch.object(ProcessAttributeTypes, "copy_attribute_properties")
     @mock.patch.object(ProcessAttributeTypes, "find_dependency")
@@ -298,6 +298,18 @@ class ProcessAttributeTypesTests(FactoryTestCase):
                 mock.call(source, target, source.attrs[0].types[1]),
             ]
         )
+
+    @mock.patch.object(ProcessAttributeTypes, "reset_attribute_type")
+    def test_copy_attribute_properties_from_empty_source(
+        self, mock_reset_attribute_type
+    ):
+        source = ClassFactory.create()
+        target = ClassFactory.elements(1)
+        attr = target.attrs[0]
+
+        self.processor.copy_attribute_properties(source, target, attr, attr.types[0])
+
+        mock_reset_attribute_type.assert_called_once_with(attr.types[0])
 
     def test_copy_attribute_properties_from_nillable_source(self):
         source = ClassFactory.elements(1, nillable=True)

--- a/xsdata/codegen/handlers/process_attributes_types.py
+++ b/xsdata/codegen/handlers/process_attributes_types.py
@@ -187,7 +187,7 @@ class ProcessAttributeTypes(RelativeHandlerInterface):
         source = self.find_dependency(attr_type, attr.tag)
         if not source:
             logger.warning("Reset absent type: %s", attr_type.name)
-            self.reset_attribute_type(attr_type, True)
+            self.reset_attribute_type(attr_type)
         elif source.is_enumeration:
             attr.restrictions.min_length = None
             attr.restrictions.max_length = None
@@ -230,6 +230,11 @@ class ProcessAttributeTypes(RelativeHandlerInterface):
         Raises:
             AnalyzerValueError: if the source class has more than one attributes
         """
+        if not source.attrs:
+            logger.warning("Reset absent simple type: %s", attr_type.name)
+            cls.reset_attribute_type(attr_type)
+            return
+
         source_attr = source.attrs[0]
         index = attr.types.index(attr_type)
         attr.types.pop(index)
@@ -257,17 +262,16 @@ class ProcessAttributeTypes(RelativeHandlerInterface):
         attr.default = attr.default or source_attr.default
 
     @classmethod
-    def reset_attribute_type(cls, attr_type: AttrType, use_str: bool = True):
-        """Reset the attribute type to string or any simple type.
+    def reset_attribute_type(cls, attr_type: AttrType):
+        """Reset the attribute type to string.
 
         The method will also unset the circular/forward flags, as native
         types only depend on python builtin types.
 
         Args:
             attr_type: The attr type instance to reset
-            use_str: Whether to use xs:string or xs:anySimpleType
         """
-        attr_type.qname = str(DataType.STRING if use_str else DataType.ANY_SIMPLE_TYPE)
+        attr_type.qname = str(DataType.STRING)
         attr_type.native = True
         attr_type.circular = False
         attr_type.forward = False


### PR DESCRIPTION
## 📒 Description

When we process attribute types derived from simple types, that are incomplete due to a missing xsd, we should reset the type and log a warning like we do for all absent xs types.

Resolves #1059 

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue

## 💬 Comments

> A place to write any comments to the reviewer.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
