### PR TITLE
Split rename and merge logic for duplicate classes

### DIFF
--- a/tests/codegen/handlers/test_merge_duplicate_classes.py
+++ b/tests/codegen/handlers/test_merge_duplicate_classes.py
@@ -1,0 +1,46 @@
+from xsdata.codegen.container import ClassContainer
+from xsdata.codegen.handlers import MergeDuplicateClasses
+from xsdata.models.config import GeneratorConfig
+from xsdata.utils.testing import (
+    AttrFactory,
+    ClassFactory,
+    FactoryTestCase,
+)
+
+
+class MergeDuplicateClassesTests(FactoryTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.container = ClassContainer(config=GeneratorConfig())
+        self.processor = MergeDuplicateClasses(container=self.container)
+
+    def test_run_merges_same_classes(self) -> None:
+        first = ClassFactory.create()
+        second = first.clone()
+        third = first.clone()
+        fourth = ClassFactory.create()
+        fifth = ClassFactory.create()
+
+        self.container.extend([first, second, third, fourth, fifth])
+        self.processor.run()
+
+        self.assertEqual([first, fourth, fifth], list(self.container))
+        self.assertEqual(
+            {first.ref: third.ref, second.ref: third.ref}, self.processor.merges
+        )
+
+    def test_update_references(self) -> None:
+        target = ClassFactory.create()
+        target.attrs.append(AttrFactory.reference(qname="foo", reference=1))
+        target.attrs.append(
+            AttrFactory.reference(
+                qname="thug",
+                reference=2,
+            )
+        )
+        self.processor.merges = {2: 3}
+        self.processor.update_references(target)
+
+        self.assertEqual(1, target.attrs[0].types[0].reference)
+        self.assertEqual(3, target.attrs[1].types[0].reference)

--- a/xsdata/codegen/container.py
+++ b/xsdata/codegen/container.py
@@ -13,6 +13,7 @@ from xsdata.codegen.handlers import (
     FlattenAttributeGroups,
     FlattenClassExtensions,
     MergeAttributes,
+    MergeDuplicateClasses,
     ProcessAttributeTypes,
     ProcessMixedContentClass,
     RenameDuplicateAttributes,
@@ -225,6 +226,7 @@ class ClassContainer(ContainerInterface):
     def designate_classes(self) -> None:
         """Designate the final class names, packages and modules."""
         designators = [
+            MergeDuplicateClasses(self),
             RenameDuplicateClasses(self),
             ValidateReferences(self),
             DesignateClassPackages(self),

--- a/xsdata/codegen/handlers/__init__.py
+++ b/xsdata/codegen/handlers/__init__.py
@@ -9,6 +9,7 @@ from .filter_classes import FilterClasses
 from .flatten_attribute_groups import FlattenAttributeGroups
 from .flatten_class_extensions import FlattenClassExtensions
 from .merge_attributes import MergeAttributes
+from .merge_duplicate_classes import MergeDuplicateClasses
 from .process_attributes_types import ProcessAttributeTypes
 from .process_mixed_content_class import ProcessMixedContentClass
 from .rename_duplicate_attributes import RenameDuplicateAttributes
@@ -35,6 +36,7 @@ __all__ = [
     "FlattenAttributeGroups",
     "FlattenClassExtensions",
     "MergeAttributes",
+    "MergeDuplicateClasses",
     "ProcessAttributeTypes",
     "ProcessMixedContentClass",
     "RenameDuplicateAttributes",

--- a/xsdata/codegen/handlers/merge_duplicate_classes.py
+++ b/xsdata/codegen/handlers/merge_duplicate_classes.py
@@ -1,0 +1,73 @@
+from xsdata.codegen.mixins import ContainerHandlerInterface, ContainerInterface
+from xsdata.codegen.models import (
+    Class,
+)
+
+
+class MergeDuplicateClasses(ContainerHandlerInterface):
+    """Remove duplicate classes.
+
+    Args:
+        container: The class container instance
+
+    Attributes:
+        merges: The merge instructions applied at the end
+    """
+
+    __slots__ = ("merges",)
+
+    def __init__(self, container: ContainerInterface):
+        """Initialize the rename duplicate class handler."""
+        super().__init__(container)
+
+        self.merges: dict[int, int] = {}
+
+    def run(self) -> None:
+        """Detect and merge duplicate classes conflicts."""
+        for classes in self.group_duplicate_classes():
+            if len(classes) > 1:
+                self.merge_classes(classes)
+
+        if self.merges:
+            for target in self.container:
+                self.update_references(target)
+
+    def group_duplicate_classes(self) -> list[list[Class]]:
+        """Group duplicate classes.
+
+        This is very slow, because our gen models are unhashable.
+        """
+        groups: list[list[Class]] = []
+        for cls in self.container:
+            found = False
+            for group in groups:
+                if cls == group[0]:
+                    group.append(cls)
+                    found = True
+                    break
+            if not found:
+                groups.append([cls])
+        return groups
+
+    def merge_classes(self, classes: list[Class]) -> None:
+        """Remove the duplicate classes and schedule updates.
+
+        Args:
+            classes: A list of duplicate classes
+        """
+        keep = classes.pop()
+        replace = keep.ref
+        self.container.remove(*classes)
+
+        for item in classes:
+            self.merges[item.ref] = replace
+
+    def update_references(self, target: Class) -> None:
+        """Search and update the target class for merged references.
+
+        Args:
+            target: The target class instance to inspect and update
+        """
+        for tp in target.types():
+            if tp.reference in self.merges:
+                tp.reference = self.merges[tp.reference]

--- a/xsdata/codegen/handlers/rename_duplicate_classes.py
+++ b/xsdata/codegen/handlers/rename_duplicate_classes.py
@@ -20,8 +20,7 @@ class RenameDuplicateClasses(ContainerHandlerInterface):
 
     Attributes:
         use_names: Whether names or qualified names should be used to group classes
-        merges: The renamed instructions applied at the end
-        merges: The merge instructions applied at the end
+        renames: The renamed instructions applied at the end
         reserved: The reserved class names or qualified names
     """
 
@@ -42,12 +41,7 @@ class RenameDuplicateClasses(ContainerHandlerInterface):
         groups = collections.group_by(self.container, lambda x: text.alnum(getter(x)))
 
         for classes in groups.values():
-            if len(classes) < 2:
-                continue
-
-            if all(x == classes[0] for x in classes):
-                self.merge_classes(classes)
-            else:
+            if len(classes) > 1:
                 self.rename_classes(classes)
 
         if self.renames or self.merges:
@@ -120,7 +114,7 @@ class RenameDuplicateClasses(ContainerHandlerInterface):
         self.rename_class(target, new_qname)
 
     def rename_class(self, target: Class, new_qname: str) -> None:
-        """Update the class qualified name and update references.
+        """Update the class qualified name and schedule updates.
 
         Args:
             target: The target class to update
@@ -162,7 +156,7 @@ class RenameDuplicateClasses(ContainerHandlerInterface):
         return self.reserved
 
     def update_references(self, target: Class) -> None:
-        """Search and update the target class for renamed and merged references.
+        """Search and update the target class for renamed references.
 
         Args:
             target: The target class instance to inspect and update
@@ -178,6 +172,3 @@ class RenameDuplicateClasses(ContainerHandlerInterface):
                 ):
                     members = text.suffix(parent.default, "::")
                     parent.default = f"@enum@{tp.qname}::{members}"
-
-            elif tp.reference in self.merges:
-                tp.reference = self.merges[tp.reference]


### PR DESCRIPTION
## 📒 Description

Extract merge duplicate classes handler from the rename duplicate handler, because at the moment it's missing a lot of valid cases.


Resolves #xxxx

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue

## 💬 Comments

> A place to write any comments to the reviewer.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
