### PR TITLE
fix: normalize XSD 24:00:00 in to_time/to_datetime

### DIFF
--- a/tests/models/test_datatype.py
+++ b/tests/models/test_datatype.py
@@ -369,7 +369,8 @@ class XmlTimeTests(TestCase):
             XmlTime.utcnow().replace(fractional_second=0, second=0, minute=1),
         )
 
-        # XSD end-of-day 24:00:00 → stdlib 00:00:00
+    def test_xsd_end_of_day_24(self) -> None:
+        # XSD allows 24:00:00; stdlib time/datetime do not.
         self.assertEqual(
             time(0, 0, 0, 0, tzinfo=timezone.utc),
             XmlTime.from_string("24:00:00Z").to_time(),

--- a/tests/models/test_datatype.py
+++ b/tests/models/test_datatype.py
@@ -378,6 +378,10 @@ class XmlTimeTests(TestCase):
             datetime(2010, 9, 20, 0, 0, 0, 0, tzinfo=timezone.utc),
             XmlDateTime.from_string("2010-09-19T24:00:00Z").to_datetime(),
         )
+        with self.assertRaises(ValueError):
+            XmlTime(24, 1, 0, 0, 0).to_time()
+        with self.assertRaises(ValueError):
+            XmlDateTime(2010, 9, 19, 24, 30, 0, 0, 0).to_datetime()
 
     def test_comparisons(self) -> None:
         a = XmlTime.from_string("12:00:00Z")

--- a/tests/models/test_datatype.py
+++ b/tests/models/test_datatype.py
@@ -369,6 +369,16 @@ class XmlTimeTests(TestCase):
             XmlTime.utcnow().replace(fractional_second=0, second=0, minute=1),
         )
 
+        # XSD end-of-day 24:00:00 → stdlib 00:00:00
+        self.assertEqual(
+            time(0, 0, 0, 0, tzinfo=timezone.utc),
+            XmlTime.from_string("24:00:00Z").to_time(),
+        )
+        self.assertEqual(
+            datetime(2010, 9, 20, 0, 0, 0, 0, tzinfo=timezone.utc),
+            XmlDateTime.from_string("2010-09-19T24:00:00Z").to_datetime(),
+        )
+
     def test_comparisons(self) -> None:
         a = XmlTime.from_string("12:00:00Z")
         b = XmlTime.from_string("13:00:00.000+01:00")

--- a/xsdata/models/datatype.py
+++ b/xsdata/models/datatype.py
@@ -242,6 +242,7 @@ class XmlDateTime(NamedTuple):
 
     def to_datetime(self) -> datetime.datetime:
         """Return a `datetime.datetime` instance."""
+        validate_time(self.hour, self.minute, self.second, self.fractional_second)
         year, month, day = self.year, self.month, self.day
         hour = self.hour
         # XSD allows 24:00:00 as end-of-day; map to next calendar day 00:00:00.
@@ -440,6 +441,7 @@ class XmlTime(NamedTuple):
 
     def to_time(self) -> datetime.time:
         """Convert to a `datetime.time` instance."""
+        validate_time(self.hour, self.minute, self.second, self.fractional_second)
         # XSD allows 24:00:00 as end-of-day; stdlib time is 0..23.
         hour = 0 if self.hour == 24 else self.hour
         return datetime.time(

--- a/xsdata/models/datatype.py
+++ b/xsdata/models/datatype.py
@@ -242,11 +242,18 @@ class XmlDateTime(NamedTuple):
 
     def to_datetime(self) -> datetime.datetime:
         """Return a `datetime.datetime` instance."""
+        year, month, day = self.year, self.month, self.day
+        hour = self.hour
+        # XSD allows 24:00:00 as end-of-day; map to next calendar day 00:00:00.
+        if hour == 24:
+            hour = 0
+            next_day = datetime.date(year, month, day) + datetime.timedelta(days=1)
+            year, month, day = next_day.year, next_day.month, next_day.day
         return datetime.datetime(
-            self.year,
-            self.month,
-            self.day,
-            self.hour,
+            year,
+            month,
+            day,
+            hour,
             self.minute,
             self.second,
             self.microsecond,
@@ -433,8 +440,10 @@ class XmlTime(NamedTuple):
 
     def to_time(self) -> datetime.time:
         """Convert to a `datetime.time` instance."""
+        # XSD allows 24:00:00 as end-of-day; stdlib time is 0..23.
+        hour = 0 if self.hour == 24 else self.hour
         return datetime.time(
-            self.hour,
+            hour,
             self.minute,
             self.second,
             self.microsecond,


### PR DESCRIPTION
xsdata.models.datatype.XmlTime.to_time hits ValueError when XSD 24:00:00 parses but to_time/to_datetime crash. This PR fixes the regression with a focused test covering the case.