### PR TITLE
fix: Mark body and fault as optional in output soap classes

### DIFF
--- a/tests/codegen/mappers/test_definitions.py
+++ b/tests/codegen/mappers/test_definitions.py
@@ -504,6 +504,9 @@ class DefinitionsMapperTests(FactoryTestCase):
         self.assertEqual(expected_fault_attr, body.attrs[0])
         self.assertEqual(expected_fault_attrs, body.inner[0].attrs)
 
+        for attr in body.attrs:
+            self.assertTrue(attr.is_optional)
+
     def test_build_envelope_fault_with_detail_messages(self):
         body = ClassFactory.create(qname="Body")
         target = ClassFactory.create()

--- a/xsdata/codegen/mappers/definitions.py
+++ b/xsdata/codegen/mappers/definitions.py
@@ -259,6 +259,9 @@ class DefinitionsMapper:
             ),
         )
 
+        for attr in body.attrs:
+            attr.restrictions.min_occurs = 0
+
     @classmethod
     def build_envelope_class(
         cls,


### PR DESCRIPTION
## 📒 Description

The generator creates soap envelop classes where both body and fault are mandatory, they should both be optional

Resolves #1093

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue

## 💬 Comments

> A place to write any comments to the reviewer.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
