### PR TITLE
Use upstream docformatter repo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ Changelog = "https://xsdata.readthedocs.io/en/latest/changelog/"
 cli = [
     "click>=5.0",
     "click-default-group>=1.2",
-    "docformatter @ git+https://github.com/tdenewiler/docformatter.git@untokenize-std-lib",
+    "docformatter @ git+https://github.com/PyCQA/docformatter.git",
     "jinja2>=2.10",
     "toposort>=1.5",
     "ruff>=0.9.8"


### PR DESCRIPTION
## 📒 Description

The untokenize branch from `tdenewiler/docformatter` has been merged upstream and deleted. This points `docformatter` back to the upstream main branch.

## 🔗 What I've Done

Updated `pyproject.toml` to point to the upstream `docformatter` branch.

## 💬 Comments

> A place to write any comments to the reviewer.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
