### PR TITLE
fix: fix python 3.13 deprecation

### DIFF
--- a/xsdata/formats/dataclass/typing.py
+++ b/xsdata/formats/dataclass/typing.py
@@ -33,7 +33,12 @@ if (3, 9) <= sys.version_info[:2] <= (3, 10):
             tp = tp.__origin__[args]  # type: ignore
 
         return __eval_type(tp, globalns, localns)
+elif sys.version_info[:2] >= (3, 13):
+    # python 3.13+ requires type_params argument
+    from typing import _eval_type as __eval_type  # type: ignore
 
+    def _eval_type(tp: Any, globalns: Any, localns: Any) -> Any:
+        return __eval_type(tp, globalns, localns, type_params=())
 else:
     from typing import _eval_type  # type: ignore
 


### PR DESCRIPTION
## 📒 Description

deals with the deprecation error added in python 3.13 to the private usage of `typing._eval_type` when called without type_params

https://github.com/python/cpython/blob/3bd942f106aa36c261a2d90104c027026b2a8fb6/Lib/typing.py#L474

Resolves #1076 


## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
