### PR TITLE
Nested wildcard tails

### DIFF
--- a/tests/formats/dataclass/parsers/nodes/test_element.py
+++ b/tests/formats/dataclass/parsers/nodes/test_element.py
@@ -342,23 +342,6 @@ class ElementNodeTests(FactoryTestCase):
 
         self.assertListEqual(objects, [("p", expected_outer_node)])
 
-        # objects = [
-        #     (None, "This is before the note."),
-        #     (None, AnyElement(qname="note", text="This is a note inside the paragraph.")),
-        #     (None, "This is after the note."),
-        # ]
-
-        # self.assertTrue(self.node.bind("foo", None, None, objects))
-        # result = objects[-1][1]
-        # expected = Paragraph(
-        #     content=[
-        #         "This is before the note.",
-        #         AnyElement(qname="note", text="This is a note inside the paragraph."),
-        #         "This is after the note."
-        #     ]
-        # )
-        # self.assertEqual(result, expected)
-
     def test_bind_tail_of_wildcard_attaches_to_wildcard_parent(self) -> None:
         self.node.meta = self.context.build(Paragraph)
         note = AnyElement(

--- a/tests/formats/dataclass/parsers/nodes/test_element.py
+++ b/tests/formats/dataclass/parsers/nodes/test_element.py
@@ -138,11 +138,10 @@ class ElementNodeTests(FactoryTestCase):
         self.node.ns_map = {"ns0": "xsdata"}
 
         objects = [("a", 1)]
-        expected = Paragraph(content=["text", AnyElement(qname="a", text="1"), "tail"])
+        expected = Paragraph(content=["text", AnyElement(qname="a", text="1")])
 
         self.assertTrue(self.node.bind("foo", "text", "tail", objects))
-        self.assertEqual("foo", objects[-1][0])
-        self.assertEqual(expected, objects[-1][1])
+        self.assertListEqual([("foo", expected), (None, "tail")], objects)
 
     def test_bind_wild_text(self) -> None:
         self.node.meta = self.context.build(ExtendedType)
@@ -170,13 +169,13 @@ class ElementNodeTests(FactoryTestCase):
 
         params = {}
         self.node.bind_wild_text(params, var, "txt", "tail")
-        self.assertEqual({"wildcard": ["txt", "tail"]}, params)
+        self.assertEqual({"wildcard": ["txt"]}, params)
 
         self.node.bind_wild_text(params, var, None, "tail")
-        self.assertEqual({"wildcard": [None, "txt", "tail", "tail"]}, params)
+        self.assertEqual({"wildcard": [None, "txt"]}, params)
 
         self.node.bind_wild_text(params, var, "first", None)
-        self.assertEqual({"wildcard": ["first", None, "txt", "tail", "tail"]}, params)
+        self.assertEqual({"wildcard": ["first", None, "txt"]}, params)
 
     def test_bind_attrs(self) -> None:
         self.node.meta = self.context.build(AttrsType)
@@ -344,22 +343,21 @@ class ElementNodeTests(FactoryTestCase):
 
     def test_bind_tail_of_wildcard_attaches_to_wildcard_parent(self) -> None:
         self.node.meta = self.context.build(Paragraph)
-        note = AnyElement(
-            qname="note",
-            children=[AnyElement(text="This is a note inside the paragraph.")],
+        subparagraph = Paragraph(
+            content=["This is a subparagraph inside the paragraph."],
         )
         objects = [
-            (None, "This is before the note."),
-            (None, note),
-            (None, "This is after the note."),
+            (None, "This is before the subparagraph."),
+            ("p", subparagraph),
+            (None, "This is after the subparagraph."),
         ]
         self.assertTrue(self.node.bind("foo", None, None, objects))
         result = objects[-1][1]
         expected = Paragraph(
             content=[
-                "This is before the note.",
-                note,
-                "This is after the note.",
+                "This is before the subparagraph.",
+                subparagraph,
+                "This is after the subparagraph.",
             ]
         )
         self.assertEqual(result, expected)

--- a/xsdata/formats/dataclass/parsers/nodes/element.py
+++ b/xsdata/formats/dataclass/parsers/nodes/element.py
@@ -111,7 +111,7 @@ class ElementNode(XmlNode):
 
         objects.append((qname, obj))
 
-        if self.mixed and not self.tail_processed:
+        if not self.tail_processed:
             tail = ParserUtils.normalize_content(tail)
             if tail:
                 objects.append((None, tail))


### PR DESCRIPTION
## 📒 Description

> Write a brief description of your PR.

Resolves #1149.

Tails of nested wildcard objects are appended to the inner wildcard object, and not the outer wildcard list, as expected.

I also discovered while working on this PR that tails of non-wildcard objects within a wildcard list were just being discarded, instead of being appened to the outer wildcard list, as expected.

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue

The first change is that if a tail is not processed it is passed to its parent. This is the same behavior that occured before if the element was marked as mixed. Now all elements whose tails have not been processed do this.

The second change is that if a child tail is passed to the parent and the parent is a wildcard, this propagated tail is bound using `bind_wild_text`.  This resolves the case where the nested element isn't a wildcard, and its tails were being discarded.

The final change, probably the most controversial one, is I stripped the functionality of appending the tail of a wildcard list to its elements. As I read the xml parser spec in python stdlib/lxml and as I read the W3C XML Schema Definition Language spec, it feels clear to me that what the parsers are calling tails actually belong the parent element, and not the inner object. There were a few tests asserting the previous behavior, which I changed, but I couldn't find anything testing that behavior on real XML; only the very atomic/isolated unit tests. If my understanding of the intended behavior is wrong, I'm happy to redesign this.

## 💬 Comments

> A place to write any comments to the reviewer.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
