### PR TITLE
Implement Compound Fields only for is_list

### DIFF
--- a/xsdata/codegen/handlers/create_compound_fields.py
+++ b/xsdata/codegen/handlers/create_compound_fields.py
@@ -43,8 +43,15 @@ class CreateCompoundFields(RelativeHandlerInterface):
         """
         groups = group_by(target.attrs, get_restriction_choice)
         for choice, attrs in groups.items():
+            is_list = False
+            if self.config.list_only:
+                try:
+                    is_list = next(True for attr in attrs if attr.is_list)
+                except StopIteration:
+                    pass
+
             if choice and len(attrs) > 1:
-                if self.config.enabled:
+                if self.config.enabled and (not self.config.list_only or is_list):
                     self.group_fields(target, attrs)
                 else:
                     self.calculate_choice_min_occurs(attrs)

--- a/xsdata/models/config.py
+++ b/xsdata/models/config.py
@@ -192,6 +192,7 @@ class CompoundFields:
 
     Args:
         enabled: Use compound fields for repeatable elements
+        list_only: Only use compound fields for lists
         default_name: Default compound field name
         use_substitution_groups: Use substitution groups if they
             exist, instead of element names.
@@ -204,6 +205,7 @@ class CompoundFields:
     """
 
     enabled: bool = text_node(default=False, cli="compound-fields")
+    list_only: bool = attribute(default=False, cli=False)
     default_name: str = attribute(default="choice", cli=False)
     use_substitution_groups: bool = attribute(default=False, cli=False)
     force_default_name: bool = attribute(default=False, cli=False)


### PR DESCRIPTION
## 📒 Description

A follow up on #1065.

CompoundFields currently aggregate choices, but the description mentions "repeatable fields". Which allows it to render a choice item in the found order. In the regular case where an object has two fields, and either one of those fields must be set (or read) I would prefer to access that field by its field name, not field1_field2 or choice. There is only one situation - I am aware of - where I want to maintain order: this is when the choice field is part of a sequence with maxOccurs > 1, hence it becomes a List.

Resolves #1070.

## 🔗 What I've Done

At the compound field generation stage, explicitly check if any of the grouped attrs is in fact a list. In otherwise we assume that it is not.

## 💬 Comments

Now there must likely be a situation where this approach fails. And I wonder how the generation 'compound-fields' handles multiple elements, where only one is allowed. But this would be an issue for the existing code too.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
