### PR TITLE
Fix KeyError when models_package is not set

### DIFF
--- a/xsdata/formats/dataclass/context.py
+++ b/xsdata/formats/dataclass/context.py
@@ -132,11 +132,17 @@ class XmlContext:
         if not self.class_type.is_model(clazz):
             return False
 
-        return not self.models_package or (
+        has_valid_module = (
             hasattr(clazz, "__module__")
             and isinstance(clazz.__module__, str)
-            and clazz.__module__.startswith(self.models_package)
             and clazz.__module__ in sys.modules
+        )
+
+        if not has_valid_module:
+            return False
+
+        return not self.models_package or clazz.__module__.startswith(
+            self.models_package
         )
 
     def find_types(self, qname: str) -> list[type[T]]:


### PR DESCRIPTION
## 📒 Description

Follow-up to #1144. That PR added an `and clazz.__module__ in sys.modules` guard to `XmlContext.is_binding_model` to prevent a `KeyError`, but placed it inside the branch that only runs when `models_package` is set. When no `models_package` is configured, `is_binding_model` short-circuits on `not self.models_package` and the guard is skipped.

I've encountered this bug for example with `amd.HIPOptions` from `triton`.

This PR restructures the predicate so the `sys.modules` guard applies in both cases.

