### PR TITLE
Remove xsdata <SOURCE> shorthand

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ Changelog = "https://xsdata.readthedocs.io/en/latest/changelog/"
 [project.optional-dependencies]
 cli = [
     "click>=5.0",
-    "click-default-group>=1.2",
     "docformatter>=1.7.2",
     "jinja2>=2.10",
     "toposort>=1.5",

--- a/tests/integration/test_annotations.py
+++ b/tests/integration/test_annotations.py
@@ -17,7 +17,7 @@ def test_annotations() -> None:
     schema = filepath.joinpath("model.xsd")
     runner = CliRunner()
     result = runner.invoke(
-        cli, [str(schema), f"--config={filepath.joinpath('xsdata.xml')!s}"]
+        cli, ["generate", str(schema), f"--config={filepath.joinpath('xsdata.xml')!s}"]
     )
 
     if result.exception:

--- a/tests/integration/test_artists.py
+++ b/tests/integration/test_artists.py
@@ -16,7 +16,7 @@ def test_xml_documents() -> None:
     filepath = fixtures_dir.joinpath("artists")
     package = "tests.fixtures.artists"
     runner = CliRunner()
-    result = runner.invoke(cli, [str(filepath), "--package", package])
+    result = runner.invoke(cli, ["generate", str(filepath), "--package", package])
 
     if result.exception:
         raise result.exception

--- a/tests/integration/test_books.py
+++ b/tests/integration/test_books.py
@@ -16,6 +16,7 @@ def test_books_schema() -> None:
     result = runner.invoke(
         cli,
         [
+            "generate",
             str(schema),
             "--package",
             package,

--- a/tests/integration/test_calculator.py
+++ b/tests/integration/test_calculator.py
@@ -20,7 +20,7 @@ class CalculatorServiceTests(TestCase):
         schema = fixtures_dir.joinpath("calculator/services.wsdl")
         package = "tests.fixtures.calculator"
         runner = CliRunner()
-        result = runner.invoke(cli, [str(schema), "--package", package])
+        result = runner.invoke(cli, ["generate", str(schema), "--package", package])
 
         if result.exception:
             raise result.exception

--- a/tests/integration/test_compound.py
+++ b/tests/integration/test_compound.py
@@ -15,7 +15,16 @@ def test_xml_documents() -> None:
     package = "tests.fixtures.compound.models"
     runner = CliRunner()
     result = runner.invoke(
-        cli, [str(schema), "-p", package, "-ss", "single-package", "--compound-fields"]
+        cli,
+        [
+            "generate",
+            str(schema),
+            "-p",
+            package,
+            "-ss",
+            "single-package",
+            "--compound-fields",
+        ],
     )
 
     if result.exception:

--- a/tests/integration/test_dtd.py
+++ b/tests/integration/test_dtd.py
@@ -14,6 +14,7 @@ def test_dtd_documents() -> None:
     result = runner.invoke(
         cli,
         [
+            "generate",
             str(fixtures_dir.joinpath("dtd/complete_example.dtd")),
             "--package",
             "tests.fixtures.dtd.models",

--- a/tests/integration/test_hello_rpc.py
+++ b/tests/integration/test_hello_rpc.py
@@ -26,7 +26,7 @@ class HelloRpcServiceTests(TestCase):
         schema = fixtures_dir.joinpath("hello/hello.wsdl")
         package = "tests.fixtures.hello"
         runner = CliRunner()
-        result = runner.invoke(cli, [str(schema), "--package", package])
+        result = runner.invoke(cli, ["generate", str(schema), "--package", package])
 
         if result.exception:
             raise result.exception

--- a/tests/integration/test_primer.py
+++ b/tests/integration/test_primer.py
@@ -15,7 +15,8 @@ def test_primer_schema() -> None:
     package = "tests.fixtures.primer"
     runner = CliRunner()
     result = runner.invoke(
-        cli, [str(schema), "--package", package, "--docstring-style", "NumPy"]
+        cli,
+        ["generate", str(schema), "--package", package, "--docstring-style", "NumPy"],
     )
 
     if result.exception:

--- a/tests/integration/test_series.py
+++ b/tests/integration/test_series.py
@@ -18,7 +18,7 @@ def test_json_documents() -> None:
     package = "tests.fixtures.series"
     runner = CliRunner()
     result = runner.invoke(
-        cli, [str(filepath.joinpath("samples")), "--package", package]
+        cli, ["generate", str(filepath.joinpath("samples")), "--package", package]
     )
 
     if result.exception:

--- a/tests/integration/test_stripe.py
+++ b/tests/integration/test_stripe.py
@@ -19,6 +19,7 @@ def test_json_documents() -> None:
     result = runner.invoke(
         cli,
         [
+            "generate",
             str(filepath.joinpath("samples")),
             f"--config={filepath.joinpath('.xsdata.xml')!s}",
         ],

--- a/tests/integration/test_wrapper.py
+++ b/tests/integration/test_wrapper.py
@@ -17,6 +17,7 @@ def test_xml_documents() -> None:
     result = runner.invoke(
         cli,
         [
+            "generate",
             str(schema),
             "-p",
             package,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,7 +38,7 @@ class CliTests(TestCase):
     @mock.patch.object(ResourceTransformer, "__init__", return_value=None)
     def test_generate(self, mock_init, mock_process) -> None:
         source = fixtures_dir.joinpath("defxmlschema/chapter03.xsd")
-        result = self.runner.invoke(cli, [str(source), "--package", "foo"])
+        result = self.runner.invoke(cli, ["generate", str(source), "--package", "foo"])
         config = mock_init.call_args[1]["config"]
 
         self.assertIsNone(result.exception)
@@ -71,7 +71,7 @@ class CliTests(TestCase):
         source = fixtures_dir.joinpath("defxmlschema/chapter03.xsd")
         result = self.runner.invoke(
             cli,
-            [str(source), "--config", str(file_path), "--no-eq"],
+            ["generate", str(source), "--config", str(file_path), "--no-eq"],
             catch_exceptions=False,
         )
         config = mock_init.call_args[1]["config"]
@@ -87,7 +87,7 @@ class CliTests(TestCase):
     @mock.patch.object(ResourceTransformer, "process")
     @mock.patch.object(ResourceTransformer, "__init__", return_value=None)
     def test_generate_with_debug_mode(self, *args) -> None:
-        self.runner.invoke(cli, ["foo.xsd", "--package", "foo", "--debug"])
+        self.runner.invoke(cli, ["generate", "foo.xsd", "--package", "foo", "--debug"])
         self.assertEqual(logging.DEBUG, logger.level)
 
     @mock.patch("xsdata.cli.logger.info")

--- a/xsdata/cli.py
+++ b/xsdata/cli.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Any
 
 import click
-from click_default_group import DefaultGroup
 
 from xsdata import __version__
 from xsdata.codegen.transformer import ResourceTransformer
@@ -36,20 +35,7 @@ py_warnings.propagate = False
 logging.captureWarnings(True)
 
 
-class DeprecatedDefaultGroup(DefaultGroup):
-    """Deprecated default group."""
-
-    def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command:
-        """Override to deprecate xsdata <source> shorthand."""
-        if cmd_name not in self.commands:
-            logger.warning(
-                "`xsdata <SOURCE>` is deprecated. "
-                "Use `xsdata generate <SOURCE>` instead."
-            )
-        return super().get_command(ctx, cmd_name)
-
-
-@click.group(cls=DeprecatedDefaultGroup, default="generate", default_if_no_args=False)
+@click.group()
 @click.pass_context
 @click.version_option(__version__)
 def cli(ctx: click.Context, **kwargs: Any) -> None:


### PR DESCRIPTION
## 📒 Description

The shorthand `xsdata <SOURCE>` was deprecated last year, time to remove it.

Use `xsdata generate <SOURCE>` 



## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue

## 💬 Comments

> A place to write any comments to the reviewer.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
