### PR TITLE
Fix wrapper binding when collection item element name is reused

### DIFF
--- a/tests/formats/dataclass/parsers/nodes/test_wrapper.py
+++ b/tests/formats/dataclass/parsers/nodes/test_wrapper.py
@@ -67,3 +67,37 @@ class WrapperTests(TestCase):
         self.assertIsInstance(obj.elements[1], ElementObject)
         self.assertEqual(obj.elements[0].content, "Hello")
         self.assertEqual(obj.elements[1].content, "World")
+
+    def test_reused_item_name(self) -> None:
+        @dataclass
+        class Foo:
+            class Meta:
+                name = "Property"
+
+            foo_id: int = field(metadata={"name": "Foo-Id", "type": "Attribute"})
+
+        @dataclass
+        class Bar:
+            class Meta:
+                name = "Property"
+
+            bar_id: str = field(metadata={"name": "Bar-Id", "type": "Attribute"})
+
+        @dataclass
+        class Response:
+            foos: list[Foo] = field(
+                metadata={"wrapper": "Foos", "name": "Property", "type": "Element"}
+            )
+            bars: list[Bar] = field(
+                metadata={"wrapper": "Bars", "name": "Property", "type": "Element"}
+            )
+
+        xml = (
+            "<Response>"
+            '<Foos><Property Foo-Id="1"/><Property Foo-Id="2"/></Foos>'
+            '<Bars><Property Bar-Id="3"/><Property Bar-Id="4"/></Bars>'
+            "</Response>"
+        )
+        obj = self.parser.from_string(xml, clazz=Response)
+        self.assertEqual([Foo(foo_id=1), Foo(foo_id=2)], obj.foos)
+        self.assertEqual([Bar(bar_id="3"), Bar(bar_id="4")], obj.bars)

--- a/xsdata/formats/dataclass/parsers/bases.py
+++ b/xsdata/formats/dataclass/parsers/bases.py
@@ -89,7 +89,7 @@ class NodeParser(PushParser):
         try:
             item = queue[-1]
             if isinstance(item, ElementNode) and qname in item.meta.wrappers:
-                child = cast(XmlNode, WrapperNode(parent=item))
+                child = cast(XmlNode, WrapperNode(parent=item, qname=qname))
             else:
                 child = item.child(qname, attrs, ns_map, len(objects))
         except IndexError:

--- a/xsdata/formats/dataclass/parsers/nodes/element.py
+++ b/xsdata/formats/dataclass/parsers/nodes/element.py
@@ -35,6 +35,8 @@ class ElementNode(XmlNode):
     Attributes:
         assigned: A set to store the processed sub-nodes
         tail_processed: Whether the tail process is consumed
+        wrappers: A mapping of child item qname to the queue of wrapper
+            qnames the items were parsed under, in document order
     """
 
     __slots__ = (
@@ -48,6 +50,7 @@ class ElementNode(XmlNode):
         "ns_map",
         "position",
         "tail_processed",
+        "wrappers",
         "xsi_nil",
         "xsi_type",
     )
@@ -78,6 +81,11 @@ class ElementNode(XmlNode):
         self.xsi_nil = xsi_nil
         self.assigned: set[int] = set()
         self.tail_processed: bool = False
+        # Queue of wrapper qnames per child item qname, recorded in document
+        # order as children are built. It lets binding disambiguate sibling
+        # wrappers that reuse the same item element name (e.g. two wrappers
+        # whose items are both named ``Property``).
+        self.wrappers: dict[str, list[str]] = {}
 
     def bind(
         self,
@@ -250,7 +258,11 @@ class ElementNode(XmlNode):
             Whether the parsed object can fit in one of class
             parameters or not.
         """
+        wrapper = self.pop_wrapper(qname)
         for var in self.meta.find_children(qname):
+            if wrapper and var.wrapper_qname != wrapper:
+                continue
+
             if var.is_wildcard:
                 return self.bind_wild_var(params, var, qname, value)
 
@@ -258,6 +270,26 @@ class ElementNode(XmlNode):
                 return True
 
         return False
+
+    def pop_wrapper(self, qname: str) -> str | None:
+        """Return the wrapper qname for the next child object of the qname.
+
+        The wrapper qnames are recorded in document order as children
+        are built, so popping the first one keeps binding aligned with
+        the parsed objects and lets sibling wrappers that reuse the same
+        item element name route to the correct field.
+
+        Args:
+            qname: The qualified name of the child element
+
+        Returns:
+            The wrapper qualified name or None if the child isn't wrapped.
+        """
+        wrappers = self.wrappers.get(qname)
+        if wrappers:
+            return wrappers.pop(0)
+
+        return None
 
     @classmethod
     def bind_var(cls, params: dict, var: XmlVar, value: Any) -> bool:
@@ -438,7 +470,14 @@ class ElementNode(XmlNode):
 
         return True
 
-    def child(self, qname: str, attrs: dict, ns_map: dict, position: int) -> XmlNode:
+    def child(
+        self,
+        qname: str,
+        attrs: dict,
+        ns_map: dict,
+        position: int,
+        wrapper: str | None = None,
+    ) -> XmlNode:
         """Initialize the next child node to be queued, when an element starts.
 
         This entry point is responsible to create the next node type
@@ -450,11 +489,16 @@ class ElementNode(XmlNode):
             attrs: The element attributes
             ns_map: The element namespace prefix-URI map
             position: The current length of the intermediate objects
+            wrapper: The qualified name of the wrapper element the child
+                is nested under, if any
 
         Raises:
             ParserError: If the child element is unknown
         """
         for var in self.meta.find_children(qname):
+            if wrapper and var.wrapper_qname != wrapper:
+                continue
+
             unique = 0 if not var.is_element or var.list_element else var.index
             if not unique or unique not in self.assigned:
                 node = self.build_node(qname, var, attrs, ns_map, position)
@@ -462,6 +506,9 @@ class ElementNode(XmlNode):
                 if node:
                     if unique:
                         self.assigned.add(unique)
+
+                    if wrapper:
+                        self.wrappers.setdefault(qname, []).append(wrapper)
 
                     return node
 

--- a/xsdata/formats/dataclass/parsers/nodes/wrapper.py
+++ b/xsdata/formats/dataclass/parsers/nodes/wrapper.py
@@ -14,14 +14,16 @@ class WrapperNode(XmlNode):
 
     Args:
         parent: The parent node
+        qname: The wrapper element qualified name
 
     Attributes:
         ns_map: The node namespace prefix-URI map
     """
 
-    def __init__(self, parent: ElementNode):
+    def __init__(self, parent: ElementNode, qname: str):
         """Initialize the xml node."""
         self.parent = parent
+        self.qname = qname
         self.ns_map = parent.ns_map
 
     def bind(
@@ -52,4 +54,4 @@ class WrapperNode(XmlNode):
         Returns:
             The child xml node instance.
         """
-        return self.parent.child(qname, attrs, ns_map, position)
+        return self.parent.child(qname, attrs, ns_map, position, wrapper=self.qname)


### PR DESCRIPTION
## 📒 Description

Resolves #1142

Parsing a document with two wrapped collections on the same dataclass that reuse the same item element name failed. In the issue's example both `<Foos>` and `<Bars>` wrap items named `<Property>`, and parsing raised:

```
TypeError: Foo.__init__() missing 1 required positional argument: 'foo_id'
```

## 🔗 What I've Done

**Root cause.** A `WrapperNode` proxies the wrapped item to its parent `ElementNode` using only the bare item qname (`Property`). Both the build step (`ElementNode.child`) and the bind step (`ElementNode.bind_object`) resolve the field via `meta.find_children(qname)`, which returns every field sharing that qname in declaration order and picks the first workable one. So items from `<Bars>` were routed into the `foos` field, and the mismatched item class failed to construct.

**Fix.** Scope the item lookup to the active wrapper qname:

- `WrapperNode` now knows its wrapper element qname and passes it down when proxying to the parent.
- `ElementNode.child` filters candidate vars by their `wrapper_qname` when a wrapper is active, and records the wrapper per item qname (in document order).
- `ElementNode.bind_object` pops the recorded wrapper for each parsed item and binds it to the field whose `wrapper_qname` matches, so sibling wrappers reusing the same item name route to the correct field.

The change is confined to `xsdata/formats/dataclass/parsers` and leaves the non-wrapper code paths untouched (the wrapper argument defaults to `None`).

## 💬 Comments

Verified that serializing the same model already produced the expected XML, so this makes the parse/serialize round trip symmetric.

## 🛫 Checklist

- [ ] Updated docs
- [x] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass

### Tests / Verification

- Added `WrapperTests.test_reused_item_name` reproducing the issue. It fails on `main` with the reported `TypeError` and passes with this fix.
- `pytest tests/` — 1091 passed, 17 skipped.
- `ruff check` / `ruff format --check` clean on the changed files; `mypy` reports no new errors.

Disclosure: prepared with AI assistance; reviewed and verified locally.
