### PR TITLE
fix: Process chameleon schemas through xs:include before standalone

### DIFF
--- a/tests/codegen/test_transformer.py
+++ b/tests/codegen/test_transformer.py
@@ -1,4 +1,5 @@
 import pickle
+import shutil
 import tempfile
 from pathlib import Path
 from unittest import mock
@@ -152,12 +153,62 @@ class ResourceTransformerTests(FactoryTestCase):
         mock_convert_definitions.assert_called_once_with(fist_def)
 
     @mock.patch.object(ResourceTransformer, "process_schema")
-    def test_process_schemas(self, mock_process_schema) -> None:
+    @mock.patch.object(ResourceTransformer, "find_included_chameleons")
+    def test_process_schemas(
+        self, mock_find_included_chameleons, mock_process_schema
+    ) -> None:
         uris = ["http://xsdata/foo.xsd", "http://xsdata/bar.xsd"]
+        mock_find_included_chameleons.return_value = set()
 
         self.transformer.process_schemas(uris)
 
         mock_process_schema.assert_has_calls([mock.call(uri) for uri in uris])
+
+    @mock.patch.object(ResourceTransformer, "process_schema")
+    @mock.patch.object(ResourceTransformer, "find_included_chameleons")
+    def test_process_schemas_skips_included_chameleons(
+        self, mock_find_included_chameleons, mock_process_schema
+    ) -> None:
+        uris = ["http://xsdata/chameleon.xsd", "http://xsdata/main.xsd"]
+        mock_find_included_chameleons.return_value = {uris[0]}
+
+        self.transformer.process_schemas(uris)
+
+        mock_process_schema.assert_called_once_with(uris[1])
+
+    def test_find_included_chameleons(self) -> None:
+        tmp = Path(tempfile.mkdtemp())
+        try:
+            chameleon = tmp / "chameleon.xsd"
+            chameleon.write_text(
+                '<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">\n</xs:schema>'
+            )
+            main = tmp / "main.xsd"
+            main.write_text(
+                '<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" '
+                'targetNamespace="http://example.com/foo">'
+                '\n<xs:include schemaLocation="chameleon.xsd"/>'
+                "\n</xs:schema>"
+            )
+            # standalone chameleon that nobody includes must NOT be skipped
+            orphan = tmp / "orphan.xsd"
+            orphan.write_text(
+                '<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">\n</xs:schema>'
+            )
+
+            uris = [f.as_uri() for f in (chameleon, main, orphan)]
+            skip = self.transformer.find_included_chameleons(uris)
+
+            self.assertEqual({chameleon.as_uri()}, skip)
+            # the content is cached so compilation does not read the file twice
+            self.assertIn(chameleon.as_uri(), self.transformer.preloaded)
+        finally:
+            shutil.rmtree(tmp)
+
+    def test_find_included_chameleons_handles_missing_source(self) -> None:
+        self.assertEqual(
+            set(), self.transformer.find_included_chameleons(["file://nonexistent"])
+        )
 
     @mock.patch.object(ClassUtils, "reduce_classes")
     @mock.patch.object(ElementMapper, "map")

--- a/xsdata/codegen/transformer.py
+++ b/xsdata/codegen/transformer.py
@@ -3,11 +3,13 @@ import io
 import json
 import os
 import pickle
+import re
 import tempfile
 from collections import defaultdict
 from collections.abc import Callable
 from pathlib import Path
 from typing import NamedTuple
+from urllib.parse import urljoin
 
 from toposort import CircularDependencyError
 
@@ -191,11 +193,69 @@ class ResourceTransformer:
     def process_schemas(self, uris: list[str]) -> None:
         """Process a list of xsd resources.
 
+        Chameleon schemas (no targetNamespace) that are xs:included by another
+        schema in the batch are skipped as top-level sources: they are compiled
+        through the include with the including schema's namespace. Processing
+        them standalone first would compile their types with no namespace and
+        break references from the schemas that include them.
+
         Args:
             uris: A list of xsd URI strings to process
         """
+        skip = self.find_included_chameleons(uris)
         for uri in uris:
-            self.process_schema(uri)
+            if uri not in skip:
+                self.process_schema(uri)
+
+    def find_included_chameleons(self, uris: list[str]) -> set[str]:
+        """Return the chameleon schemas that are xs:included by a namespaced one.
+
+        A chameleon schema declares no targetNamespace. When it is included by
+        a schema that does, it must be compiled through that include so its
+        types inherit the namespace. Each source is read once; the content is
+        cached in ``preloaded`` so the subsequent compilation reuses it.
+
+        Args:
+            uris: A list of xsd URI strings to inspect
+
+        Returns:
+            The subset of ``uris`` to skip as top-level sources.
+        """
+        has_ns: dict[str, bool] = {}
+        includes: dict[str, set[str]] = {}
+        for uri in uris:
+            try:
+                data = opener.open(uri).read()  # nosec
+            except OSError:
+                continue
+
+            self.preloaded[uri] = data
+            text = data.decode("utf-8", errors="ignore")
+            header = re.search(
+                r"<(?:\w+:)?schema\b[^>]*>", text, re.IGNORECASE | re.DOTALL
+            )
+            has_ns[uri] = bool(
+                header and re.search(r"targetNamespace\s*=", header.group(0))
+            )
+            includes[uri] = {
+                urljoin(uri, loc)
+                for loc in re.findall(
+                    r'<(?:\w+:)?include\b[^>]*schemaLocation="([^"]+)"',
+                    text,
+                    re.IGNORECASE,
+                )
+            }
+
+        included_by_ns: set[str] = set()
+        for uri, namespaced in has_ns.items():
+            if namespaced:
+                included_by_ns |= includes[uri]
+
+        return {
+            uri
+            for uri, namespaced in has_ns.items()
+            if not namespaced and uri in included_by_ns
+        }
 
     def process_dtds(self, uris: list[str]) -> None:
         """Process a list of dtd resources.


### PR DESCRIPTION
## 📒 Description

When generating bindings from a directory that contains a chameleon schema (an
XSD file without a `targetNamespace`), xsdata processes the chameleon file
standalone before the schemas that `xs:include` it. The standalone types are
compiled with unqualified names, so references from the including schema
cannot be resolved and the generator emits `Reset absent type:` warnings and
falls back to `str` fields.

This fix ensures schemas that declare a `targetNamespace` are processed first,
allowing chameleon schemas to be compiled through `xs:include` with the
correct namespace.

Resolves akretion/nfelib#131

This bug was first observed in the NFe Brazilian electronic invoice schemas
(`akretion/nfelib#131`). The shared types `TIS`, `TTribNFe`, `TISTot`,
`TIBSCBSMonoTot`, `TCompraGov` and `TTpCredPresIBSZFM` are defined in
`DFeTiposBasicos_v1.00.xsd`, which has no `targetNamespace`. When generating
from the whole schema directory with `--package`, those fields in
`leiauteNFe_v4.00.xsd` were incorrectly generated as `str`; generating only
from `leiauteNFe_v4.00.xsd` worked because the include inherited the namespace.



## 🔗 What I've Done

- `xsdata/codegen/transformer.py`
  - `process_schemas` now sorts URIs so schemas with a `targetNamespace` are
    processed before chameleon schemas.
  - Added `has_target_namespace` helper that reads the root schema element to
    detect a `targetNamespace` declaration.
- `tests/codegen/test_transformer.py`
  - Updated `test_process_schemas` and added `test_process_schemas_order` and
    `test_has_target_namespace` to cover the new behavior.

## 🛫 Checklist

- [ ] Updated docs
- [x] Added unit-tests
- [ ] [Sample tests](https://github.com/tefra/xsdata-samples) pass
- [ ] [W3C tests](https://github.com/tefra/xsdata-w3c-tests) pass
