### PR TITLE
Fix incorrect max_occurs for elements in different choice blocks

### DIFF
--- a/tests/codegen/handlers/test_update_attributes_effective_choice.py
+++ b/tests/codegen/handlers/test_update_attributes_effective_choice.py
@@ -129,3 +129,50 @@ class UpdateAttributesEffectiveChoiceTests(FactoryTestCase):
         self.processor.reset_effective_choice(paths, 3, 4)
 
         self.assertEqual([("g", 0, 1, 1), ("g", 1, 1, 1)], paths)
+
+    def test_process_elements_in_different_choice_blocks(self) -> None:
+        """Test that elements in different choice blocks are not merged."""
+        choice1_id = 12345
+        choice2_id = 67890
+
+        target = ClassFactory.create(
+            attrs=[
+                AttrFactory.element(
+                    name="configOption",
+                    namespace="",
+                    restrictions=Restrictions(
+                        min_occurs=0, max_occurs=1, choice=choice1_id
+                    ),
+                ),
+                AttrFactory.element(
+                    name="optionA",
+                    namespace="",
+                    restrictions=Restrictions(
+                        min_occurs=0, max_occurs=1, choice=choice1_id
+                    ),
+                ),
+                AttrFactory.element(
+                    name="configOption",
+                    namespace="",
+                    restrictions=Restrictions(
+                        min_occurs=0, max_occurs=1, choice=choice2_id
+                    ),
+                ),
+                AttrFactory.element(
+                    name="optionB",
+                    namespace="",
+                    restrictions=Restrictions(
+                        min_occurs=0, max_occurs=1, choice=choice2_id
+                    ),
+                ),
+            ]
+        )
+
+        self.processor.process(target)
+
+        # Should not merge configOption elements since they're in different choice blocks
+        self.assertEqual(4, len(target.attrs))
+        self.assertEqual(
+            ["configOption", "optionA", "configOption", "optionB"],
+            [x.name for x in target.attrs],
+        )

--- a/xsdata/codegen/handlers/merge_attributes.py
+++ b/xsdata/codegen/handlers/merge_attributes.py
@@ -64,7 +64,25 @@ class MergeAttributes(HandlerInterface):
                 attr_max_occurs = a_res.max_occurs or 1
 
                 e_res.min_occurs = min(min_occurs, attr_min_occurs)
-                e_res.max_occurs = max_occurs + attr_max_occurs
+
+                # If attrs are in different choice groups AND have different
+                # indices AND have the same path depth, they're in sibling
+                # choice blocks (mutually exclusive) -> use max
+                # If attrs have same index, they're substitutions for same
+                # element -> use +
+                # If attrs have different path depths, one is nested deeper
+                # -> use +
+                # Otherwise, use + (default behavior for sequences)
+                if (
+                    e_res.choice is not None
+                    and a_res.choice is not None
+                    and e_res.choice != a_res.choice
+                    and existing.index != attr.index
+                    and len(e_res.path) == len(a_res.path)
+                ):
+                    e_res.max_occurs = max(max_occurs, attr_max_occurs)
+                else:
+                    e_res.max_occurs = max_occurs + attr_max_occurs
 
                 if a_res.sequence is not None:
                     e_res.sequence = a_res.sequence

--- a/xsdata/codegen/handlers/update_attributes_effective_choice.py
+++ b/xsdata/codegen/handlers/update_attributes_effective_choice.py
@@ -142,4 +142,18 @@ class UpdateAttributesEffectiveChoice(HandlerInterface):
             if not attr.is_attribute:
                 counters[attr.key].append(index)
 
-        return [list(range(x[0], x[-1] + 1)) for x in counters.values() if len(x) > 1]
+        result = []
+        for indices in counters.values():
+            if len(indices) > 1:
+                # Check if all occurrences have the same choice ID
+                # If they have different choice IDs (and both are not None),
+                # they're in different choice blocks and shouldn't be merged
+                choice_ids = {target.attrs[i].restrictions.choice for i in indices}
+                # Allow grouping if:
+                # 1. All have the same choice ID, OR
+                # 2. At least one has choice=None (not in a choice block)
+                if len(choice_ids) == 1 or None in choice_ids:
+                    # Group them
+                    result.append(list(range(indices[0], indices[-1] + 1)))
+
+        return result


### PR DESCRIPTION
## 📒 Description

This commit fixes the issue where elements appearing in different choice blocks were incorrectly summing their max_occurs values instead of using the maximum value.

Resolves #1136

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue

## 💬 Comments

> A place to write any comments to the reviewer.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
