### PR TITLE
prevent grouping mutually exclusive choice branches

### DIFF
--- a/xsdata/codegen/handlers/update_attributes_effective_choice.py
+++ b/xsdata/codegen/handlers/update_attributes_effective_choice.py
@@ -160,9 +160,14 @@ class UpdateAttributesEffectiveChoice(HandlerInterface):
                     # (e.g., one in outer sequence, one in inner choice branch)
                     result.append(list(range(indices[0], indices[-1] + 1)))
                 elif len(choice_ids) == 1 and len(path_lengths) == 1:
-                    # All elements in the same choice at the same nesting level
-                    # This is a repeating pattern, group them
-                    result.append(list(range(indices[0], indices[-1] + 1)))
+                    # Check if all occurrences have the same path
+                    # If they have different paths within the same choice,
+                    # they're in different branches (mutually exclusive)
+                    paths = {tuple(target.attrs[i].restrictions.path) for i in indices}
+                    if len(paths) == 1:
+                        # All elements in the same choice at the same nesting level
+                        # This is a repeating pattern, group them
+                        result.append(list(range(indices[0], indices[-1] + 1)))
                 # else: different choices or same choice but different nesting levels
                 # = mutually exclusive branches, don't group
 


### PR DESCRIPTION
## 📒 Description

Avoid grouping attributes that belong  to the same choice but different branches. 
Previously, the handler only checked the choice ID and path length, which caused elements located in 
distinct branches (e.g., sequences within a choice) to be incorrectly aggregated into a single repeating choice block.

Resolves #1215

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
