### PR TITLE
fix: Avoid conflict with attributes named value when flattening extensions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,18 +8,18 @@ repos:
       - id: end-of-file-fixer
       - id: debug-statements
   - repo: https://github.com/crate-ci/typos
-    rev: v1.26.0
+    rev: v1.27.0
     hooks:
       - id: typos
         exclude: ^tests/|.xsd|xsdata/models/datatype.py$
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.0
+    rev: v0.7.2
     hooks:
       - id: ruff
         args: [ --fix, --show-fixes]
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.12.1
+    rev: v1.13.0
     hooks:
       - id: mypy
         files: ^(xsdata/)

--- a/tests/codegen/handlers/test_flatten_class_extensions.py
+++ b/tests/codegen/handlers/test_flatten_class_extensions.py
@@ -474,3 +474,13 @@ class FlattenClassExtensionsTests(FactoryTestCase):
         self.assertEqual(0, len(item.extensions))
         self.assertEqual(expected, item.attrs[0])
         self.assertEqual(expected.restrictions, item.attrs[0].restrictions)
+
+    def test_get_or_create_attribute_ignore_existing_attribute(self):
+        target = ClassFactory.create()
+        attr = AttrFactory.create(tag=Tag.ATTRIBUTE, name="value")
+
+        result = FlattenClassExtensions.get_or_create_attribute(
+            target, "value", Tag.EXTENSION
+        )
+
+        self.assertIsNot(attr.tag, result)

--- a/xsdata/codegen/handlers/flatten_class_extensions.py
+++ b/xsdata/codegen/handlers/flatten_class_extensions.py
@@ -380,7 +380,7 @@ class FlattenClassExtensions(RelativeHandlerInterface):
             tag: The attr tag name
         """
         attr = ClassUtils.find_attr(target, name)
-        if attr is None:
+        if attr is None or attr.tag == Tag.ATTRIBUTE:
             attr = Attr(name=name, tag=tag)
             attr.restrictions.min_occurs = 1
             attr.restrictions.max_occurs = 1


### PR DESCRIPTION
## 📒 Description

When we flatten simple type extensions, we create a default text node value attr. If the model includes an attribute field with name "value", the whole thing fails.


Resolves #1084

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue

## 💬 Comments

> A place to write any comments to the reviewer.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
