### PR TITLE
fix: Prohibited fields need default value None

### DIFF
--- a/tests/formats/dataclass/test_filters.py
+++ b/tests/formats/dataclass/test_filters.py
@@ -281,6 +281,7 @@ class FiltersTests(FactoryTestCase):
         expected = (
             "field(\n"
             "        init=False,\n"
+            "        default=None,\n"
             "        metadata={\n"
             '            "type": "Ignore",\n'
             "        }\n"

--- a/xsdata/formats/dataclass/filters.py
+++ b/xsdata/formats/dataclass/filters.py
@@ -256,6 +256,9 @@ class Filters:
         if attr.fixed or attr.is_prohibited:
             kwargs["init"] = False
 
+            if attr.is_prohibited:
+                kwargs[self.DEFAULT_KEY] = None
+
         if default_value is not False and not attr.is_prohibited:
             key = self.FACTORY_KEY if attr.is_factory else self.DEFAULT_KEY
             kwargs[key] = default_value


### PR DESCRIPTION
## 📒 Description

Prohibited fields need a default value, otherwise repr fails

```
from dataclasses import dataclass, field
from xsdata.models.xsd import Any



@dataclass(kw_only=True)
class Foo:
    bar: Any = field(
        init=False,
        metadata={
            "type": "Ignore",
        },
    )

print(Foo())


  File "/usr/lib/python3.12/dataclasses.py", line 262, in wrapper
    result = user_function(self)
             ^^^^^^^^^^^^^^^^^^^
  File "<string>", line 3, in __repr__
AttributeError: 'Foo' object has no attribute 'bar'

```




resolve #1091

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue

## 💬 Comments

> A place to write any comments to the reviewer.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
