### PR TITLE
Fix missing imports on inheriting multiple mixins for the same class …

### DIFF
--- a/tests/formats/dataclass/test_filters.py
+++ b/tests/formats/dataclass/test_filters.py
@@ -1072,7 +1072,7 @@ class FiltersTests(FactoryTestCase):
         expected_imports = {
             "b": {"@b"},
             "c": {"@c"},
-            "d": {"(d", " d)"},
-            "e": {"(e", " e)"},
+            "d": {"(d", ", d", " d)"},
+            "e": {"(e", ", e", " e)"},
         }
         self.assertEqual(expected_imports, filters.import_patterns["a"])

--- a/xsdata/formats/dataclass/filters.py
+++ b/xsdata/formats/dataclass/filters.py
@@ -83,6 +83,7 @@ class Filters:
                 patterns.update(
                     [
                         f"({ext.func_name}",
+                        f", {ext.func_name}",
                         f" {ext.func_name})",
                     ]
                 )


### PR DESCRIPTION
## 📒 Description

Attempt to resolve #1156 

## 🔗 What I've Done

Instead of matching only `(Mixin`, `Mixin)`, match also `, Mixin` which should make sure it matches also mixins in the middle of the list.

## 💬 Comments

There could be a need for more refactoring of how search through the output is done.
It would be nicer if it searched only the class declaration, not the whole output.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
