### PR TITLE
Inject xml.etree.ElementTree.Element

### DIFF
--- a/xsdata/formats/converter.py
+++ b/xsdata/formats/converter.py
@@ -15,7 +15,7 @@ from typing import (
     Union,
     cast,
 )
-from xml.etree.ElementTree import QName
+from xml.etree.ElementTree import QName, Element
 
 from xsdata.exceptions import ConverterError
 from xsdata.models.datatype import (
@@ -820,6 +820,18 @@ class DateTimeConverter(DateTimeBase):
         return self.parse(value, **kwargs)
 
 
+class ElementConverter(Converter):
+    """A ElementTree.Element converter."""
+
+    def deserialize(self, value: Any, **kwargs: Any) -> Any:
+        """Not implemented."""
+        raise Exception("not implemented")
+
+    def serialize(self, value: Element, **kwargs: Any) -> Any:
+        """Return the ElementTree.Element, as it is, since it is handles downstream."""
+        return value if isinstance(value, Element) else str(value)
+
+
 class ProxyConverter(Converter):
     """Proxy wrapper to treat callables as converters.
 
@@ -874,3 +886,4 @@ converter.register_converter(XmlPeriod, ProxyConverter(XmlPeriod))
 converter.register_converter(QName, QNameConverter())
 converter.register_converter(Decimal, DecimalConverter())
 converter.register_converter(Enum, EnumConverter())
+converter.register_converter(Element, ElementConverter())


### PR DESCRIPTION
## 📒 Description

> Write a brief description of your PR.

Resolves resp. demonstrates a hacky solution of #1143

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue

I have smuggled an `xml.etree.ElementTree.Element` to the dataclasses hierarchy to serialize it while skipping the encoding. This allows to embed an existing XML string into the surrounding XML model.

## 💬 Comments

> A place to write any comments to the reviewer.

This is currently a draft and a hack to make it working for my use case, while I did not find the correct place where something like that would be handled correctly.

My use case is, OAI-PMH [1,2] to embed metadata that follows another schema and is handles by an already existing library. You can see the example in the OAI-PMH specification [1,2].

[1] https://www.openarchives.org/OAI/openarchivesprotocol.html#GetRecord
[2] https://www.openarchives.org/OAI/openarchivesprotocol.html#ListRecords

An alternative approach was to parse the xml string coming from the other library with the xsdata parser. Than I have injected it into a parent data class. But that did not preserve the namespaces. A fix was to handle the namespaces separately but than the namespace definitions are moved to the root element, while I want to keep them in the nested element, since they are only relevant for it.

```
metadata_string = # the xml string comming from the other library
metadata = XmlParser().from_string(metadata_string, MetadataType)
RecordType(
     metadata=metadata,
)
```

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
