### PR TITLE
feat: Filter element unions against fixed attribute values

### DIFF
--- a/tests/formats/dataclass/parsers/test_utils.py
+++ b/tests/formats/dataclass/parsers/test_utils.py
@@ -7,7 +7,7 @@ from xsdata.formats.converter import ConverterFactory
 from xsdata.formats.dataclass.context import XmlContext
 from xsdata.formats.dataclass.parsers.config import ParserConfig
 from xsdata.formats.dataclass.parsers.utils import ParserUtils
-from xsdata.models.enums import Namespace, QNames
+from xsdata.models.enums import Namespace, ProcessType, QNames
 from xsdata.utils.testing import FactoryTestCase, XmlMetaFactory, XmlVarFactory
 
 
@@ -116,6 +116,9 @@ class ParserUtilsTests(FactoryTestCase):
 
         var = XmlVarFactory.create("fixed", default=lambda: float("nan"))
         ParserUtils.validate_fixed_value(meta, var, float("nan"))
+
+        var = XmlVarFactory.create("fixed", default=lambda: ProcessType.LAX)
+        ParserUtils.validate_fixed_value(meta, var, "lax")
 
     def test_parse_var_with_error(self):
         meta = XmlMetaFactory.create(clazz=TypeA, qname="foo")

--- a/xsdata/formats/dataclass/parsers/nodes/union.py
+++ b/xsdata/formats/dataclass/parsers/nodes/union.py
@@ -1,7 +1,8 @@
 import copy
+import functools
 from contextlib import suppress
 from dataclasses import replace
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Type
 
 from xsdata.exceptions import ParserError
 from xsdata.formats.dataclass.context import XmlContext
@@ -40,6 +41,7 @@ class UnionNode(XmlNode):
         "context",
         "level",
         "events",
+        "candidates",
     )
 
     def __init__(
@@ -60,7 +62,40 @@ class UnionNode(XmlNode):
         self.config = config
         self.context = context
         self.level = 0
+        self.candidates = self.filter_candidates()
         self.events: List[Tuple[str, str, Any, Any]] = []
+
+    def filter_candidates(self) -> List[Type]:
+        """Filter union candidates by fixed attributes."""
+        candidates = list(self.var.types)
+        fixed_attribute = functools.partial(
+            self.filter_fixed_attrs, parent_ns=target_uri(self.var.qname)
+        )
+
+        return list(filter(fixed_attribute, candidates))
+
+    def filter_fixed_attrs(self, candidate: Type, parent_ns: str) -> bool:
+        """Return whether the node attrs are incompatible with fixed attrs.
+
+        Args:
+            candidate: The candidate type
+            parent_ns: The parent namespace
+        """
+        if not self.context.class_type.is_model(candidate):
+            return not self.attrs
+
+        meta = self.context.build(candidate, parent_ns=parent_ns)
+        for qname, value in self.attrs.items():
+            var = meta.find_attribute(qname)
+            if not var or var.init:
+                continue
+
+            try:
+                ParserUtils.validate_fixed_value(meta, var, value)
+            except ParserError:
+                return False
+
+        return True
 
     def child(self, qname: str, attrs: Dict, ns_map: Dict, position: int) -> XmlNode:
         """Record the event for the child element.
@@ -120,29 +155,31 @@ class UnionNode(XmlNode):
         parent_namespace = target_uri(qname)
         config = replace(self.config, fail_on_converter_warnings=True)
 
-        for clazz in self.var.types:
-            candidate = None
+        for candidate in self.candidates:
+            result = None
             with suppress(Exception):
-                if self.context.class_type.is_model(clazz):
-                    self.context.build(clazz, parent_ns=parent_namespace)
+                if self.context.class_type.is_model(candidate):
+                    self.context.build(candidate, parent_ns=parent_namespace)
                     parser = NodeParser(
-                        config=config, context=self.context, handler=EventsHandler
+                        config=config,
+                        context=self.context,
+                        handler=EventsHandler,
                     )
-                    candidate = parser.parse(self.events, clazz)
+                    result = parser.parse(self.events, candidate)
                 else:
-                    candidate = ParserUtils.parse_var(
+                    result = ParserUtils.parse_var(
                         meta=self.meta,
                         var=self.var,
                         config=config,
                         value=text,
-                        types=[clazz],
+                        types=[candidate],
                         ns_map=self.ns_map,
                     )
 
-            score = self.context.class_type.score_object(candidate)
+            score = self.context.class_type.score_object(result)
             if score > max_score:
                 max_score = score
-                obj = candidate
+                obj = result
 
         if obj:
             objects.append((self.var.qname, obj))

--- a/xsdata/formats/dataclass/parsers/utils.py
+++ b/xsdata/formats/dataclass/parsers/utils.py
@@ -228,7 +228,7 @@ class ParserUtils:
         Special cases
             - float nans are never equal in python
             - strings with whitespaces, need trimming
-
+            - comparing raw str values
         """
 
         default_value = var.default() if callable(var.default) else var.default
@@ -243,6 +243,9 @@ class ParserUtils:
             and default_value.strip() == value.strip()
         ):
             return
+
+        if isinstance(value, str) and not isinstance(default_value, str):
+            default_value = converter.serialize(default_value, format=var.format)
 
         if default_value != value:
             raise ParserError(


### PR DESCRIPTION
## 📒 Description

For union fields, the parser has to attempt parsing with each type and then decide which output is the "most" successful. This is is slow and painful process, this pr adds an optimization strategy when union types have fixed attributes.


Resolves #1057 

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue

## 💬 Comments

> A place to write any comments to the reviewer.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
