### PR TITLE
feat: XmlSerializer skip optional nillable elements

### DIFF
--- a/docs/models/fields.md
+++ b/docs/models/fields.md
@@ -63,12 +63,12 @@ The namespace name of the XML element or attribute.
 ### `nillable`
 
 Specify if the field has to be present in the serialized result even when it doesn't
-have any meaningful content.
+have any meaningful content. If the field is not required the serializer will ignore it.
 
 ```python
 >>> @dataclass
 ... class Root:
-...     first: Optional[str] = field(metadata={"nillable": True}, default=None)
+...     first: Optional[str] = field(metadata={"nillable": True, "required": True}, default=None)
 ...     second: Optional[str] = field(default=None)
 ...
 >>> print(serializer.render(Root()))

--- a/tests/fixtures/models.py
+++ b/tests/fixtures/models.py
@@ -172,6 +172,8 @@ class SequentialType:
     x4: Optional[int] = field(
         default=None, metadata={"type": "Element", "sequence": 2}
     )
+    x5: Optional[str] = field(default=None, metadata={"type": "Element", "nillable": True})
+    x6: Optional[str] = field(default=None, metadata={"type": "Element", "nillable": True, "required": True})
 
 
 @dataclass

--- a/tests/formats/dataclass/serializers/test_mixins.py
+++ b/tests/formats/dataclass/serializers/test_mixins.py
@@ -693,6 +693,10 @@ class EventGeneratorTests(TestCase):
         expected = [
             ("start", "a"),
             ("attr", "a0", "foo"),
+            ("start", "{xsdata}x6"),
+            ("attr", QNames.XSI_NIL, "true"),
+            ("data", None),
+            ("end", "{xsdata}x6"),
             ("end", "a"),
         ]
 
@@ -814,6 +818,7 @@ class EventGeneratorTests(TestCase):
         x2 = next(meta.find_children("x2"))
         x3 = next(meta.find_children("x3"))
         x4 = next(meta.find_children("x4"))
+        x6 = next(meta.find_children("x6"))
 
         actual = self.generator.next_value(obj, meta)
         expected = [
@@ -825,6 +830,7 @@ class EventGeneratorTests(TestCase):
             (x1, 4),
             (x3, 9),
             (x4, 10),
+            (x6, None),
         ]
 
         self.assertIsInstance(actual, Generator)

--- a/xsdata/formats/dataclass/serializers/mixins.py
+++ b/xsdata/formats/dataclass/serializers/mixins.py
@@ -933,7 +933,7 @@ class EventGenerator:
 
             if var.sequence is None:
                 value = getattr(obj, var.name)
-                if value is not None or var.nillable:
+                if value is not None or (var.nillable and var.required):
                     yield var, value
                 index += 1
                 continue
@@ -955,11 +955,11 @@ class EventGenerator:
                         if j < len(values):
                             rolling = True
                             value = values[j]
-                            if value is not None or var.nillable:
+                            if value is not None or (var.nillable and var.required):
                                 yield var, value
                     elif j == 0:
                         rolling = True
-                        if values is not None or var.nillable:
+                        if values is not None or (var.nillable and var.required):
                             yield var, values
 
                 j += 1


### PR DESCRIPTION
## 📒 Description

Using nillable on optional elements, is not very common, since both of these outputs are correct, let's make xsdata to render the minimum valid output by default.


```xsd
<?xml version="1.0" encoding="utf-8"?>
<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
    <xs:element name="elements">
      <xs:complexType>
        <xs:sequence>
          <xs:element minOccurs="0" name="foobar" nillable="true" type="xs:string"/>
        </xs:sequence>
      </xs:complexType>
    </xs:element>
</xs:schema>
```


```xml
<elements xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <foobar xsi:nil="true"/>
</elements>
```

```xml
<?xml version="1.0" encoding="utf-8"?>
<elements xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
</elements>
```



Resolves #1063 

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue

## 💬 Comments

> A place to write any comments to the reviewer.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
