### PR TITLE
Fix: KeyError in `XmlMetaBuilder.build_class_meta` for certain packages

### DIFF
--- a/xsdata/formats/dataclass/context.py
+++ b/xsdata/formats/dataclass/context.py
@@ -136,6 +136,7 @@ class XmlContext:
             hasattr(clazz, "__module__")
             and isinstance(clazz.__module__, str)
             and clazz.__module__.startswith(self.models_package)
+            and clazz.__module__ in sys.modules
         )
 
     def find_types(self, qname: str) -> list[type[T]]:


### PR DESCRIPTION
## Description
For certain packages installed alongside xsdata entries in `sys.modules` are missing for classes from those packages. This leads to a `KeyError` when trying to get the module.

One of the nvidia packages pytorch depends on leads to this error for me. I dont know which one exactly.

Trace:
```
   return XmlParser().from_bytes(raw, cvat_xml.Annotations)
  File "/code/.venv/lib/python3.10/site-packages/xsdata/formats/dataclass/parsers/mixins.py", line 88, in from_bytes
    return self.parse(io.BytesIO(source), clazz, ns_map)
  File "/code/.venv/lib/python3.10/site-packages/xsdata/formats/dataclass/parsers/bases.py", line 58, in parse
    result = handler.parse(source, ns_map)
  File "/code/.venv/lib/python3.10/site-packages/xsdata/formats/dataclass/parsers/handlers/lxml.py", line 42, in parse
    return self.process_context(ctx, ns_map)
  File "/code/.venv/lib/python3.10/site-packages/xsdata/formats/dataclass/parsers/handlers/lxml.py", line 60, in process_context
    self.parser.start(
  File "/code/.venv/lib/python3.10/site-packages/xsdata/formats/dataclass/parsers/bases.py", line 94, in start
    child = item.child(qname, attrs, ns_map, len(objects))
  File "/code/.venv/lib/python3.10/site-packages/xsdata/formats/dataclass/parsers/nodes/element.py", line 459, in child
    node = self.build_node(qname, var, attrs, ns_map, position)
  File "/code/.venv/lib/python3.10/site-packages/xsdata/formats/dataclass/parsers/nodes/element.py", line 559, in build_node
    clazz = self.context.find_type(qname)
  File "/code/.venv/lib/python3.10/site-packages/xsdata/formats/dataclass/context.py", line 168, in find_type
    types: list[type] = self.find_types(qname)
  File "/code/.venv/lib/python3.10/site-packages/xsdata/formats/dataclass/context.py", line 153, in find_types
    self.build_xsi_cache()
  File "/code/.venv/lib/python3.10/site-packages/xsdata/formats/dataclass/context.py", line 112, in build_xsi_cache
    meta = builder.build_class_meta(clazz)
  File "/code/.venv/lib/python3.10/site-packages/xsdata/formats/dataclass/models/builders.py", line 248, in build_class_meta
    module = sys.modules[clazz.__module__]
KeyError: ''
```

## 🔗 What I've Done

Added a simple check whether the clazz.__module__ exists in sys.modules.


## 🛫 Checklist

I think there is no need to update docs or tests for this small fix.