### PR TITLE
Validate calendar date in XmlDate.from_string

### DIFF
--- a/tests/models/test_datatype.py
+++ b/tests/models/test_datatype.py
@@ -29,6 +29,10 @@ class XmlDateTests(TestCase):
             "2002/01-01",
             "2002/01/01",
             "2002-01-01U",
+            "2019-02-29",
+            "2001-13-45",
+            "2001-00-00",
+            "2001-10-32",
         ]
         for example in examples:
             with self.assertRaises(ValueError, msg=example):

--- a/xsdata/models/datatype.py
+++ b/xsdata/models/datatype.py
@@ -88,6 +88,7 @@ class XmlDate(NamedTuple):
         assert year is not None
         assert month is not None
         assert day is not None
+        validate_date(year, month, day)
         return cls(year, month, day, offset)
 
     @classmethod


### PR DESCRIPTION
`XmlDate.from_string` parses the year/month/day fields but never calls `validate_date`, so it accepts values outside the `xs:date` lexical space:

```python
from xsdata.models.datatype import XmlDate, XmlDateTime

XmlDate.from_string("2019-02-29")   # accepted -> XmlDate(2019, 2, 29)  (2019 is not a leap year)
XmlDate.from_string("2001-13-45")   # accepted -> XmlDate(2001, 13, 45)
XmlDate.from_string("2001-00-00")   # accepted -> XmlDate(2001, 0, 0)

# the sibling type already rejects the identical calendar value:
XmlDateTime.from_string("2019-02-29T00:00:00")  # ValueError: Day must be in 1..28
```

`XmlDateTime.from_string` and `XmlTime.from_string` both validate (via `validate_date` / `validate_time`) right after asserting the fields are non-`None`. `XmlDate.from_string` is the only calendar-bearing type that skips the check — a sibling inconsistency, with no reason `xs:date` should be more lenient than `xs:dateTime`.

This is reachable through the converter: `XmlDate` fields register `ProxyConverter(XmlDate.from_string)`, so `converter.deserialize("2019-02-29", [XmlDate])` returns a nonsense `XmlDate` that later raises a confusing downstream error on `.to_date()`. In practice a real XML document carrying a data-entry mistake like `2019-02-29` is silently accepted at the parse boundary instead of being rejected there.

**Fix**: one line — call the already-imported `validate_date(year, month, day)` in `XmlDate.from_string`, matching `XmlDateTime.from_string`.

**Verification** (re-runnable from the diff):
- Without the fix, the four added cases (`2019-02-29`, `2001-13-45`, `2001-00-00`, `2001-10-32`) are accepted; the new assertions fail (`ValueError not raised : 2019-02-29`).
- With the fix they raise `ValueError`, matching `XmlDateTime`. Valid dates are unaffected — `2020-02-29` (a real leap day) and `2002-01-01Z` still parse.
- `tests/models/test_datatype.py` + `tests/formats/test_converter.py` → 68 passed; `ruff check` clean.

This is a hardening of accept/reject behavior at the parse boundary, not a hot-path crash. If you'd rather `xs:date` stay lenient here, say so and I'll close it.

---

*Disclosure*: This PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug, ran the repro, wrote the test, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
