### PR TITLE
Fix elements in same choice different branches incorrectly merged as list

### DIFF
--- a/xsdata/codegen/handlers/merge_attributes.py
+++ b/xsdata/codegen/handlers/merge_attributes.py
@@ -65,21 +65,20 @@ class MergeAttributes(HandlerInterface):
 
                 e_res.min_occurs = min(min_occurs, attr_min_occurs)
 
-                # If attrs are in different choice groups AND have different
-                # indices AND have the same path depth, they're in sibling
-                # choice blocks (mutually exclusive) -> use max
-                # If attrs have same index, they're substitutions for same
-                # element -> use +
-                # If attrs have different path depths, one is nested deeper
-                # -> use +
-                # Otherwise, use + (default behavior for sequences)
-                if (
+                # Determine if attrs are mutually exclusive (max) or additive (sum)
+                is_mutually_exclusive = (
                     e_res.choice is not None
                     and a_res.choice is not None
-                    and e_res.choice != a_res.choice
                     and existing.index != attr.index
-                    and len(e_res.path) == len(a_res.path)
-                ):
+                    and (
+                        # Same choice, different branches
+                        e_res.choice == a_res.choice
+                        # Different sibling choices at same depth
+                        or len(e_res.path) == len(a_res.path)
+                    )
+                )
+
+                if is_mutually_exclusive:
                     e_res.max_occurs = max(max_occurs, attr_max_occurs)
                 else:
                     e_res.max_occurs = max_occurs + attr_max_occurs

--- a/xsdata/codegen/handlers/update_attributes_effective_choice.py
+++ b/xsdata/codegen/handlers/update_attributes_effective_choice.py
@@ -149,11 +149,21 @@ class UpdateAttributesEffectiveChoice(HandlerInterface):
                 # If they have different choice IDs (and both are not None),
                 # they're in different choice blocks and shouldn't be merged
                 choice_ids = {target.attrs[i].restrictions.choice for i in indices}
-                # Allow grouping if:
-                # 1. All have the same choice ID, OR
-                # 2. At least one has choice=None (not in a choice block)
-                if len(choice_ids) == 1 or None in choice_ids:
-                    # Group them
+
+                # Also check if all occurrences have the same path length
+                # If they have different path lengths within the same choice,
+                # they're in different branches (mutually exclusive)
+                path_lengths = {len(target.attrs[i].restrictions.path) for i in indices}
+
+                if None in choice_ids:
+                    # At least one element is outside a choice, so they can co-exist
+                    # (e.g., one in outer sequence, one in inner choice branch)
                     result.append(list(range(indices[0], indices[-1] + 1)))
+                elif len(choice_ids) == 1 and len(path_lengths) == 1:
+                    # All elements in the same choice at the same nesting level
+                    # This is a repeating pattern, group them
+                    result.append(list(range(indices[0], indices[-1] + 1)))
+                # else: different choices or same choice but different nesting levels
+                # = mutually exclusive branches, don't group
 
         return result


### PR DESCRIPTION


## 📒 Description

When an element appears in multiple branches of the same xs:choice at different nesting levels, they should be treated as mutually exclusive (only one branch is selected at runtime), not additive.

Resolves #1136

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue

## 💬 Comments

> A place to write any comments to the reviewer.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
