### PR TITLE
Add cli config to use generic collections

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {name: Python 3.8, python: '3.8'}
           - {name: Python 3.9, python: '3.9'}
           - {name: Python 3.10, python: '3.10'}
           - {name: Python 3.11, python: '3.11'}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,24 +2,24 @@ exclude: tests/fixtures
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: debug-statements
   - repo: https://github.com/crate-ci/typos
-    rev: v1.24.6
+    rev: v1.26.0
     hooks:
       - id: typos
         exclude: ^tests/|.xsd|xsdata/models/datatype.py$
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.6
+    rev: v0.7.0
     hooks:
       - id: ruff
         args: [ --fix, --show-fixes]
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.2
+    rev: v1.12.1
     hooks:
       - id: mypy
         files: ^(xsdata/)

--- a/docs/codegen/config.md
+++ b/docs/codegen/config.md
@@ -60,7 +60,14 @@ type # typing.Type
 
 **CLI Option:** `--subscriptable-types / --no-subscriptable-types`
 
-**Requirements:** `python>=3.9`
+### `genericCollections`
+
+Use `collections.abc.Iterable` and `collections.abc.Mapping` instead of `List|Tuple` and
+`Dict`
+
+**Default Value:** `False`
+
+**CLI Option:** `--generic-collections / --no-generic-collections`
 
 ### `unionType`
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -34,7 +34,7 @@ $ xsdata --help
 
 ## Requirements
 
-!!! Note "xsData relies on these awesome libraries and supports `python >= 3.8`"
+!!! Note "xsData relies on these awesome libraries and supports `python >= 3.9`"
 
     - [lxml](https://lxml.de/) - XML advanced features
     - [requests](https://requests.readthedocs.io/) - Webservice Default Transport

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -29,7 +28,7 @@ classifiers = [
     "Topic :: Text Processing :: Markup :: XML",
 ]
 keywords = ["xsd", "wsdl", "schema", "dtd", "binding", "xml", "json", "dataclasses", "generator", "cli"]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "typing-extensions>=4.7.0",
 ]

--- a/tests/formats/dataclass/cases/__init__.py
+++ b/tests/formats/dataclass/cases/__init__.py
@@ -1,4 +1,3 @@
 import sys
 
-PY39 = sys.version_info[:2] >= (3, 9)
 PY310 = sys.version_info[:2] >= (3, 10)

--- a/tests/formats/dataclass/cases/attribute.py
+++ b/tests/formats/dataclass/cases/attribute.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 from typing import Dict, List, Literal, Optional, Set, Tuple, Union
 
 from tests.formats.dataclass.cases import PY39, PY310
@@ -12,6 +13,7 @@ tokens = [
     (List[Union[List[int], int]], False),
     (List[List[int]], False),
     (Tuple[int, ...], ((int,), None, tuple)),
+    (Iterable[int], ((int,), None, list)),
     (List[int], ((int,), None, list)),
     (List[Union[str, int]], ((str, int), None, list)),
     (Optional[List[Union[str, int]]], ((str, int), None, list)),

--- a/tests/formats/dataclass/cases/attribute.py
+++ b/tests/formats/dataclass/cases/attribute.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable
 from typing import Dict, List, Literal, Optional, Set, Tuple, Union
 
-from tests.formats.dataclass.cases import PY39, PY310
+from tests.formats.dataclass.cases import PY310
 from xsdata.models.enums import Mode
 
 tokens = [
@@ -17,6 +17,13 @@ tokens = [
     (List[int], ((int,), None, list)),
     (List[Union[str, int]], ((str, int), None, list)),
     (Optional[List[Union[str, int]]], ((str, int), None, list)),
+    (list[int, int], False),
+    (dict[str, str], False),
+    (dict, False),
+    (set[str], False),
+    (tuple[int, ...], ((int,), None, tuple)),
+    (list[int], ((int,), None, list)),
+    (list[Union[str, int]], ((str, int), None, list)),
 ]
 
 not_tokens = [
@@ -26,19 +33,6 @@ not_tokens = [
     (str, ((str,), None, None)),
     (Union[str, Mode], ((str, Mode), None, None)),
 ]
-
-if PY39:
-    tokens.extend(
-        [
-            (list[int, int], False),
-            (dict[str, str], False),
-            (dict, False),
-            (set[str], False),
-            (tuple[int, ...], ((int,), None, tuple)),
-            (list[int], ((int,), None, list)),
-            (list[Union[str, int]], ((str, int), None, list)),
-        ]
-    )
 
 if PY310:
     tokens.extend(

--- a/tests/formats/dataclass/cases/attributes.py
+++ b/tests/formats/dataclass/cases/attributes.py
@@ -1,8 +1,6 @@
 from collections.abc import Mapping
 from typing import Dict, List, Set, Tuple
 
-from tests.formats.dataclass.cases import PY39
-
 cases = [
     (int, False),
     (Set, False),
@@ -12,11 +10,5 @@ cases = [
     (Dict, ((str,), dict, None)),
     (Dict[str, str], ((str,), dict, None)),
     (Mapping[str, str], ((str,), dict, None)),
+    (dict[str, str], ((str,), dict, None)),
 ]
-
-if PY39:
-    cases.extend(
-        [
-            (dict[str, str], ((str,), dict, None)),
-        ]
-    )

--- a/tests/formats/dataclass/cases/attributes.py
+++ b/tests/formats/dataclass/cases/attributes.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from typing import Dict, List, Set, Tuple
 
 from tests.formats.dataclass.cases import PY39
@@ -10,6 +11,7 @@ cases = [
     (Dict[str, int], False),
     (Dict, ((str,), dict, None)),
     (Dict[str, str], ((str,), dict, None)),
+    (Mapping[str, str], ((str,), dict, None)),
 ]
 
 if PY39:

--- a/tests/formats/dataclass/cases/element.py
+++ b/tests/formats/dataclass/cases/element.py
@@ -1,8 +1,6 @@
 from collections.abc import Iterable
 from typing import Dict, List, Optional, Set, Tuple, Union
 
-from tests.formats.dataclass.cases import PY39
-
 tokens = [
     (Set, False),
     (Dict[str, int], False),
@@ -16,6 +14,11 @@ tokens = [
     (Iterable[Iterable[str, ...]], ((str,), list, list)),
     (Tuple[List[str], ...], ((str,), tuple, list)),
     (Optional[Tuple[List[str], ...]], ((str,), tuple, list)),
+    (list[str], ((str,), None, list)),
+    (tuple[str, ...], ((str,), None, tuple)),
+    (list[list[str]], ((str,), list, list)),
+    (list[tuple[str, ...]], ((str,), list, tuple)),
+    (tuple[list[str], ...], ((str,), tuple, list)),
 ]
 
 not_tokens = [
@@ -30,22 +33,6 @@ not_tokens = [
     (List[Union[str, int]], ((str, int), list, None)),
     (Optional[List[Union[str, int]]], ((str, int), list, None)),
     (Tuple[str, ...], ((str,), tuple, None)),
+    (list[str], ((str,), list, None)),
+    (tuple[str, ...], ((str,), tuple, None)),
 ]
-
-if PY39:
-    tokens.extend(
-        [
-            (list[str], ((str,), None, list)),
-            (tuple[str, ...], ((str,), None, tuple)),
-            (list[list[str]], ((str,), list, list)),
-            (list[tuple[str, ...]], ((str,), list, tuple)),
-            (tuple[list[str], ...], ((str,), tuple, list)),
-        ]
-    )
-
-    not_tokens.extend(
-        [
-            (list[str], ((str,), list, None)),
-            (tuple[str, ...], ((str,), tuple, None)),
-        ]
-    )

--- a/tests/formats/dataclass/cases/element.py
+++ b/tests/formats/dataclass/cases/element.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 from typing import Dict, List, Optional, Set, Tuple, Union
 
 from tests.formats.dataclass.cases import PY39
@@ -12,6 +13,7 @@ tokens = [
     (List[List[str]], ((str,), list, list)),
     (Optional[List[List[Union[str, int]]]], ((str, int), list, list)),
     (List[Tuple[str, ...]], ((str,), list, tuple)),
+    (Iterable[Iterable[str, ...]], ((str,), list, list)),
     (Tuple[List[str], ...], ((str,), tuple, list)),
     (Optional[Tuple[List[str], ...]], ((str,), tuple, list)),
 ]

--- a/tests/formats/dataclass/cases/elements.py
+++ b/tests/formats/dataclass/cases/elements.py
@@ -1,6 +1,6 @@
 from typing import Dict, List, Optional, Tuple, Union
 
-from tests.formats.dataclass.cases import PY39, PY310
+from tests.formats.dataclass.cases import PY310
 
 cases = [
     (Dict, False),
@@ -10,17 +10,10 @@ cases = [
     (Optional[Union[str, int]], ((object,), None, None)),
     (Union[str, int, None], ((object,), None, None)),
     (List[Union[List[str], Tuple[str, ...]]], ((object,), list, None)),
+    (list[str], ((object,), list, None)),
+    (tuple[str, ...], ((object,), tuple, None)),
+    (list[Union[list[str], tuple[str, ...]]], ((object,), list, None)),
 ]
-
-
-if PY39:
-    cases.extend(
-        [
-            (list[str], ((object,), list, None)),
-            (tuple[str, ...], ((object,), tuple, None)),
-            (list[Union[list[str], tuple[str, ...]]], ((object,), list, None)),
-        ]
-    )
 
 
 if PY310:

--- a/tests/formats/dataclass/cases/wildcard.py
+++ b/tests/formats/dataclass/cases/wildcard.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 from typing import Dict, List, Literal, Optional, Set, Tuple
 
 from tests.formats.dataclass.cases import PY310
@@ -11,6 +12,7 @@ cases = [
     (object, ((object,), None, None)),
     (List[object], ((object,), list, None)),
     (Tuple[object, ...], ((object,), tuple, None)),
+    (Iterable[object, ...], ((object,), list, None)),
     (Optional[object], ((object,), None, None)),
 ]
 

--- a/tests/formats/dataclass/test_filters.py
+++ b/tests/formats/dataclass/test_filters.py
@@ -643,6 +643,9 @@ class FiltersTests(FactoryTestCase):
         self.filters.format.frozen = False
         self.assertEqual('list["A.B.C"]', self.filters.field_type(self.obj, attr))
 
+        self.filters.generic_collections = True
+        self.assertEqual('Iterable["A.B.C"]', self.filters.field_type(self.obj, attr))
+
     def test_field_type_with_token_attr(self):
         attr = AttrFactory.create(
             types=AttrTypeFactory.list(1, qname="foo_bar"),
@@ -709,6 +712,9 @@ class FiltersTests(FactoryTestCase):
 
         self.filters.subscriptable_types = True
         self.assertEqual("dict[str, str]", self.filters.field_type(self.obj, attr))
+
+        self.filters.generic_collections = True
+        self.assertEqual("Mapping[str, str]", self.filters.field_type(self.obj, attr))
 
     def test_field_type_with_native_type(self):
         attr = AttrFactory.create(
@@ -901,6 +907,14 @@ class FiltersTests(FactoryTestCase):
 
         output = ": Any = "
         expected = "from typing import Any"
+        self.assertIn(expected, self.filters.default_imports(output))
+
+        output = ": Iterable[str] = "
+        expected = "from collections.abc import Iterable"
+        self.assertIn(expected, self.filters.default_imports(output))
+
+        output = ": Mapping[str, str] = "
+        expected = "from collections.abc import Mapping"
         self.assertIn(expected, self.filters.default_imports(output))
 
     def test_default_imports_combo(self):

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -29,7 +29,7 @@ class GeneratorConfigTests(TestCase):
         expected = (
             '<?xml version="1.0" encoding="UTF-8"?>\n'
             f'<Config xmlns="http://pypi.org/project/xsdata" version="{__version__}">\n'
-            '  <Output maxLineLength="79" subscriptableTypes="false" unionType="false">\n'
+            '  <Output maxLineLength="79" subscriptableTypes="false" genericCollections="false" unionType="false">\n'
             "    <Package>generated</Package>\n"
             '    <Format repr="true" eq="true" order="false" unsafeHash="false" frozen="false" slots="false" kwOnly="false">dataclasses</Format>\n'
             "    <Structure>filenames</Structure>\n"
@@ -89,7 +89,7 @@ class GeneratorConfigTests(TestCase):
         expected = (
             '<?xml version="1.0" encoding="UTF-8"?>\n'
             f'<Config xmlns="http://pypi.org/project/xsdata" version="{__version__}">\n'
-            '  <Output maxLineLength="79" subscriptableTypes="false" unionType="false">\n'
+            '  <Output maxLineLength="79" subscriptableTypes="false" genericCollections="false" unionType="false">\n'
             "    <Package>foo.bar</Package>\n"
             '    <Format repr="true" eq="true" order="false" unsafeHash="false"'
             ' frozen="false" slots="false" kwOnly="false">dataclasses</Format>\n'
@@ -171,6 +171,18 @@ class GeneratorConfigTests(TestCase):
                     "Enabling postponed annotations, because `union_type==True`",
                     str(w[-1].message),
                 )
+
+    def test_generic_collections_requires_frozen_false(self):
+        with warnings.catch_warnings(record=True) as w:
+            output = GeneratorOutput(
+                generic_collections=True, format=OutputFormat(frozen=True)
+            )
+            self.assertFalse(output.generic_collections)
+
+            self.assertEqual(
+                "Generic Collections, requires frozen=False, reverting...",
+                str(w[-1].message),
+            )
 
     def test_format_slots_requires_310(self):
         if sys.version_info < (3, 10):

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -136,23 +136,6 @@ class GeneratorConfigTests(TestCase):
 
         self.assertEqual("Enabling eq because order is true", str(w[-1].message))
 
-    def test_subscriptable_types_requires_390(self):
-        if sys.version_info < (3, 9):
-            with warnings.catch_warnings(record=True) as w:
-                self.assertFalse(
-                    GeneratorOutput(subscriptable_types=True).subscriptable_types
-                )
-
-            self.assertEqual(
-                "Generics PEP 585 requires python >= 3.9, reverting...",
-                str(w[-1].message),
-            )
-
-        else:
-            self.assertTrue(
-                GeneratorOutput(subscriptable_types=True).subscriptable_types
-            )
-
     def test_use_union_type_requires_310_and_postponed_annotations(self):
         if sys.version_info < (3, 10):
             with warnings.catch_warnings(record=True) as w:

--- a/xsdata/formats/dataclass/client.py
+++ b/xsdata/formats/dataclass/client.py
@@ -51,7 +51,7 @@ class Config:
             for f in fields(cls)
         }
 
-        return cls(**params)
+        return cls(**params)  # type: ignore
 
 
 class TransportTypes:

--- a/xsdata/formats/dataclass/typing.py
+++ b/xsdata/formats/dataclass/typing.py
@@ -1,5 +1,5 @@
 import sys
-from collections.abc import Iterable, Iterator, Mapping
+from collections.abc import Iterable, Mapping
 from typing import (
     Any,
     Callable,

--- a/xsdata/models/config.py
+++ b/xsdata/models/config.py
@@ -225,6 +225,7 @@ class GeneratorOutput:
         max_line_length: Adjust the maximum line length
         subscriptable_types: Use PEP-585 generics for standard
             collections, python>=3.9 Only
+        generic_collections: Use generic collections (Iterable, Mapping)
         union_type: Use PEP-604 union type, python>=3.10 Only
         postponed_annotations: Use 563 postponed evaluation of  annotations
         unnest_classes: Move inner classes to upper level
@@ -243,6 +244,7 @@ class GeneratorOutput:
     wrapper_fields: bool = element(default=False)
     max_line_length: int = attribute(default=79)
     subscriptable_types: bool = attribute(default=False)
+    generic_collections: bool = attribute(default=False)
     union_type: bool = attribute(default=False)
     postponed_annotations: bool = element(default=False)
     unnest_classes: bool = element(default=False)
@@ -273,6 +275,13 @@ class GeneratorOutput:
             self.postponed_annotations = True
             warnings.warn(
                 "Enabling postponed annotations, because `union_type==True`",
+                CodegenWarning,
+            )
+
+        if self.generic_collections and self.format.frozen:
+            self.generic_collections = False
+            warnings.warn(
+                "Generic Collections, requires frozen=False, reverting...",
                 CodegenWarning,
             )
 

--- a/xsdata/models/config.py
+++ b/xsdata/models/config.py
@@ -257,13 +257,6 @@ class GeneratorOutput:
 
     def validate(self):
         """Reset configuration conflicts."""
-        if self.subscriptable_types and sys.version_info < (3, 9):
-            self.subscriptable_types = False
-            warnings.warn(
-                "Generics PEP 585 requires python >= 3.9, reverting...",
-                CodegenWarning,
-            )
-
         if self.union_type and sys.version_info < (3, 10):
             self.union_type = False
             warnings.warn(


### PR DESCRIPTION
## 📒 Description

Add a cli option to use generic collections, `collections.abc.Iterable` and `collections.abc.Mapping`.


Resolves Something

## 🔗 What I've Done

- Add cli mutually exclusive option with frozen
- Update filters and typing evaluations 
- Drop 3.8 Support

## 💬 Comments

> A place to write any comments to the reviewer.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
